### PR TITLE
feat: auto-mode router with rule-based tag scoring

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -1,8 +1,8 @@
-"""Conductor CLI — `conductor call --with <provider> --task "..."`.
+"""Conductor CLI — ``conductor call [--with <id> | --auto] --task "..."``.
 
-v0.1 ships only the `call` command in manual mode (`--with <id>`). Auto mode,
-`list`, `smoke`, `init`, and `doctor` land in subsequent phases per
-autumn-garage/.cortex/plans/conductor-bootstrap.md.
+v0.1 ships the ``call`` command in both manual mode (``--with <id>``) and auto
+mode (``--auto``, router picks). ``list``, ``smoke``, ``init``, and ``doctor``
+land in Phase 5 per autumn-garage/.cortex/plans/conductor-bootstrap.md.
 """
 
 from __future__ import annotations
@@ -21,6 +21,7 @@ from conductor.providers import (
     ProviderError,
     get_provider,
 )
+from conductor.router import NoConfiguredProvider, RouteDecision, pick
 
 
 def _read_task(task: Optional[str]) -> str:
@@ -43,9 +44,23 @@ def _read_task(task: Optional[str]) -> str:
     return body
 
 
-def _emit(response: CallResponse, *, as_json: bool) -> None:
+def _parse_tags(raw: Optional[str]) -> list[str]:
+    if not raw:
+        return []
+    return [t.strip() for t in raw.split(",") if t.strip()]
+
+
+def _emit(
+    response: CallResponse,
+    *,
+    as_json: bool,
+    decision: Optional[RouteDecision] = None,
+) -> None:
     if as_json:
-        click.echo(json.dumps(asdict(response), default=str, indent=2))
+        payload = asdict(response)
+        if decision is not None:
+            payload["route"] = asdict(decision)
+        click.echo(json.dumps(payload, default=str, indent=2))
     else:
         click.echo(response.text)
 
@@ -60,8 +75,21 @@ def main() -> None:
 @click.option(
     "--with",
     "provider_id",
-    required=True,
-    help="Provider identifier (kimi, claude, codex, gemini, ollama).",
+    default=None,
+    help="Provider identifier (kimi, claude, codex, gemini, ollama). "
+    "Mutually exclusive with --auto.",
+)
+@click.option(
+    "--auto",
+    is_flag=True,
+    default=False,
+    help="Let the router pick based on --tags and configured providers.",
+)
+@click.option(
+    "--tags",
+    default=None,
+    help="Comma-separated task tags for --auto routing "
+    "(e.g. 'long-context,cheap'). Ignored in --with mode.",
 )
 @click.option(
     "--task",
@@ -78,20 +106,36 @@ def main() -> None:
     "as_json",
     is_flag=True,
     default=False,
-    help="Emit the full CallResponse as JSON instead of plain text.",
+    help="Emit the full CallResponse as JSON (with routing info when --auto).",
 )
 def call(
-    provider_id: str,
+    provider_id: Optional[str],
+    auto: bool,
+    tags: Optional[str],
     task: Optional[str],
     model: Optional[str],
     as_json: bool,
 ) -> None:
-    """Send a task to a specific provider and print the response."""
+    """Send a task to a provider and print the response."""
+    if auto and provider_id:
+        raise click.UsageError("--with and --auto are mutually exclusive.")
+    if not auto and not provider_id:
+        raise click.UsageError("pass --with <id> or --auto.")
+
     body = _read_task(task)
-    try:
-        provider = get_provider(provider_id)
-    except KeyError as e:
-        raise click.UsageError(str(e)) from e
+
+    decision: Optional[RouteDecision] = None
+    if auto:
+        try:
+            provider, decision = pick(_parse_tags(tags))
+        except NoConfiguredProvider as e:
+            click.echo(f"conductor: {e}", err=True)
+            sys.exit(2)
+    else:
+        try:
+            provider = get_provider(provider_id)
+        except KeyError as e:
+            raise click.UsageError(str(e)) from e
 
     try:
         response = provider.call(body, model=model)
@@ -102,7 +146,7 @@ def call(
         click.echo(f"conductor: {e}", err=True)
         sys.exit(1)
 
-    _emit(response, as_json=as_json)
+    _emit(response, as_json=as_json, decision=decision)
 
 
 if __name__ == "__main__":

--- a/src/conductor/router.py
+++ b/src/conductor/router.py
@@ -1,0 +1,115 @@
+"""Auto-mode router — pick a provider for a task based on tags.
+
+v0.1 router: rule-based, not LLM-based. For a task with tags T, a provider P
+scores ``len(set(P.tags) & T)``. Tied scores break by a hardcoded priority
+order (kimi, claude, codex, gemini, ollama) — the opinionated default the
+project ships with. Users who want different priorities will configure them
+via ``conductor init`` in Phase 5 (``~/.config/conductor/config.toml``).
+
+The router never calls ``smoke()`` — that would burn a real API round-trip
+on every ``--auto`` invocation. It filters on ``configured()`` only, which
+is cheap (env-var/CLI presence check). Users who suspect a configured
+provider is unhealthy run ``conductor smoke <id>`` manually.
+
+The router also never swallows "no provider available" — if every
+candidate is unconfigured, ``pick()`` raises ``NoConfiguredProvider``
+rather than returning None, per the project's no-silent-failures rule.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from conductor.providers import (
+    Provider,
+    ProviderError,
+    get_provider,
+    known_providers,
+)
+
+# Opinionated v0.1 priority. Lower index wins on tie.
+# - kimi first: cheap, long context, widely capable → sensible default for
+#   most "just pick something" calls.
+# - claude next: strongest reasoning when the task calls for it.
+# - mistral: new, strong reasoning and function calling.
+# - codex: parallel to claude but via Codex CLI.
+# - gemini: long-context and web-search fallback.
+# - ollama last: only when the others are unavailable (local-only, slower).
+DEFAULT_PRIORITY: tuple[str, ...] = ("kimi", "claude", "mistral", "codex", "gemini", "ollama")
+
+
+class NoConfiguredProvider(ProviderError):
+    """Raised when no provider in the registry is configured enough to call."""
+
+
+@dataclass(frozen=True)
+class RouteDecision:
+    """Why the router picked what it picked.
+
+    Surfaced via ``--json`` so consumers can log/debug routing behavior.
+    """
+
+    provider: str
+    score: int
+    task_tags: tuple[str, ...]
+    matched_tags: tuple[str, ...]
+    candidates_considered: tuple[str, ...]
+    candidates_skipped: tuple[tuple[str, str], ...]  # (provider, reason)
+
+
+def pick(
+    task_tags: Optional[list[str]] = None,
+    *,
+    priority: tuple[str, ...] = DEFAULT_PRIORITY,
+) -> tuple[Provider, RouteDecision]:
+    """Pick the best-scoring configured provider for ``task_tags``.
+
+    Resolution:
+      1. Iterate registry in ``priority`` order (unknown registry entries
+         tacked on at the end, alphabetized).
+      2. Drop providers where ``configured()`` returns False.
+      3. Score each remaining provider by tag-overlap with the task.
+      4. Return the highest scorer; ties break by priority order.
+
+    Returns (provider, decision). Raises NoConfiguredProvider if every
+    provider is unconfigured.
+    """
+    task_tag_set = set(task_tags or [])
+
+    order = [p for p in priority if p in set(known_providers())]
+    order += sorted(set(known_providers()) - set(order))
+
+    considered: list[tuple[str, int, tuple[str, ...]]] = []
+    skipped: list[tuple[str, str]] = []
+
+    for name in order:
+        provider = get_provider(name)
+        ok, reason = provider.configured()
+        if not ok:
+            skipped.append((name, reason or "not configured"))
+            continue
+        matched = tuple(sorted(task_tag_set & set(provider.tags)))
+        considered.append((name, len(matched), matched))
+
+    if not considered:
+        raise NoConfiguredProvider(
+            "no provider is configured. Configure at least one via its "
+            "auth mechanism (e.g. `claude login`, `codex login`, `gemini`, "
+            "`ollama serve`, or `CLOUDFLARE_API_TOKEN`+`CLOUDFLARE_ACCOUNT_ID`). "
+            f"Skipped: {skipped}"
+        )
+
+    # max score, then earliest priority-index on ties.
+    priority_index = {name: i for i, name in enumerate(order)}
+    considered.sort(key=lambda entry: (-entry[1], priority_index[entry[0]]))
+    winner_name, winner_score, winner_matched = considered[0]
+
+    return get_provider(winner_name), RouteDecision(
+        provider=winner_name,
+        score=winner_score,
+        task_tags=tuple(sorted(task_tag_set)),
+        matched_tags=winner_matched,
+        candidates_considered=tuple(name for name, _, _ in considered),
+        candidates_skipped=tuple(skipped),
+    )

--- a/tests/test_cli_auto.py
+++ b/tests/test_cli_auto.py
@@ -1,0 +1,126 @@
+"""CLI tests for --auto routing."""
+
+from __future__ import annotations
+
+import httpx
+import respx
+from click.testing import CliRunner
+
+from conductor.cli import main
+from conductor.providers.kimi import (
+    CLOUDFLARE_ACCOUNT_ID_ENV,
+    CLOUDFLARE_API_TOKEN_ENV,
+    KIMI_DEFAULT_MODEL,
+)
+
+_TEST_ACCOUNT_ID = "acct-test-1234"
+_CF_CHAT_URL = (
+    f"https://api.cloudflare.com/client/v4/accounts/{_TEST_ACCOUNT_ID}"
+    "/ai/v1/chat/completions"
+)
+
+
+def _stub_only_kimi_configured(mocker):
+    from conductor.providers import (
+        ClaudeProvider,
+        CodexProvider,
+        GeminiProvider,
+        OllamaProvider,
+    )
+
+    for cls in (ClaudeProvider, CodexProvider, GeminiProvider, OllamaProvider):
+        mocker.patch.object(cls, "configured", lambda self: (False, "stubbed off"))
+
+
+def test_call_auto_and_with_are_mutually_exclusive(mocker):
+    _stub_only_kimi_configured(mocker)
+    result = CliRunner().invoke(
+        main, ["call", "--with", "kimi", "--auto", "--task", "hi"]
+    )
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output.lower()
+
+
+def test_call_requires_with_or_auto(mocker):
+    result = CliRunner().invoke(main, ["call", "--task", "hi"])
+    assert result.exit_code != 0
+    assert "--with" in result.output or "--auto" in result.output
+
+
+def test_call_auto_picks_configured_provider(monkeypatch, mocker):
+    _stub_only_kimi_configured(mocker)
+    monkeypatch.setenv(CLOUDFLARE_API_TOKEN_ENV, "cf-test-token")
+    monkeypatch.setenv(CLOUDFLARE_ACCOUNT_ID_ENV, _TEST_ACCOUNT_ID)
+
+    with respx.mock() as router:
+        router.post(_CF_CHAT_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "model": KIMI_DEFAULT_MODEL,
+                    "choices": [{"message": {"content": "auto-routed"}}],
+                    "usage": {},
+                },
+            )
+        )
+        result = CliRunner().invoke(
+            main, ["call", "--auto", "--tags", "long-context", "--task", "hi"]
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "auto-routed" in result.output
+
+
+def test_call_auto_json_includes_route_decision(monkeypatch, mocker):
+    _stub_only_kimi_configured(mocker)
+    monkeypatch.setenv(CLOUDFLARE_API_TOKEN_ENV, "cf-test-token")
+    monkeypatch.setenv(CLOUDFLARE_ACCOUNT_ID_ENV, _TEST_ACCOUNT_ID)
+
+    with respx.mock() as router:
+        router.post(_CF_CHAT_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "model": KIMI_DEFAULT_MODEL,
+                    "choices": [{"message": {"content": "ok"}}],
+                    "usage": {},
+                },
+            )
+        )
+        result = CliRunner().invoke(
+            main,
+            ["call", "--auto", "--tags", "long-context,cheap", "--task", "hi", "--json"],
+        )
+
+    import json
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["text"] == "ok"
+    assert payload["route"]["provider"] == "kimi"
+    assert set(payload["route"]["task_tags"]) == {"long-context", "cheap"}
+
+
+def test_call_auto_with_no_configured_providers_exits_2(mocker):
+    from conductor.providers import (
+        ClaudeProvider,
+        CodexProvider,
+        GeminiProvider,
+        KimiProvider,
+        OllamaProvider,
+    )
+
+    for cls in (
+        ClaudeProvider,
+        CodexProvider,
+        GeminiProvider,
+        KimiProvider,
+        OllamaProvider,
+    ):
+        mocker.patch.object(cls, "configured", lambda self: (False, "nope"))
+
+    result = CliRunner().invoke(
+        main, ["call", "--auto", "--tags", "cheap", "--task", "hi"]
+    )
+    assert result.exit_code == 2
+    assert "no provider is configured" in result.output.lower()

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,0 +1,118 @@
+"""Tests for the auto-mode router.
+
+All five providers expose their own ``configured()`` (env-var or CLI check);
+we stub those directly so tests run without real CLIs/env vars.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from conductor.router import (
+    DEFAULT_PRIORITY,
+    NoConfiguredProvider,
+    pick,
+)
+
+
+def _stub_configured(mocker, results: dict[str, bool]):
+    """Patch ``configured()`` on each provider class with a fixed result.
+
+    Keys in ``results`` are provider identifiers; values are True/False.
+    Providers missing from the dict default to False (unconfigured).
+    """
+    from conductor.providers import (
+        ClaudeProvider,
+        CodexProvider,
+        GeminiProvider,
+        KimiProvider,
+        OllamaProvider,
+    )
+
+    classes = {
+        "kimi": KimiProvider,
+        "claude": ClaudeProvider,
+        "codex": CodexProvider,
+        "gemini": GeminiProvider,
+        "ollama": OllamaProvider,
+    }
+    for name, cls in classes.items():
+        ok = results.get(name, False)
+        mocker.patch.object(
+            cls,
+            "configured",
+            lambda self, _ok=ok: (_ok, None if _ok else "stub not configured"),
+        )
+
+
+def test_pick_returns_only_configured_provider(mocker):
+    _stub_configured(mocker, {"ollama": True})
+    provider, decision = pick([])
+    assert provider.name == "ollama"
+    assert decision.provider == "ollama"
+
+
+def test_pick_scores_by_tag_overlap(mocker):
+    _stub_configured(mocker, {"kimi": True, "claude": True, "ollama": True})
+    # "local" is only on ollama; it should win even though priority says kimi first.
+    provider, decision = pick(["local"])
+    assert provider.name == "ollama"
+    assert decision.score == 1
+    assert decision.matched_tags == ("local",)
+
+
+def test_pick_priority_tiebreak(mocker):
+    _stub_configured(mocker, {"kimi": True, "claude": True})
+    # No tags → both score 0 → priority order decides → kimi.
+    provider, _ = pick([])
+    assert provider.name == "kimi"
+
+
+def test_pick_priority_tiebreak_with_equal_tag_score(mocker):
+    _stub_configured(mocker, {"kimi": True, "gemini": True})
+    # "long-context" matches both kimi and gemini; priority says kimi first.
+    provider, decision = pick(["long-context"])
+    assert provider.name == "kimi"
+    assert decision.score == 1
+
+
+def test_pick_higher_tag_score_beats_priority(mocker):
+    _stub_configured(mocker, {"kimi": True, "ollama": True})
+    # Both configured, but "offline" and "local" are ollama-only tags.
+    # Ollama scores 2 vs kimi's 0 → ollama wins despite lower priority.
+    provider, decision = pick(["offline", "local"])
+    assert provider.name == "ollama"
+    assert decision.score == 2
+
+
+def test_pick_raises_when_no_provider_configured(mocker):
+    _stub_configured(mocker, {})
+    with pytest.raises(NoConfiguredProvider) as exc:
+        pick(["long-context"])
+    # Error lists what was skipped so users can see which CLI/env is missing.
+    assert "Skipped" in str(exc.value)
+
+
+def test_pick_empty_tags_falls_back_to_priority(mocker):
+    _stub_configured(
+        mocker, {"kimi": True, "claude": True, "codex": True, "gemini": True}
+    )
+    provider, decision = pick([])
+    assert provider.name == "kimi"
+    assert decision.matched_tags == ()
+
+
+def test_route_decision_surfaces_skipped_with_reasons(mocker):
+    _stub_configured(mocker, {"kimi": True})
+    _, decision = pick(["cheap"])
+    skipped_names = {name for name, _ in decision.candidates_skipped}
+    assert skipped_names == {"claude", "codex", "gemini", "ollama"}
+
+
+def test_priority_order_is_stable():
+    # Guardrail: the default priority is part of the project's opinionated
+    # default. A change here should be a deliberate doctrine-level decision,
+    # not a drive-by edit. Priority entries that don't map to a registered
+    # provider (e.g. "mistral" before its adapter lands) are silently
+    # skipped by `pick()` — they reserve the slot for future adapters.
+    assert DEFAULT_PRIORITY == ("kimi", "claude", "mistral", "codex", "gemini", "ollama")


### PR DESCRIPTION
## Summary
Phase 4 of the Conductor v0.1 bootstrap plan. Adds ``conductor call --auto [--tags a,b,c]`` so callers don't have to name a provider explicitly. The manual path (``--with <id>``) remains; the two are mutually exclusive, one is required.

## Router design
- ``pick(task_tags)`` scores each configured provider by tag-overlap with the task.
- Ties break by a hardcoded priority: **kimi → claude → mistral → codex → gemini → ollama**. ``mistral`` is a reserved slot — no adapter shipped yet; priority entries that don't map to a registered provider are silently skipped by ``pick()``.
- Filter is ``configured()`` only — never ``smoke()``. ``smoke()`` would burn a real API round-trip on every ``--auto`` call; users run ``conductor smoke <id>`` manually (Phase 5) to verify health.
- ``NoConfiguredProvider`` is raised (not swallowed) when every provider is unconfigured — error includes the skipped-with-reason list so users see what's missing.
- ``RouteDecision`` dataclass is returned alongside the Provider so ``--json`` callers can log/debug routing behavior.

## CLI
- ``--with <id>`` and ``--auto`` mutually exclusive; one required.
- ``--tags a,b,c`` populates the tag set (ignored in ``--with`` mode).
- ``--json`` includes a ``route`` block when ``--auto`` is used.

Examples:
```sh
conductor call --auto --tags long-context --task "summarize this"
conductor call --auto --tags cheap,local --task "ping"
conductor call --auto --task "hi" --json   # empty tags → priority fallback
```

## Test plan
- [x] ``uv run pytest`` — 63 passed (14 new router + auto CLI tests).
- [x] Router: tag overlap scoring, priority tiebreak, configured filter, ``NoConfiguredProvider`` error path, empty-tags priority fallback, score-beats-priority case.
- [x] CLI: mutual exclusion, ``--auto`` happy path (mocked httpx at Cloudflare), ``--json`` shape includes route info, no-configured-provider exits 2.
- [x] Live spot-check: ``uv run conductor call --auto --tags long-context --task "hi"`` round-trips successfully against real providers in the dev env.

## Mistral note
``DEFAULT_PRIORITY`` reserves a slot for ``mistral``. An earlier draft of the Mistral adapter (written against an older ``mistralai`` SDK version that doesn't match the installed v2.x) was removed during this PR — when Mistral lands for real, it'll slot in without a priority reshuffle.

## Companion plan
[autumn-garage/.cortex/plans/conductor-bootstrap.md](https://github.com/autumngarage/autumn-garage/blob/main/.cortex/plans/conductor-bootstrap.md) (Phase 4 section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)