### PR TITLE
feat: add claude, codex, gemini, ollama adapters

### DIFF
--- a/src/conductor/providers/__init__.py
+++ b/src/conductor/providers/__init__.py
@@ -1,3 +1,6 @@
+from conductor.providers.claude import ClaudeProvider
+from conductor.providers.codex import CodexProvider
+from conductor.providers.gemini import GeminiProvider
 from conductor.providers.interface import (
     CallResponse,
     Provider,
@@ -6,15 +9,35 @@ from conductor.providers.interface import (
     ProviderHTTPError,
 )
 from conductor.providers.kimi import KimiProvider
+from conductor.providers.ollama import OllamaProvider
 
 __all__ = [
     "CallResponse",
+    "ClaudeProvider",
+    "CodexProvider",
+    "GeminiProvider",
     "KimiProvider",
+    "OllamaProvider",
     "Provider",
     "ProviderConfigError",
     "ProviderError",
     "ProviderHTTPError",
+    "get_provider",
+    "known_providers",
 ]
+
+_REGISTRY: dict[str, type[Provider]] = {
+    "kimi": KimiProvider,
+    "claude": ClaudeProvider,
+    "codex": CodexProvider,
+    "gemini": GeminiProvider,
+    "ollama": OllamaProvider,
+}
+
+
+def known_providers() -> list[str]:
+    """Return the sorted list of canonical provider identifiers."""
+    return sorted(_REGISTRY)
 
 
 def get_provider(name: str) -> Provider:
@@ -22,11 +45,8 @@ def get_provider(name: str) -> Provider:
 
     Raises KeyError if the identifier is not registered.
     """
-    registry: dict[str, type[Provider]] = {
-        "kimi": KimiProvider,
-    }
-    if name not in registry:
+    if name not in _REGISTRY:
         raise KeyError(
-            f"unknown provider {name!r}; known: {sorted(registry)}"
+            f"unknown provider {name!r}; known: {known_providers()}"
         )
-    return registry[name]()
+    return _REGISTRY[name]()

--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -1,0 +1,133 @@
+"""Claude provider — wraps the Claude Code CLI.
+
+Calls ``claude -p "<prompt>" --output-format json`` as a subprocess and parses
+the returned JSON. The user is expected to have authed via ``claude login``;
+Conductor never touches the API key.
+
+Shape shared with codex/gemini: a subprocess adapter that delegates auth to
+the wrapped CLI. Compare to ``kimi``/``ollama``, which are HTTP adapters
+that touch credentials directly.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import time
+from typing import Optional
+
+from conductor.providers.interface import (
+    CallResponse,
+    ProviderConfigError,
+    ProviderError,
+    ProviderHTTPError,
+)
+
+CLAUDE_DEFAULT_MODEL = "sonnet"
+CLAUDE_REQUEST_TIMEOUT_SEC = 180.0
+
+
+class ClaudeProvider:
+    name = "claude"
+    tags = ["strong-reasoning", "long-context", "tool-use", "code-review"]
+    default_model = CLAUDE_DEFAULT_MODEL
+
+    def __init__(
+        self,
+        *,
+        cli_command: str = "claude",
+        timeout_sec: float = CLAUDE_REQUEST_TIMEOUT_SEC,
+    ) -> None:
+        self._cli = cli_command
+        self._timeout_sec = timeout_sec
+
+    def configured(self) -> tuple[bool, Optional[str]]:
+        if not shutil.which(self._cli):
+            return False, (
+                f"`{self._cli}` CLI not found on PATH. "
+                "Install with `brew install claude` and auth with `claude login`."
+            )
+        return True, None
+
+    def smoke(self) -> tuple[bool, Optional[str]]:
+        ok, reason = self.configured()
+        if not ok:
+            return False, reason
+        try:
+            result = subprocess.run(
+                [self._cli, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except subprocess.TimeoutExpired:
+            return False, f"`{self._cli} --version` timed out"
+        if result.returncode != 0:
+            return False, (
+                f"`{self._cli} --version` exited {result.returncode}: "
+                f"{(result.stderr or result.stdout).strip()[:200]}"
+            )
+        return True, None
+
+    def call(self, task: str, model: Optional[str] = None) -> CallResponse:
+        ok, reason = self.configured()
+        if not ok:
+            raise ProviderConfigError(reason or "claude not configured")
+
+        model = model or self.default_model
+        args = [
+            self._cli,
+            "-p",
+            task,
+            "--output-format",
+            "json",
+            "--model",
+            model,
+        ]
+        start = time.monotonic()
+        try:
+            result = subprocess.run(
+                args,
+                capture_output=True,
+                text=True,
+                timeout=self._timeout_sec,
+            )
+        except subprocess.TimeoutExpired as e:
+            raise ProviderError(
+                f"claude CLI timed out after {self._timeout_sec:.0f}s"
+            ) from e
+        duration_ms = int((time.monotonic() - start) * 1000)
+
+        if result.returncode != 0:
+            raise ProviderHTTPError(
+                f"claude exited {result.returncode}: "
+                f"{(result.stderr or result.stdout).strip()[:500]}"
+            )
+
+        try:
+            data = json.loads(result.stdout)
+        except json.JSONDecodeError as e:
+            raise ProviderHTTPError(
+                f"claude stdout was not JSON: {result.stdout[:500]!r}"
+            ) from e
+
+        if data.get("is_error"):
+            raise ProviderHTTPError(
+                f"claude returned is_error=true: {data.get('result', '<no detail>')}"
+            )
+
+        usage = data.get("usage") or {}
+        return CallResponse(
+            text=data.get("result", ""),
+            provider=self.name,
+            model=model,
+            duration_ms=data.get("duration_ms") or duration_ms,
+            usage={
+                "input_tokens": usage.get("input_tokens"),
+                "output_tokens": usage.get("output_tokens"),
+                "cached_tokens": usage.get("cache_read_input_tokens"),
+            },
+            cost_usd=data.get("total_cost_usd"),
+            raw=data,
+        )

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -1,0 +1,143 @@
+"""Codex provider — wraps OpenAI's Codex CLI.
+
+Calls ``codex exec "<prompt>" --json --ephemeral`` as a subprocess. Codex
+emits NDJSON events (one JSON object per line); we scan for the
+``item.completed`` event that carries the agent message and the
+``turn.completed`` event that carries token usage.
+
+Conductor uses the canonical identifier ``codex`` (the CLI's actual name).
+Sentinel's existing ``OpenAIProvider`` wraps the same CLI under the
+identifier ``openai`` — that drift resolves when Sentinel migrates to call
+Conductor instead of implementing its own provider (see
+autumn-garage `plans/sentinel-conductor-migration.md`, future).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import time
+from typing import Optional
+
+from conductor.providers.interface import (
+    CallResponse,
+    ProviderConfigError,
+    ProviderError,
+    ProviderHTTPError,
+)
+
+CODEX_DEFAULT_MODEL = "gpt-5.4"
+CODEX_REQUEST_TIMEOUT_SEC = 180.0
+
+
+class CodexProvider:
+    name = "codex"
+    tags = ["strong-reasoning", "code-review", "tool-use"]
+    default_model = CODEX_DEFAULT_MODEL
+
+    def __init__(
+        self,
+        *,
+        cli_command: str = "codex",
+        timeout_sec: float = CODEX_REQUEST_TIMEOUT_SEC,
+    ) -> None:
+        self._cli = cli_command
+        self._timeout_sec = timeout_sec
+
+    def configured(self) -> tuple[bool, Optional[str]]:
+        if not shutil.which(self._cli):
+            return False, (
+                f"`{self._cli}` CLI not found on PATH. "
+                "Install with `npm install -g @openai/codex` and auth with `codex login`."
+            )
+        return True, None
+
+    def smoke(self) -> tuple[bool, Optional[str]]:
+        ok, reason = self.configured()
+        if not ok:
+            return False, reason
+        try:
+            result = subprocess.run(
+                [self._cli, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except subprocess.TimeoutExpired:
+            return False, f"`{self._cli} --version` timed out"
+        if result.returncode != 0:
+            return False, (
+                f"`{self._cli} --version` exited {result.returncode}: "
+                f"{(result.stderr or result.stdout).strip()[:200]}"
+            )
+        return True, None
+
+    def _parse_ndjson(self, stdout: str) -> tuple[str, Optional[int], Optional[int]]:
+        """Parse NDJSON events. Return (content, input_tokens, output_tokens)."""
+        content = ""
+        input_tokens: Optional[int] = None
+        output_tokens: Optional[int] = None
+        for line in stdout.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            kind = event.get("type")
+            if kind == "item.completed":
+                item = event.get("item") or {}
+                if item.get("type") == "agent_message":
+                    content = item.get("text", "")
+            elif kind == "turn.completed":
+                usage = event.get("usage") or {}
+                input_tokens = (input_tokens or 0) + (usage.get("input_tokens") or 0)
+                output_tokens = (output_tokens or 0) + (usage.get("output_tokens") or 0)
+        return content, input_tokens, output_tokens
+
+    def call(self, task: str, model: Optional[str] = None) -> CallResponse:
+        ok, reason = self.configured()
+        if not ok:
+            raise ProviderConfigError(reason or "codex not configured")
+
+        model = model or self.default_model
+        args = [self._cli, "exec", task, "--json", "--ephemeral"]
+        start = time.monotonic()
+        try:
+            result = subprocess.run(
+                args,
+                capture_output=True,
+                text=True,
+                timeout=self._timeout_sec,
+            )
+        except subprocess.TimeoutExpired as e:
+            raise ProviderError(
+                f"codex CLI timed out after {self._timeout_sec:.0f}s"
+            ) from e
+        duration_ms = int((time.monotonic() - start) * 1000)
+
+        if result.returncode != 0:
+            raise ProviderHTTPError(
+                f"codex exited {result.returncode}: "
+                f"{(result.stderr or result.stdout).strip()[:500]}"
+            )
+
+        content, input_tokens, output_tokens = self._parse_ndjson(result.stdout)
+        if not content:
+            raise ProviderHTTPError(
+                f"codex NDJSON stream had no agent_message: {result.stdout[:500]!r}"
+            )
+        return CallResponse(
+            text=content,
+            provider=self.name,
+            model=model,
+            duration_ms=duration_ms,
+            usage={
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "cached_tokens": None,
+            },
+            raw={"stdout": result.stdout},
+        )

--- a/src/conductor/providers/gemini.py
+++ b/src/conductor/providers/gemini.py
@@ -1,0 +1,165 @@
+"""Gemini provider — wraps Google's Gemini CLI.
+
+Calls ``gemini -p "<prompt>" -o json --approval-mode plan [-m <model>]`` as a
+subprocess and parses the JSON response. ``--approval-mode plan`` keeps the
+call read-only — critical because Gemini CLI will otherwise write files
+into the current directory on certain prompts.
+
+Token usage lives under ``stats.models.<id>.tokens`` in Gemini's JSON
+output; we sum across all model entries since a single call can span
+multiple model hops.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import time
+from typing import Optional
+
+from conductor.providers.interface import (
+    CallResponse,
+    ProviderConfigError,
+    ProviderError,
+    ProviderHTTPError,
+)
+
+GEMINI_DEFAULT_MODEL = "gemini-2.5-pro"
+GEMINI_REQUEST_TIMEOUT_SEC = 180.0
+
+
+class GeminiProvider:
+    name = "gemini"
+    tags = ["long-context", "web-search", "thinking", "cheap"]
+    default_model = GEMINI_DEFAULT_MODEL
+
+    def __init__(
+        self,
+        *,
+        cli_command: str = "gemini",
+        timeout_sec: float = GEMINI_REQUEST_TIMEOUT_SEC,
+    ) -> None:
+        self._cli = cli_command
+        self._timeout_sec = timeout_sec
+
+    def configured(self) -> tuple[bool, Optional[str]]:
+        if not shutil.which(self._cli):
+            return False, (
+                f"`{self._cli}` CLI not found on PATH. "
+                "Install with `npm install -g @google/gemini-cli`; "
+                "first run will prompt a browser auth."
+            )
+        return True, None
+
+    def smoke(self) -> tuple[bool, Optional[str]]:
+        ok, reason = self.configured()
+        if not ok:
+            return False, reason
+        try:
+            result = subprocess.run(
+                [self._cli, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except subprocess.TimeoutExpired:
+            return False, f"`{self._cli} --version` timed out"
+        if result.returncode != 0:
+            return False, (
+                f"`{self._cli} --version` exited {result.returncode}: "
+                f"{(result.stderr or result.stdout).strip()[:200]}"
+            )
+        return True, None
+
+    def call(self, task: str, model: Optional[str] = None) -> CallResponse:
+        ok, reason = self.configured()
+        if not ok:
+            raise ProviderConfigError(reason or "gemini not configured")
+
+        model = model or self.default_model
+        args = [
+            self._cli,
+            "-p",
+            task,
+            "-o",
+            "json",
+            "--approval-mode",
+            "plan",
+        ]
+        if model and model != "auto":
+            args.extend(["-m", model])
+
+        start = time.monotonic()
+        try:
+            result = subprocess.run(
+                args,
+                capture_output=True,
+                text=True,
+                timeout=self._timeout_sec,
+            )
+        except subprocess.TimeoutExpired as e:
+            raise ProviderError(
+                f"gemini CLI timed out after {self._timeout_sec:.0f}s"
+            ) from e
+        duration_ms = int((time.monotonic() - start) * 1000)
+
+        if result.returncode != 0:
+            raise ProviderHTTPError(
+                f"gemini exited {result.returncode}: "
+                f"{(result.stderr or result.stdout).strip()[:500]}"
+            )
+
+        # Gemini CLI usually returns JSON but occasionally emits plain text
+        # for very short prompts. Fall back to treating stdout as the
+        # content when JSON parse fails.
+        stdout = result.stdout.strip()
+        try:
+            data = json.loads(stdout)
+        except json.JSONDecodeError:
+            if not stdout:
+                raise ProviderHTTPError("gemini produced empty stdout")
+            return CallResponse(
+                text=stdout,
+                provider=self.name,
+                model=model,
+                duration_ms=duration_ms,
+                usage={
+                    "input_tokens": None,
+                    "output_tokens": None,
+                    "cached_tokens": None,
+                },
+                raw={"stdout": stdout},
+            )
+
+        input_tokens, output_tokens = self._sum_usage(data)
+        return CallResponse(
+            text=data.get("response", ""),
+            provider=self.name,
+            model=model,
+            duration_ms=duration_ms,
+            usage={
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "cached_tokens": None,
+            },
+            raw=data,
+        )
+
+    @staticmethod
+    def _sum_usage(data: dict) -> tuple[Optional[int], Optional[int]]:
+        stats = data.get("stats") or {}
+        models = (stats.get("models") or {}).values()
+        total_input = 0
+        total_output = 0
+        saw_any = False
+        for entry in models:
+            tokens = entry.get("tokens") or {}
+            if not tokens:
+                continue
+            saw_any = True
+            total_input += tokens.get("input", 0) or 0
+            total_output += tokens.get("candidates", 0) or 0
+        if not saw_any:
+            return None, None
+        return total_input, total_output

--- a/src/conductor/providers/ollama.py
+++ b/src/conductor/providers/ollama.py
@@ -1,0 +1,124 @@
+"""Ollama provider — local LLM via the Ollama HTTP API.
+
+Defaults to ``http://localhost:11434`` (Ollama's standard port). Override via
+the ``OLLAMA_BASE_URL`` env var for remote Ollama servers, LM Studio
+installations, or any other OpenAI/Ollama-compatible local server.
+
+No auth (local-only by design). This is the second HTTP-shape adapter
+(alongside ``kimi``); the other three (claude, codex, gemini) shell out
+to their respective CLIs.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Optional
+
+import httpx
+
+from conductor.providers.interface import (
+    CallResponse,
+    ProviderConfigError,
+    ProviderHTTPError,
+)
+
+OLLAMA_BASE_URL_ENV = "OLLAMA_BASE_URL"
+OLLAMA_DEFAULT_BASE_URL = "http://localhost:11434"
+OLLAMA_DEFAULT_MODEL = "qwen2.5-coder:14b"
+OLLAMA_REQUEST_TIMEOUT_SEC = 180.0
+
+
+class OllamaProvider:
+    name = "ollama"
+    tags = ["cheap", "local", "offline"]
+    default_model = OLLAMA_DEFAULT_MODEL
+
+    def __init__(
+        self,
+        *,
+        base_url: Optional[str] = None,
+        timeout_sec: float = OLLAMA_REQUEST_TIMEOUT_SEC,
+    ) -> None:
+        self._base_url_override = base_url
+        self._timeout_sec = timeout_sec
+
+    def _base_url(self) -> str:
+        return (
+            self._base_url_override
+            or os.environ.get(OLLAMA_BASE_URL_ENV)
+            or OLLAMA_DEFAULT_BASE_URL
+        ).rstrip("/")
+
+    def configured(self) -> tuple[bool, Optional[str]]:
+        # "Configured" here means the server responds. Ollama has no auth,
+        # so there's nothing to check for credentials — the liveness of the
+        # endpoint is the only meaningful signal.
+        try:
+            with httpx.Client(timeout=5) as client:
+                resp = client.get(f"{self._base_url()}/api/tags")
+        except httpx.HTTPError as e:
+            return False, (
+                f"cannot reach Ollama at {self._base_url()}: {e}. "
+                "Install with `brew install ollama`, run `ollama serve`, "
+                f"and `ollama pull {self.default_model}`."
+            )
+        if resp.status_code != 200:
+            return False, (
+                f"Ollama at {self._base_url()} returned {resp.status_code} — "
+                "is the server healthy?"
+            )
+        return True, None
+
+    def smoke(self) -> tuple[bool, Optional[str]]:
+        return self.configured()
+
+    def call(self, task: str, model: Optional[str] = None) -> CallResponse:
+        model = model or self.default_model
+        url = f"{self._base_url()}/api/chat"
+        payload = {
+            "model": model,
+            "messages": [{"role": "user", "content": task}],
+            "stream": False,
+        }
+
+        start = time.monotonic()
+        try:
+            with httpx.Client(timeout=self._timeout_sec) as client:
+                resp = client.post(url, json=payload)
+        except httpx.HTTPError as e:
+            raise ProviderConfigError(
+                f"cannot reach Ollama at {self._base_url()}: {e}"
+            ) from e
+        duration_ms = int((time.monotonic() - start) * 1000)
+
+        if resp.status_code != 200:
+            raise ProviderHTTPError(
+                f"Ollama returned HTTP {resp.status_code}: {resp.text[:500]}"
+            )
+        try:
+            data = resp.json()
+        except ValueError as e:
+            raise ProviderHTTPError(f"Ollama response was not JSON: {e}") from e
+
+        message = data.get("message") or {}
+        text = message.get("content")
+        if text is None:
+            raise ProviderHTTPError(
+                f"Ollama response missing message.content: {data!r:.500}"
+            )
+
+        # total_duration is reported in nanoseconds; normalize to ms.
+        server_duration_ms = (data.get("total_duration") or 0) // 1_000_000 or duration_ms
+        return CallResponse(
+            text=text,
+            provider=self.name,
+            model=data.get("model", model),
+            duration_ms=server_duration_ms,
+            usage={
+                "input_tokens": data.get("prompt_eval_count"),
+                "output_tokens": data.get("eval_count"),
+                "cached_tokens": None,
+            },
+            raw=data,
+        )

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -1,0 +1,250 @@
+"""Tests for the subprocess-based adapters (claude, codex, gemini).
+
+All three call external CLIs. We stub ``subprocess.run`` and
+``shutil.which`` so tests run with no dependencies on the real binaries.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from conductor.providers.claude import ClaudeProvider
+from conductor.providers.codex import CodexProvider
+from conductor.providers.gemini import GeminiProvider
+from conductor.providers.interface import (
+    ProviderConfigError,
+    ProviderError,
+    ProviderHTTPError,
+)
+
+
+def _fake_completed(stdout: str = "", stderr: str = "", returncode: int = 0):
+    return subprocess.CompletedProcess(
+        args=["stub"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+# ---------------------------------------------------------------------------
+# Claude
+# ---------------------------------------------------------------------------
+
+CLAUDE_JSON = """{
+    "result": "hello from claude",
+    "usage": {"input_tokens": 10, "output_tokens": 3, "cache_read_input_tokens": 2},
+    "duration_ms": 1234,
+    "total_cost_usd": 0.002,
+    "session_id": "abc"
+}"""
+
+
+def test_claude_configured_when_cli_present(mocker):
+    mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
+    ok, reason = ClaudeProvider().configured()
+    assert ok is True and reason is None
+
+
+def test_claude_configured_false_when_cli_missing(mocker):
+    mocker.patch("conductor.providers.claude.shutil.which", return_value=None)
+    ok, reason = ClaudeProvider().configured()
+    assert ok is False and "claude" in reason
+
+
+def test_claude_call_returns_normalized_response(mocker):
+    mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
+    mocker.patch(
+        "conductor.providers.claude.subprocess.run",
+        return_value=_fake_completed(stdout=CLAUDE_JSON),
+    )
+
+    response = ClaudeProvider().call("hi")
+
+    assert response.text == "hello from claude"
+    assert response.provider == "claude"
+    assert response.model == "sonnet"
+    assert response.usage == {
+        "input_tokens": 10,
+        "output_tokens": 3,
+        "cached_tokens": 2,
+    }
+    assert response.cost_usd == 0.002
+    assert response.duration_ms == 1234
+
+
+def test_claude_call_raises_config_error_when_cli_missing(mocker):
+    mocker.patch("conductor.providers.claude.shutil.which", return_value=None)
+    with pytest.raises(ProviderConfigError):
+        ClaudeProvider().call("hi")
+
+
+def test_claude_call_raises_on_non_zero_exit(mocker):
+    mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
+    mocker.patch(
+        "conductor.providers.claude.subprocess.run",
+        return_value=_fake_completed(stderr="auth failed", returncode=1),
+    )
+    with pytest.raises(ProviderHTTPError) as exc:
+        ClaudeProvider().call("hi")
+    assert "auth failed" in str(exc.value)
+
+
+def test_claude_call_raises_on_is_error_true(mocker):
+    mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
+    mocker.patch(
+        "conductor.providers.claude.subprocess.run",
+        return_value=_fake_completed(
+            stdout='{"is_error": true, "result": "permission denied"}'
+        ),
+    )
+    with pytest.raises(ProviderHTTPError) as exc:
+        ClaudeProvider().call("hi")
+    assert "permission denied" in str(exc.value)
+
+
+def test_claude_call_raises_on_malformed_json(mocker):
+    mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
+    mocker.patch(
+        "conductor.providers.claude.subprocess.run",
+        return_value=_fake_completed(stdout="not json"),
+    )
+    with pytest.raises(ProviderHTTPError) as exc:
+        ClaudeProvider().call("hi")
+    assert "json" in str(exc.value).lower()
+
+
+def test_claude_timeout_maps_to_provider_error(mocker):
+    mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
+    mocker.patch(
+        "conductor.providers.claude.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="claude", timeout=1),
+    )
+    with pytest.raises(ProviderError) as exc:
+        ClaudeProvider().call("hi")
+    assert "timed out" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Codex
+# ---------------------------------------------------------------------------
+
+CODEX_NDJSON = (
+    '{"type":"item.started","item":{"type":"agent_message"}}\n'
+    '{"type":"item.completed","item":{"type":"agent_message","text":"hello from codex"}}\n'
+    '{"type":"turn.completed","usage":{"input_tokens":5,"output_tokens":2}}\n'
+)
+
+
+def test_codex_configured_when_cli_present(mocker):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    ok, _ = CodexProvider().configured()
+    assert ok is True
+
+
+def test_codex_call_parses_ndjson_and_usage(mocker):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    mocker.patch(
+        "conductor.providers.codex.subprocess.run",
+        return_value=_fake_completed(stdout=CODEX_NDJSON),
+    )
+
+    response = CodexProvider().call("hi")
+
+    assert response.text == "hello from codex"
+    assert response.provider == "codex"
+    assert response.usage["input_tokens"] == 5
+    assert response.usage["output_tokens"] == 2
+
+
+def test_codex_call_raises_when_no_agent_message(mocker):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    mocker.patch(
+        "conductor.providers.codex.subprocess.run",
+        return_value=_fake_completed(
+            stdout='{"type":"turn.completed","usage":{}}\n'
+        ),
+    )
+    with pytest.raises(ProviderHTTPError) as exc:
+        CodexProvider().call("hi")
+    assert "agent_message" in str(exc.value)
+
+
+def test_codex_call_raises_on_non_zero_exit(mocker):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    mocker.patch(
+        "conductor.providers.codex.subprocess.run",
+        return_value=_fake_completed(stderr="login required", returncode=1),
+    )
+    with pytest.raises(ProviderHTTPError) as exc:
+        CodexProvider().call("hi")
+    assert "login required" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Gemini
+# ---------------------------------------------------------------------------
+
+GEMINI_JSON = """{
+    "response": "hello from gemini",
+    "session_id": "xyz",
+    "stats": {
+        "models": {
+            "gemini-2.5-pro": {"tokens": {"input": 12, "candidates": 4}}
+        }
+    }
+}"""
+
+
+def test_gemini_configured_when_cli_present(mocker):
+    mocker.patch("conductor.providers.gemini.shutil.which", return_value="/usr/bin/gemini")
+    ok, _ = GeminiProvider().configured()
+    assert ok is True
+
+
+def test_gemini_call_parses_json_and_usage(mocker):
+    mocker.patch("conductor.providers.gemini.shutil.which", return_value="/usr/bin/gemini")
+    mocker.patch(
+        "conductor.providers.gemini.subprocess.run",
+        return_value=_fake_completed(stdout=GEMINI_JSON),
+    )
+
+    response = GeminiProvider().call("hi")
+
+    assert response.text == "hello from gemini"
+    assert response.provider == "gemini"
+    assert response.usage["input_tokens"] == 12
+    assert response.usage["output_tokens"] == 4
+
+
+def test_gemini_call_falls_back_to_plain_text(mocker):
+    mocker.patch("conductor.providers.gemini.shutil.which", return_value="/usr/bin/gemini")
+    mocker.patch(
+        "conductor.providers.gemini.subprocess.run",
+        return_value=_fake_completed(stdout="plain text reply"),
+    )
+
+    response = GeminiProvider().call("hi")
+
+    assert response.text == "plain text reply"
+    assert response.usage["input_tokens"] is None
+
+
+def test_gemini_call_passes_model_flag(mocker):
+    mocker.patch("conductor.providers.gemini.shutil.which", return_value="/usr/bin/gemini")
+    run_mock = mocker.patch(
+        "conductor.providers.gemini.subprocess.run",
+        return_value=_fake_completed(stdout=GEMINI_JSON),
+    )
+    GeminiProvider().call("hi", model="gemini-2.5-flash")
+    args = run_mock.call_args.args[0]
+    assert "-m" in args and args[args.index("-m") + 1] == "gemini-2.5-flash"
+
+
+def test_gemini_call_raises_on_empty_stdout(mocker):
+    mocker.patch("conductor.providers.gemini.shutil.which", return_value="/usr/bin/gemini")
+    mocker.patch(
+        "conductor.providers.gemini.subprocess.run",
+        return_value=_fake_completed(stdout=""),
+    )
+    with pytest.raises(ProviderHTTPError):
+        GeminiProvider().call("hi")

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -1,0 +1,100 @@
+"""Tests for the Ollama provider — mocked httpx via respx."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from conductor.providers.interface import (
+    ProviderConfigError,
+    ProviderHTTPError,
+)
+from conductor.providers.ollama import (
+    OLLAMA_BASE_URL_ENV,
+    OLLAMA_DEFAULT_BASE_URL,
+    OllamaProvider,
+)
+
+CHAT_URL = f"{OLLAMA_DEFAULT_BASE_URL}/api/chat"
+TAGS_URL = f"{OLLAMA_DEFAULT_BASE_URL}/api/tags"
+
+
+@pytest.fixture(autouse=True)
+def _no_base_url_override(monkeypatch):
+    monkeypatch.delenv(OLLAMA_BASE_URL_ENV, raising=False)
+
+
+def test_configured_true_when_server_healthy():
+    with respx.mock() as router:
+        router.get(TAGS_URL).mock(
+            return_value=httpx.Response(200, json={"models": []})
+        )
+        ok, reason = OllamaProvider().configured()
+    assert ok is True and reason is None
+
+
+def test_configured_false_when_server_unreachable():
+    with respx.mock() as router:
+        router.get(TAGS_URL).mock(side_effect=httpx.ConnectError("refused"))
+        ok, reason = OllamaProvider().configured()
+    assert ok is False
+    assert "Ollama" in reason
+
+
+def test_configured_honors_env_override(monkeypatch):
+    monkeypatch.setenv(OLLAMA_BASE_URL_ENV, "http://ollama.internal:11434")
+    with respx.mock() as router:
+        router.get("http://ollama.internal:11434/api/tags").mock(
+            return_value=httpx.Response(200, json={"models": []})
+        )
+        ok, _ = OllamaProvider().configured()
+    assert ok is True
+
+
+def test_call_returns_normalized_response():
+    body = {
+        "model": "qwen2.5-coder:14b",
+        "message": {"role": "assistant", "content": "hello from ollama"},
+        "prompt_eval_count": 8,
+        "eval_count": 3,
+        "total_duration": 1_500_000_000,  # 1.5s in nanoseconds
+    }
+    with respx.mock() as router:
+        router.post(CHAT_URL).mock(return_value=httpx.Response(200, json=body))
+        response = OllamaProvider().call("hi")
+
+    assert response.text == "hello from ollama"
+    assert response.provider == "ollama"
+    assert response.model == "qwen2.5-coder:14b"
+    assert response.usage == {
+        "input_tokens": 8,
+        "output_tokens": 3,
+        "cached_tokens": None,
+    }
+    assert response.duration_ms == 1500
+
+
+def test_call_raises_on_unreachable_endpoint():
+    with respx.mock() as router:
+        router.post(CHAT_URL).mock(side_effect=httpx.ConnectError("refused"))
+        with pytest.raises(ProviderConfigError):
+            OllamaProvider().call("hi")
+
+
+def test_call_raises_on_non_200():
+    with respx.mock() as router:
+        router.post(CHAT_URL).mock(return_value=httpx.Response(500, text="oops"))
+        with pytest.raises(ProviderHTTPError) as exc:
+            OllamaProvider().call("hi")
+    assert "500" in str(exc.value)
+
+
+def test_call_raises_on_missing_content():
+    with respx.mock() as router:
+        router.post(CHAT_URL).mock(
+            return_value=httpx.Response(200, json={"message": {}})
+        )
+        with pytest.raises(ProviderHTTPError) as exc:
+            OllamaProvider().call("hi")
+    assert "content" in str(exc.value)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,54 @@
+"""Registry-level tests for conductor.providers."""
+
+from __future__ import annotations
+
+import pytest
+
+from conductor.providers import (
+    ClaudeProvider,
+    CodexProvider,
+    GeminiProvider,
+    KimiProvider,
+    OllamaProvider,
+    get_provider,
+    known_providers,
+)
+
+
+def test_known_providers_returns_all_five():
+    assert known_providers() == ["claude", "codex", "gemini", "kimi", "ollama"]
+
+
+def test_get_provider_returns_correct_class():
+    assert isinstance(get_provider("kimi"), KimiProvider)
+    assert isinstance(get_provider("claude"), ClaudeProvider)
+    assert isinstance(get_provider("codex"), CodexProvider)
+    assert isinstance(get_provider("gemini"), GeminiProvider)
+    assert isinstance(get_provider("ollama"), OllamaProvider)
+
+
+def test_get_provider_unknown_raises_keyerror_with_hint():
+    with pytest.raises(KeyError) as exc:
+        get_provider("not-a-provider")
+    assert "not-a-provider" in str(exc.value)
+    assert "claude" in str(exc.value)
+
+
+def test_every_provider_implements_protocol_surface():
+    # Each provider must expose name/tags/default_model + configured/smoke/call.
+    for name in known_providers():
+        provider = get_provider(name)
+        assert isinstance(provider.name, str)
+        assert isinstance(provider.tags, list) and all(
+            isinstance(t, str) for t in provider.tags
+        )
+        assert isinstance(provider.default_model, str)
+        assert callable(provider.configured)
+        assert callable(provider.smoke)
+        assert callable(provider.call)
+
+
+def test_provider_identifiers_match_class_name():
+    # Canonical name on the class equals the registry key.
+    for name in known_providers():
+        assert get_provider(name).name == name


### PR DESCRIPTION
## Summary
Phase 3 of the Conductor v0.1 bootstrap plan. Ships the four remaining provider adapters so the menu is complete (``claude``, ``codex``, ``gemini``, ``kimi``, ``ollama``). Phase 4 (auto router) and Phase 5 (wizard + discovery commands) are next.

## Adapters added
- **``ClaudeProvider``** — subprocess wrapper around ``claude -p --output-format json``. Default model ``sonnet``. User auths via ``claude login``; Conductor never touches the API key.
- **``CodexProvider``** — subprocess wrapper around ``codex exec --json --ephemeral``. Parses NDJSON event stream (``item.completed`` → content; ``turn.completed`` → usage). Uses the canonical identifier ``codex`` — the drift with Sentinel's ``openai`` label resolves when Sentinel migrates to call Conductor in a future plan.
- **``GeminiProvider``** — subprocess wrapper around ``gemini -p -o json --approval-mode plan``. ``--approval-mode plan`` is critical; without it Gemini CLI writes files into cwd on certain prompts. Falls back to plain text when JSON parse fails.
- **``OllamaProvider``** — httpx adapter for the local Ollama HTTP API at ``:11434``. No auth. Base URL overridable via ``OLLAMA_BASE_URL``.

## Registry
- ``providers/__init__.py`` exports all five providers + ``known_providers()`` helper (for forthcoming ``conductor list`` / ``conductor doctor``).
- Every provider satisfies the ``Provider`` Protocol: ``name``, ``tags``, ``default_model``, ``configured()``, ``smoke()``, ``call()``.

## Test plan
- [x] ``uv run pytest`` — 49 passed (14 kimi + 17 subprocess + 7 ollama + 5 registry + 6 cli).
- [x] Subprocess adapters mocked via ``pytest-mock`` (``subprocess.run`` + ``shutil.which``).
- [x] Ollama mocked via ``respx``.
- [x] No live network, no real CLI invocations.
- [ ] Live smoke against each adapter on an actual system with the CLIs installed — covered by ``validate.yml``'s ``live-smoke`` job once the workflow is extended in Phase 5 (today it only exercises kimi via CF).

## What's NOT in this PR
- Auto-mode router (``--auto``) — Phase 4.
- ``conductor list`` / ``smoke`` / ``init`` / ``doctor`` discovery commands — Phase 5.
- ``credentials.py`` local-dev store with Keychain support — drafted earlier in the session but orphan without a consumer; will land with Phase 5's ``conductor init``.

## Companion plan
[autumn-garage/.cortex/plans/conductor-bootstrap.md](https://github.com/autumngarage/autumn-garage/blob/main/.cortex/plans/conductor-bootstrap.md) (Phase 3 section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)