### PR TITLE
feat: phase 5 — list, smoke, doctor, init wizard, credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,17 +44,21 @@ conductor call --with kimi --task "ping" --json
 
 Shipped:
 
-- `conductor call --with kimi --task "..."` — manual mode for the Kimi (Moonshot AI) provider via OpenAI-compatible HTTP at `api.moonshot.ai/v1`.
-- `--task` flag or stdin for input. `--json` for structured output. `--model` to override the default.
-- Test suite covers the happy path, missing key, non-200 responses, and malformed responses with mocked httpx.
+- Five provider adapters: `kimi` (Cloudflare Workers AI HTTP), `claude` / `codex` / `gemini` (CLI shell-out), `ollama` (local HTTP).
+- `conductor call --with <id> --task "..."` — manual mode for any provider.
+- `conductor call --auto [--tags a,b,c] --task "..."` — rule-based router picks the best configured provider for the task's tags.
+- `conductor list [--json]` — shows every provider with ready/not-ready status, default model, and capability tags.
+- `conductor smoke <id>` / `conductor smoke --all [--json]` — proves a provider's auth + endpoint work (cheapest round-trip that exercises the full path).
+- `conductor doctor [--json]` — diagnostic report: which providers are configured, which env vars are set, what's in the macOS Keychain.
+- `conductor init [-y]` — interactive first-run wizard (TTY-detected, `--yes` for non-TTY). For providers needing credentials (today just `kimi`), prompts, offers macOS Keychain / direnv `.envrc` / print-only storage, runs the smoke test, prints the equivalent non-interactive setup.
+- Credentials resolver (`conductor.credentials`): env var first, then macOS Keychain under service `conductor`.
 
-Deferred to subsequent phases (see `autumn-garage/.cortex/plans/conductor-bootstrap.md`):
+Deferred (see `autumn-garage/.cortex/plans/conductor-bootstrap.md`):
 
-- Adapters for `claude`, `codex`, `gemini` (CLI shell-out) and `ollama` (HTTP).
-- Auto mode (`--auto` with rule-based routing on task tags + provider capabilities).
-- Discovery commands: `conductor list`, `conductor smoke <id>`, `conductor doctor`.
-- Interactive setup wizard: `conductor init` (per Doctrine 0002).
 - Streaming, tool use, cost aggregation — all post-v0.1.
+- LLM-based meta-routing for `--auto` (today: rule-based tag scoring).
+- 1Password (`op run`) storage backend for `conductor init`.
+- Brew tap for `brew install autumngarage/conductor/conductor`.
 
 ## How Sentinel and Touchstone use it
 

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -1,35 +1,37 @@
-"""Conductor CLI — ``conductor call [--with <id> | --auto] --task "..."``.
+"""Conductor CLI — call, list, smoke, doctor, init.
 
-v0.1 ships the ``call`` command in both manual mode (``--with <id>``) and auto
-mode (``--auto``, router picks). ``list``, ``smoke``, ``init``, and ``doctor``
-land in Phase 5 per autumn-garage/.cortex/plans/conductor-bootstrap.md.
+v0.1 surface:
+  conductor call --with <id> --task "..."             # manual
+  conductor call --auto [--tags a,b,c] --task "..."   # router picks
+  conductor list [--json]                             # providers + status
+  conductor smoke [<id>] [--all] [--json]             # health check
+  conductor doctor [--json]                           # diagnostic report
+  conductor init [--yes]                              # interactive setup
 """
 
 from __future__ import annotations
 
 import json
+import os
 import sys
 from dataclasses import asdict
 from typing import Optional
 
 import click
 
-from conductor import __version__
+from conductor import __version__, credentials
 from conductor.providers import (
     CallResponse,
     ProviderConfigError,
     ProviderError,
     get_provider,
+    known_providers,
 )
 from conductor.router import NoConfiguredProvider, RouteDecision, pick
+from conductor.wizard import run_init_wizard
 
 
 def _read_task(task: Optional[str]) -> str:
-    """Use --task if provided; otherwise read all of stdin.
-
-    Empty task is an error — silently sending an empty prompt wastes tokens
-    and produces a confusing response.
-    """
     if task is not None:
         body = task
     elif not sys.stdin.isatty():
@@ -50,7 +52,7 @@ def _parse_tags(raw: Optional[str]) -> list[str]:
     return [t.strip() for t in raw.split(",") if t.strip()]
 
 
-def _emit(
+def _emit_call(
     response: CallResponse,
     *,
     as_json: bool,
@@ -69,6 +71,11 @@ def _emit(
 @click.version_option(__version__, prog_name="conductor")
 def main() -> None:
     """Pick an LLM, give it a job."""
+
+
+# ---------------------------------------------------------------------------
+# call — send a task to a provider
+# ---------------------------------------------------------------------------
 
 
 @main.command()
@@ -146,7 +153,235 @@ def call(
         click.echo(f"conductor: {e}", err=True)
         sys.exit(1)
 
-    _emit(response, as_json=as_json, decision=decision)
+    _emit_call(response, as_json=as_json, decision=decision)
+
+
+# ---------------------------------------------------------------------------
+# list — show provider menu + configured status
+# ---------------------------------------------------------------------------
+
+
+def _provider_rows() -> list[dict]:
+    rows = []
+    for name in known_providers():
+        provider = get_provider(name)
+        ok, reason = provider.configured()
+        rows.append(
+            {
+                "provider": name,
+                "configured": ok,
+                "reason": None if ok else reason,
+                "default_model": provider.default_model,
+                "tags": list(provider.tags),
+            }
+        )
+    return rows
+
+
+@main.command(name="list")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit the provider list as JSON.",
+)
+def list_cmd(as_json: bool) -> None:
+    """Show every known provider and whether it's configured."""
+    rows = _provider_rows()
+    if as_json:
+        click.echo(json.dumps(rows, indent=2))
+        return
+
+    # Plain text table — avoid a rich dependency for core output so scripting
+    # consumers can grep reliably.
+    name_w = max(len("PROVIDER"), max(len(r["provider"]) for r in rows))
+    model_w = max(len("DEFAULT MODEL"), max(len(r["default_model"]) for r in rows))
+    header = f"{'PROVIDER':<{name_w}}  {'READY':<5}  {'DEFAULT MODEL':<{model_w}}  TAGS"
+    click.echo(header)
+    click.echo("-" * len(header))
+    for r in rows:
+        ready = "yes" if r["configured"] else "no"
+        tags = ",".join(r["tags"])
+        click.echo(
+            f"{r['provider']:<{name_w}}  {ready:<5}  {r['default_model']:<{model_w}}  {tags}"
+        )
+        if not r["configured"] and r["reason"]:
+            click.echo(f"{'':<{name_w}}  {'':<5}  └─ {r['reason']}")
+
+
+# ---------------------------------------------------------------------------
+# smoke — run one or all providers' smoke tests
+# ---------------------------------------------------------------------------
+
+
+@main.command()
+@click.argument("provider_id", required=False)
+@click.option(
+    "--all",
+    "run_all",
+    is_flag=True,
+    default=False,
+    help="Run smoke tests for every configured provider.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit results as JSON.",
+)
+def smoke(provider_id: Optional[str], run_all: bool, as_json: bool) -> None:
+    """Prove a provider's auth + endpoint actually work."""
+    if provider_id and run_all:
+        raise click.UsageError("pass a provider id OR --all, not both.")
+    if not provider_id and not run_all:
+        raise click.UsageError("pass a provider id or --all.")
+
+    if provider_id:
+        if provider_id not in known_providers():
+            raise click.UsageError(
+                f"unknown provider {provider_id!r}; known: {known_providers()}"
+            )
+        targets = [provider_id]
+    else:
+        targets = [
+            name for name in known_providers()
+            if get_provider(name).configured()[0]
+        ]
+
+    results = []
+    any_failed = False
+    for name in targets:
+        provider = get_provider(name)
+        ok, reason = provider.smoke()
+        results.append({"provider": name, "ok": ok, "reason": reason})
+        if not ok:
+            any_failed = True
+
+    if as_json:
+        click.echo(json.dumps(results, indent=2))
+    else:
+        if not results:
+            click.echo("no configured providers to smoke-test.")
+        for r in results:
+            symbol = "✓" if r["ok"] else "✗"
+            click.echo(f"{symbol} {r['provider']}")
+            if not r["ok"] and r["reason"]:
+                click.echo(f"  {r['reason']}")
+
+    if any_failed:
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# doctor — diagnostic report (install + env + keychain)
+# ---------------------------------------------------------------------------
+
+
+_DIAGNOSTIC_ENV_VARS = (
+    "CLOUDFLARE_API_TOKEN",
+    "CLOUDFLARE_ACCOUNT_ID",
+    "OLLAMA_BASE_URL",
+)
+
+
+def _diagnostic_payload() -> dict:
+    providers_info = []
+    for name in known_providers():
+        provider = get_provider(name)
+        ok, reason = provider.configured()
+        providers_info.append(
+            {
+                "provider": name,
+                "configured": ok,
+                "reason": None if ok else reason,
+                "default_model": provider.default_model,
+                "tags": list(provider.tags),
+            }
+        )
+
+    env_info = []
+    for var in _DIAGNOSTIC_ENV_VARS:
+        in_env = var in os.environ
+        in_keychain = credentials.keychain_has(var)
+        env_info.append(
+            {
+                "name": var,
+                "in_env": in_env,
+                "in_keychain": in_keychain,
+            }
+        )
+
+    return {
+        "version": __version__,
+        "platform": sys.platform,
+        "python": sys.version.split()[0],
+        "providers": providers_info,
+        "credentials": env_info,
+    }
+
+
+@main.command()
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit diagnostic report as JSON.",
+)
+def doctor(as_json: bool) -> None:
+    """Diagnose what's configured, what's missing, and where to look."""
+    payload = _diagnostic_payload()
+
+    if as_json:
+        click.echo(json.dumps(payload, indent=2))
+        return
+
+    click.echo(f"conductor v{payload['version']}  ·  {payload['platform']}  ·  python {payload['python']}")
+    click.echo("")
+    click.echo("Providers:")
+    for p in payload["providers"]:
+        symbol = "✓" if p["configured"] else "✗"
+        click.echo(f"  {symbol} {p['provider']:<8}  default={p['default_model']}")
+        if not p["configured"]:
+            click.echo(f"      └─ {p['reason']}")
+
+    click.echo("")
+    click.echo("Credentials (env / keychain):")
+    for c in payload["credentials"]:
+        in_env = "env" if c["in_env"] else "—"
+        in_kc = "keychain" if c["in_keychain"] else "—"
+        click.echo(f"  {c['name']:<24}  {in_env:<4}  {in_kc}")
+
+    click.echo("")
+    click.echo("Next steps:")
+    not_configured = [p for p in payload["providers"] if not p["configured"]]
+    if not not_configured:
+        click.echo("  everything is configured. try `conductor smoke --all`.")
+    else:
+        click.echo("  run `conductor init` to configure missing providers interactively,")
+        click.echo("  or set the env vars listed above and re-run `conductor doctor`.")
+
+
+# ---------------------------------------------------------------------------
+# init — interactive setup wizard (Doctrine 0002 compliant)
+# ---------------------------------------------------------------------------
+
+
+@main.command()
+@click.option(
+    "--yes",
+    "-y",
+    "accept_defaults",
+    is_flag=True,
+    default=False,
+    help="Accept all defaults without prompting (non-TTY friendly).",
+)
+def init(accept_defaults: bool) -> None:
+    """Interactively configure Conductor for first use."""
+    exit_code = run_init_wizard(accept_defaults=accept_defaults)
+    sys.exit(exit_code)
 
 
 if __name__ == "__main__":

--- a/src/conductor/credentials.py
+++ b/src/conductor/credentials.py
@@ -1,0 +1,124 @@
+"""Credential resolution for Conductor providers.
+
+Provider adapters call ``credentials.get("CLOUDFLARE_API_TOKEN")`` instead of
+``os.environ.get`` directly. Resolution order:
+
+  1. Environment variable — wins if set. Covers CI runners, ``direnv``,
+     ``op run``, and any shell that exported the variable.
+  2. macOS Keychain via ``security find-generic-password`` under service
+     ``conductor``. Populated by ``conductor init`` when the user picks the
+     Keychain storage option.
+  3. (Future) 1Password CLI via ``op read``. Deferred — requires its own
+     sign-in handling and item layout.
+
+The module is macOS-specific today (Keychain via ``security``). On other
+platforms the Keychain path is a no-op; only env vars work until a
+platform-appropriate backend lands.
+
+The design preserves Conductor's "no-silent-failures" principle: callers
+get None when nothing is found and surface a readable error; this module
+never guesses a credential.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from typing import Optional
+
+CONDUCTOR_KEYCHAIN_SERVICE = "conductor"
+
+
+def get(key: str) -> Optional[str]:
+    """Resolve a credential by name; return None if not found anywhere.
+
+    Order: env var, then macOS Keychain (if available), then None.
+    """
+    if value := os.environ.get(key):
+        return value
+    if sys.platform == "darwin":
+        return _keychain_find(key)
+    return None
+
+
+def set_in_keychain(key: str, value: str) -> None:
+    """Store a credential in the macOS Keychain under service ``conductor``.
+
+    Uses ``security add-generic-password -U`` to update-if-exists. Raises
+    RuntimeError if ``security`` is unavailable or the call fails so the
+    caller can surface the error explicitly.
+    """
+    if sys.platform != "darwin":
+        raise RuntimeError(
+            "Keychain storage is macOS-only. On this platform, "
+            "export the variable in your shell rc or a direnv .envrc."
+        )
+    if not shutil.which("security"):
+        raise RuntimeError(
+            "`security` command not found (expected at /usr/bin/security on macOS)"
+        )
+    result = subprocess.run(
+        [
+            "security",
+            "add-generic-password",
+            "-s",
+            CONDUCTOR_KEYCHAIN_SERVICE,
+            "-a",
+            key,
+            "-w",
+            value,
+            "-U",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Keychain write failed ({result.returncode}): {result.stderr.strip()}"
+        )
+
+
+def delete_from_keychain(key: str) -> None:
+    """Remove a Conductor Keychain entry; silently OK if it doesn't exist."""
+    if sys.platform != "darwin" or not shutil.which("security"):
+        return
+    subprocess.run(
+        [
+            "security",
+            "delete-generic-password",
+            "-s",
+            CONDUCTOR_KEYCHAIN_SERVICE,
+            "-a",
+            key,
+        ],
+        capture_output=True,
+    )
+
+
+def keychain_has(key: str) -> bool:
+    """Return True if the Keychain has a Conductor entry for ``key``."""
+    return _keychain_find(key) is not None
+
+
+def _keychain_find(key: str) -> Optional[str]:
+    if not shutil.which("security"):
+        return None
+    result = subprocess.run(
+        [
+            "security",
+            "find-generic-password",
+            "-s",
+            CONDUCTOR_KEYCHAIN_SERVICE,
+            "-a",
+            key,
+            "-w",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    value = result.stdout.rstrip("\n")
+    return value or None

--- a/src/conductor/providers/kimi.py
+++ b/src/conductor/providers/kimi.py
@@ -41,6 +41,7 @@ from typing import Optional
 
 import httpx
 
+from conductor import credentials
 from conductor.providers.interface import (
     CallResponse,
     ProviderConfigError,
@@ -75,24 +76,26 @@ class KimiProvider:
         self._timeout_sec = timeout_sec
 
     def _resolve_token(self) -> str:
-        token = self._api_token or os.environ.get(CLOUDFLARE_API_TOKEN_ENV)
+        token = self._api_token or credentials.get(CLOUDFLARE_API_TOKEN_ENV)
         if not token:
             raise ProviderConfigError(
                 f"{CLOUDFLARE_API_TOKEN_ENV} is not set. "
                 "Create a Cloudflare API token with Workers AI read permission "
                 "at https://dash.cloudflare.com/profile/api-tokens "
-                f"and export {CLOUDFLARE_API_TOKEN_ENV}=... in your shell."
+                "and set it via `conductor init` or "
+                f"`export {CLOUDFLARE_API_TOKEN_ENV}=...`."
             )
         return token
 
     def _resolve_account_id(self) -> str:
-        account_id = self._account_id or os.environ.get(CLOUDFLARE_ACCOUNT_ID_ENV)
+        account_id = self._account_id or credentials.get(CLOUDFLARE_ACCOUNT_ID_ENV)
         if not account_id:
             raise ProviderConfigError(
                 f"{CLOUDFLARE_ACCOUNT_ID_ENV} is not set. "
                 "Find your account ID on the right sidebar of any zone page in "
                 "https://dash.cloudflare.com/ (or run `wrangler whoami`) "
-                f"and export {CLOUDFLARE_ACCOUNT_ID_ENV}=... in your shell."
+                "and set it via `conductor init` or "
+                f"`export {CLOUDFLARE_ACCOUNT_ID_ENV}=...`."
             )
         return account_id
 
@@ -106,17 +109,16 @@ class KimiProvider:
         }
 
     def configured(self) -> tuple[bool, Optional[str]]:
-        missing = [
-            var
-            for var in (CLOUDFLARE_API_TOKEN_ENV, CLOUDFLARE_ACCOUNT_ID_ENV)
-            if not os.environ.get(var)
-        ]
-        if self._api_token and CLOUDFLARE_API_TOKEN_ENV in missing:
-            missing.remove(CLOUDFLARE_API_TOKEN_ENV)
-        if self._account_id and CLOUDFLARE_ACCOUNT_ID_ENV in missing:
-            missing.remove(CLOUDFLARE_ACCOUNT_ID_ENV)
+        missing = []
+        if not (self._api_token or credentials.get(CLOUDFLARE_API_TOKEN_ENV)):
+            missing.append(CLOUDFLARE_API_TOKEN_ENV)
+        if not (self._account_id or credentials.get(CLOUDFLARE_ACCOUNT_ID_ENV)):
+            missing.append(CLOUDFLARE_ACCOUNT_ID_ENV)
         if missing:
-            return False, f"missing env var(s): {', '.join(missing)}"
+            return False, (
+                f"missing credential(s): {', '.join(missing)}. "
+                "Set via `conductor init` or export as env vars."
+            )
         return True, None
 
     def smoke(self) -> tuple[bool, Optional[str]]:

--- a/src/conductor/wizard.py
+++ b/src/conductor/wizard.py
@@ -1,0 +1,206 @@
+"""Interactive setup wizard for `conductor init`.
+
+Satisfies Autumn Garage Doctrine 0002 (interactive-by-default): detects
+TTY, prompts for ambiguous choices, offers a ``--yes`` escape hatch,
+prints the equivalent non-interactive setup steps at the end so scripters
+learn them by using the tool.
+
+Scope of v0.1:
+  - Walks each of the five known providers in turn.
+  - For credential-bearing providers (kimi today; future API-key adapters
+    will drop in): prompts for the required credentials when they're not
+    already present, offers Keychain or direnv .envrc storage, runs the
+    smoke test, reports the outcome.
+  - For CLI-wrapping providers (claude/codex/gemini) and the local
+    provider (ollama): checks ``configured()`` and prints the install /
+    login hint if missing.
+  - Never overwrites existing env vars or Keychain entries without
+    explicit confirmation.
+
+The wizard does not touch ``~/.config/conductor/config.toml`` at v0.1 —
+we don't have user-level config yet. When we do (auto-mode priority
+override, default tags, backend selection), the wizard grows into it.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+
+import click
+
+from conductor import credentials
+from conductor.providers import get_provider, known_providers
+from conductor.providers.kimi import (
+    CLOUDFLARE_ACCOUNT_ID_ENV,
+    CLOUDFLARE_API_TOKEN_ENV,
+)
+
+# Each provider gets a setup recipe. For API-key providers the recipe
+# lists the credentials to prompt for. For CLI-wrapped providers the
+# recipe is empty (we check configured() but don't collect secrets).
+_KIMI_CREDS = (
+    (CLOUDFLARE_API_TOKEN_ENV, "Cloudflare API token with Workers AI read permission"),
+    (CLOUDFLARE_ACCOUNT_ID_ENV, "Cloudflare account ID"),
+)
+
+
+@dataclass
+class WizardOutcome:
+    provider: str
+    status: str  # "ok" | "skipped" | "failed"
+    detail: str
+
+
+def _is_tty() -> bool:
+    """Indirection so tests can patch `conductor.wizard._is_tty` directly;
+    CliRunner swaps sys.stdin with a pipe and makes the attribute hard to
+    monkey-patch in place."""
+    return sys.stdin.isatty()
+
+
+def run_init_wizard(*, accept_defaults: bool = False) -> int:
+    """Walk the user through configuring every provider that needs it.
+
+    Returns a shell exit code: 0 on success, non-zero if the user
+    explicitly aborted.
+    """
+    interactive = _is_tty() and not accept_defaults
+
+    click.echo("conductor init — interactive setup.")
+    click.echo("")
+    if not interactive:
+        click.echo(
+            "(non-interactive mode: accepting defaults / reading existing state only; "
+            "pass no flags on a TTY for the full wizard)"
+        )
+        click.echo("")
+
+    outcomes: list[WizardOutcome] = []
+
+    for name in known_providers():
+        provider = get_provider(name)
+        click.echo(f"── {name} ──")
+        ok, reason = provider.configured()
+        if ok:
+            click.echo("  already configured. (conductor smoke {0} to verify.)".format(name))
+            outcomes.append(WizardOutcome(name, "ok", "already configured"))
+            click.echo("")
+            continue
+
+        # Provider-specific recipes. Only kimi has a secret-collection
+        # flow at v0.1; the others just need a CLI install + login the
+        # user performs outside conductor.
+        if name == "kimi":
+            outcomes.append(_kimi_flow(interactive))
+        else:
+            click.echo(f"  not configured: {reason}")
+            outcomes.append(WizardOutcome(name, "skipped", reason or "configure externally"))
+        click.echo("")
+
+    _print_summary(outcomes)
+    _print_equivalent_flag_form(outcomes)
+    return 0
+
+
+def _kimi_flow(interactive: bool) -> WizardOutcome:
+    missing = [
+        (var, label)
+        for var, label in _KIMI_CREDS
+        if credentials.get(var) is None
+    ]
+    if not missing:
+        return WizardOutcome("kimi", "ok", "both credentials resolved")
+
+    if not interactive:
+        click.echo("  missing credentials: " + ", ".join(v for v, _ in missing))
+        click.echo("  rerun on a TTY or pass --yes with the credentials in env.")
+        return WizardOutcome("kimi", "skipped", "non-interactive and credentials absent")
+
+    click.echo(
+        "  kimi routes through Cloudflare Workers AI. You need a CF API token "
+        "and the account ID."
+    )
+    click.echo(
+        "  Get a token at https://dash.cloudflare.com/profile/api-tokens "
+        "(Workers AI read)."
+    )
+
+    values: dict[str, str] = {}
+    for var, label in missing:
+        value = click.prompt(f"  {label} ({var})", hide_input=True, default="", show_default=False)
+        if not value:
+            click.echo(f"  skipping — {var} not provided.")
+            return WizardOutcome("kimi", "skipped", f"{var} not provided")
+        values[var] = value
+
+    storage = click.prompt(
+        "  store how? [keychain / envrc / print]",
+        default="keychain",
+        show_default=True,
+    ).strip().lower()
+    if storage not in {"keychain", "envrc", "print"}:
+        click.echo(f"  unknown storage {storage!r}; defaulting to print.")
+        storage = "print"
+
+    if storage == "keychain":
+        try:
+            for var, value in values.items():
+                credentials.set_in_keychain(var, value)
+            click.echo("  stored in macOS Keychain (service: conductor).")
+        except RuntimeError as e:
+            click.echo(f"  keychain storage failed: {e}")
+            click.echo("  falling back to print-only.")
+            storage = "print"
+
+    if storage == "envrc":
+        envrc_path = os.path.join(os.getcwd(), ".envrc")
+        _append_envrc(envrc_path, values)
+        click.echo(f"  wrote export lines to {envrc_path}. run `direnv allow` there.")
+
+    if storage == "print":
+        click.echo("  add these to your shell rc or envrc:")
+        for var, value in values.items():
+            click.echo(f"    export {var}={value!r}")
+
+    # Populate in-process env so the smoke test below succeeds even on
+    # keychain/envrc paths where the current shell hasn't re-sourced.
+    for var, value in values.items():
+        os.environ[var] = value
+
+    provider = get_provider("kimi")
+    ok, reason = provider.smoke()
+    if ok:
+        click.echo("  smoke test passed ✓")
+        return WizardOutcome("kimi", "ok", f"stored via {storage}, smoke passed")
+    click.echo(f"  smoke test FAILED: {reason}")
+    return WizardOutcome("kimi", "failed", f"stored via {storage}, smoke failed: {reason}")
+
+
+def _append_envrc(path: str, values: dict[str, str]) -> None:
+    existing = ""
+    if os.path.exists(path):
+        with open(path, "r", encoding="utf-8") as f:
+            existing = f.read()
+    with open(path, "a", encoding="utf-8") as f:
+        if existing and not existing.endswith("\n"):
+            f.write("\n")
+        f.write("\n# Added by `conductor init`\n")
+        for var, value in values.items():
+            f.write(f"export {var}={value!r}\n")
+
+
+def _print_summary(outcomes: list[WizardOutcome]) -> None:
+    click.echo("Summary:")
+    for o in outcomes:
+        symbol = {"ok": "✓", "skipped": "·", "failed": "✗"}.get(o.status, "?")
+        click.echo(f"  {symbol} {o.provider:<8}  {o.detail}")
+
+
+def _print_equivalent_flag_form(outcomes: list[WizardOutcome]) -> None:
+    click.echo("")
+    click.echo("Next:")
+    click.echo("  conductor list       # see what's ready")
+    click.echo("  conductor smoke --all  # verify every configured provider")
+    click.echo("  conductor call --auto --task \"...\"")

--- a/tests/test_cli_phase5.py
+++ b/tests/test_cli_phase5.py
@@ -1,0 +1,169 @@
+"""CLI tests for list, smoke, doctor commands."""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from conductor.cli import main
+
+
+def _stub_all_unconfigured(mocker):
+    from conductor.providers import (
+        ClaudeProvider,
+        CodexProvider,
+        GeminiProvider,
+        KimiProvider,
+        OllamaProvider,
+    )
+
+    for cls in (
+        ClaudeProvider,
+        CodexProvider,
+        GeminiProvider,
+        KimiProvider,
+        OllamaProvider,
+    ):
+        mocker.patch.object(
+            cls, "configured", lambda self: (False, f"stub: {cls.__name__} unset")
+        )
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+def test_list_text_output_shows_all_five_providers(mocker):
+    _stub_all_unconfigured(mocker)
+    result = CliRunner().invoke(main, ["list"])
+    assert result.exit_code == 0, result.output
+    for name in ("kimi", "claude", "codex", "gemini", "ollama"):
+        assert name in result.output
+
+
+def test_list_json_output_returns_structured_rows(mocker):
+    _stub_all_unconfigured(mocker)
+    result = CliRunner().invoke(main, ["list", "--json"])
+    assert result.exit_code == 0
+    rows = json.loads(result.output)
+    assert len(rows) == 5
+    assert {r["provider"] for r in rows} == {
+        "kimi",
+        "claude",
+        "codex",
+        "gemini",
+        "ollama",
+    }
+    assert all(r["configured"] is False for r in rows)
+    assert all(r["default_model"] for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# smoke
+# ---------------------------------------------------------------------------
+
+
+def test_smoke_unknown_provider_errors():
+    result = CliRunner().invoke(main, ["smoke", "not-a-provider"])
+    assert result.exit_code != 0
+    assert "unknown provider" in result.output.lower()
+
+
+def test_smoke_with_id_and_all_mutually_exclusive():
+    result = CliRunner().invoke(main, ["smoke", "kimi", "--all"])
+    assert result.exit_code != 0
+    assert "not both" in result.output.lower()
+
+
+def test_smoke_requires_target():
+    result = CliRunner().invoke(main, ["smoke"])
+    assert result.exit_code != 0
+    assert "--all" in result.output or "provider id" in result.output.lower()
+
+
+def test_smoke_specific_provider_passes(mocker):
+    from conductor.providers import KimiProvider
+
+    mocker.patch.object(KimiProvider, "smoke", return_value=(True, None))
+    result = CliRunner().invoke(main, ["smoke", "kimi"])
+    assert result.exit_code == 0
+    assert "kimi" in result.output
+    assert "✓" in result.output
+
+
+def test_smoke_specific_provider_fails_exits_1(mocker):
+    from conductor.providers import KimiProvider
+
+    mocker.patch.object(KimiProvider, "smoke", return_value=(False, "bad token"))
+    result = CliRunner().invoke(main, ["smoke", "kimi"])
+    assert result.exit_code == 1
+    assert "bad token" in result.output
+
+
+def test_smoke_all_only_hits_configured_providers(mocker):
+    from conductor.providers import (
+        ClaudeProvider,
+        CodexProvider,
+        GeminiProvider,
+        KimiProvider,
+        OllamaProvider,
+    )
+
+    # Only claude is configured.
+    for cls in (CodexProvider, GeminiProvider, KimiProvider, OllamaProvider):
+        mocker.patch.object(cls, "configured", lambda self: (False, "no"))
+    mocker.patch.object(ClaudeProvider, "configured", lambda self: (True, None))
+    claude_smoke = mocker.patch.object(
+        ClaudeProvider, "smoke", return_value=(True, None)
+    )
+
+    result = CliRunner().invoke(main, ["smoke", "--all"])
+    assert result.exit_code == 0
+    assert claude_smoke.called
+
+
+def test_smoke_json_output_shape(mocker):
+    from conductor.providers import KimiProvider
+
+    mocker.patch.object(KimiProvider, "smoke", return_value=(True, None))
+    result = CliRunner().invoke(main, ["smoke", "kimi", "--json"])
+    assert result.exit_code == 0
+    results = json.loads(result.output)
+    assert results == [{"provider": "kimi", "ok": True, "reason": None}]
+
+
+# ---------------------------------------------------------------------------
+# doctor
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_text_output_covers_every_provider(mocker, monkeypatch):
+    _stub_all_unconfigured(mocker)
+    for var in ("CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "OLLAMA_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+    result = CliRunner().invoke(main, ["doctor"])
+    assert result.exit_code == 0, result.output
+    for name in ("kimi", "claude", "codex", "gemini", "ollama"):
+        assert name in result.output
+    assert "Credentials" in result.output or "credentials" in result.output.lower()
+    assert "conductor init" in result.output
+
+
+def test_doctor_json_shape(mocker, monkeypatch):
+    _stub_all_unconfigured(mocker)
+    monkeypatch.setenv("CLOUDFLARE_API_TOKEN", "x")
+    monkeypatch.delenv("CLOUDFLARE_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+    mocker.patch("conductor.cli.credentials.keychain_has", return_value=False)
+
+    result = CliRunner().invoke(main, ["doctor", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert set(payload.keys()) >= {"version", "platform", "python", "providers", "credentials"}
+    assert len(payload["providers"]) == 5
+    cred_map = {c["name"]: c for c in payload["credentials"]}
+    assert cred_map["CLOUDFLARE_API_TOKEN"]["in_env"] is True
+    assert cred_map["CLOUDFLARE_ACCOUNT_ID"]["in_env"] is False

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,101 @@
+"""Tests for the credentials resolver — mocked subprocess, no real Keychain."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from conductor import credentials
+
+
+def _fake_completed(stdout: str = "", stderr: str = "", returncode: int = 0):
+    return subprocess.CompletedProcess(
+        args=["stub"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def test_get_prefers_env_var(monkeypatch, mocker):
+    monkeypatch.setenv("CONDUCTOR_TEST_KEY", "from-env")
+    # Even if Keychain would return something, env var wins.
+    mocker.patch.object(credentials, "_keychain_find", return_value="from-keychain")
+    assert credentials.get("CONDUCTOR_TEST_KEY") == "from-env"
+
+
+def test_get_falls_back_to_keychain(monkeypatch, mocker):
+    monkeypatch.delenv("CONDUCTOR_TEST_KEY", raising=False)
+    mocker.patch.object(credentials.sys, "platform", "darwin")
+    mocker.patch.object(credentials, "_keychain_find", return_value="from-keychain")
+    assert credentials.get("CONDUCTOR_TEST_KEY") == "from-keychain"
+
+
+def test_get_returns_none_when_unset(monkeypatch, mocker):
+    monkeypatch.delenv("CONDUCTOR_TEST_KEY", raising=False)
+    mocker.patch.object(credentials, "_keychain_find", return_value=None)
+    assert credentials.get("CONDUCTOR_TEST_KEY") is None
+
+
+def test_set_in_keychain_calls_security(mocker):
+    mocker.patch.object(credentials.sys, "platform", "darwin")
+    mocker.patch("conductor.credentials.shutil.which", return_value="/usr/bin/security")
+    run_mock = mocker.patch(
+        "conductor.credentials.subprocess.run",
+        return_value=_fake_completed(returncode=0),
+    )
+
+    credentials.set_in_keychain("SOME_KEY", "secret-value")
+
+    args = run_mock.call_args.args[0]
+    assert args[0] == "security"
+    assert args[1] == "add-generic-password"
+    assert "-U" in args  # update-if-exists
+    assert "-w" in args and args[args.index("-w") + 1] == "secret-value"
+
+
+def test_set_in_keychain_raises_on_non_zero(mocker):
+    mocker.patch.object(credentials.sys, "platform", "darwin")
+    mocker.patch("conductor.credentials.shutil.which", return_value="/usr/bin/security")
+    mocker.patch(
+        "conductor.credentials.subprocess.run",
+        return_value=_fake_completed(stderr="denied", returncode=1),
+    )
+    with pytest.raises(RuntimeError) as exc:
+        credentials.set_in_keychain("K", "v")
+    assert "denied" in str(exc.value)
+
+
+def test_set_in_keychain_raises_on_non_darwin(mocker):
+    mocker.patch.object(credentials.sys, "platform", "linux")
+    with pytest.raises(RuntimeError) as exc:
+        credentials.set_in_keychain("K", "v")
+    assert "macOS-only" in str(exc.value)
+
+
+def test_keychain_find_parses_stdout(mocker):
+    mocker.patch("conductor.credentials.shutil.which", return_value="/usr/bin/security")
+    mocker.patch(
+        "conductor.credentials.subprocess.run",
+        return_value=_fake_completed(stdout="value-from-keychain\n"),
+    )
+    assert credentials._keychain_find("K") == "value-from-keychain"
+
+
+def test_keychain_find_returns_none_on_non_zero(mocker):
+    mocker.patch("conductor.credentials.shutil.which", return_value="/usr/bin/security")
+    mocker.patch(
+        "conductor.credentials.subprocess.run",
+        return_value=_fake_completed(returncode=44),
+    )
+    assert credentials._keychain_find("missing") is None
+
+
+def test_keychain_find_returns_none_when_security_absent(mocker):
+    mocker.patch("conductor.credentials.shutil.which", return_value=None)
+    assert credentials._keychain_find("K") is None
+
+
+def test_keychain_has_shortcut(mocker):
+    mocker.patch.object(credentials, "_keychain_find", return_value="x")
+    assert credentials.keychain_has("K") is True
+    mocker.patch.object(credentials, "_keychain_find", return_value=None)
+    assert credentials.keychain_has("K") is False

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -1,0 +1,164 @@
+"""Tests for the conductor init wizard."""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from conductor.cli import main
+from conductor.providers.kimi import (
+    CLOUDFLARE_ACCOUNT_ID_ENV,
+    CLOUDFLARE_API_TOKEN_ENV,
+)
+
+
+def test_init_non_interactive_mode_reports_state(mocker, monkeypatch):
+    # Non-interactive: everything unconfigured, wizard should report and exit 0.
+    from conductor.providers import (
+        ClaudeProvider,
+        CodexProvider,
+        GeminiProvider,
+        KimiProvider,
+        OllamaProvider,
+    )
+
+    for cls in (
+        ClaudeProvider,
+        CodexProvider,
+        GeminiProvider,
+        KimiProvider,
+        OllamaProvider,
+    ):
+        mocker.patch.object(cls, "configured", lambda self: (False, "stubbed"))
+    monkeypatch.delenv(CLOUDFLARE_API_TOKEN_ENV, raising=False)
+    monkeypatch.delenv(CLOUDFLARE_ACCOUNT_ID_ENV, raising=False)
+    mocker.patch("conductor.wizard.credentials.get", return_value=None)
+
+    result = CliRunner().invoke(main, ["init", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert "Summary" in result.output
+    for name in ("kimi", "claude", "codex", "gemini", "ollama"):
+        assert name in result.output
+
+
+def test_init_skips_already_configured_providers(mocker):
+    from conductor.providers import (
+        ClaudeProvider,
+        CodexProvider,
+        GeminiProvider,
+        KimiProvider,
+        OllamaProvider,
+    )
+
+    mocker.patch.object(ClaudeProvider, "configured", lambda self: (True, None))
+    for cls in (CodexProvider, GeminiProvider, KimiProvider, OllamaProvider):
+        mocker.patch.object(cls, "configured", lambda self: (False, "nope"))
+
+    result = CliRunner().invoke(main, ["init", "--yes"])
+    assert result.exit_code == 0
+    assert "already configured" in result.output
+
+
+def test_init_kimi_interactive_stores_in_keychain(mocker, monkeypatch):
+    # Pretend we're on a TTY so the wizard takes the interactive path.
+    mocker.patch("conductor.wizard._is_tty", return_value=True)
+
+    from conductor.providers import (
+        ClaudeProvider,
+        CodexProvider,
+        GeminiProvider,
+        KimiProvider,
+        OllamaProvider,
+    )
+
+    for cls in (ClaudeProvider, CodexProvider, GeminiProvider, OllamaProvider):
+        mocker.patch.object(cls, "configured", lambda self: (False, "stubbed"))
+
+    # Kimi starts unconfigured, becomes configured after the wizard writes.
+    state = {"configured": False}
+
+    def _kimi_configured(self):
+        return (state["configured"], None if state["configured"] else "missing")
+
+    mocker.patch.object(KimiProvider, "configured", _kimi_configured)
+    mocker.patch.object(KimiProvider, "smoke", return_value=(True, None))
+
+    # credentials.get returns None initially so the wizard prompts.
+    mocker.patch("conductor.wizard.credentials.get", return_value=None)
+    set_mock = mocker.patch("conductor.wizard.credentials.set_in_keychain")
+
+    monkeypatch.delenv(CLOUDFLARE_API_TOKEN_ENV, raising=False)
+    monkeypatch.delenv(CLOUDFLARE_ACCOUNT_ID_ENV, raising=False)
+
+    # stdin order: api token, account id, storage choice
+    result = CliRunner().invoke(
+        main,
+        ["init"],
+        input="my-cf-token\nmy-account-id\nkeychain\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    # Both credentials were stored.
+    assert set_mock.call_count == 2
+    keys = [call.args[0] for call in set_mock.call_args_list]
+    assert CLOUDFLARE_API_TOKEN_ENV in keys
+    assert CLOUDFLARE_ACCOUNT_ID_ENV in keys
+    assert "smoke test passed" in result.output.lower()
+
+
+def test_init_kimi_interactive_print_only(mocker, monkeypatch):
+    mocker.patch("conductor.wizard._is_tty", return_value=True)
+
+    from conductor.providers import (
+        ClaudeProvider,
+        CodexProvider,
+        GeminiProvider,
+        KimiProvider,
+        OllamaProvider,
+    )
+
+    for cls in (ClaudeProvider, CodexProvider, GeminiProvider, OllamaProvider):
+        mocker.patch.object(cls, "configured", lambda self: (False, "stubbed"))
+    mocker.patch.object(KimiProvider, "configured", lambda self: (False, "missing"))
+    mocker.patch.object(KimiProvider, "smoke", return_value=(True, None))
+    mocker.patch("conductor.wizard.credentials.get", return_value=None)
+    set_mock = mocker.patch("conductor.wizard.credentials.set_in_keychain")
+
+    monkeypatch.delenv(CLOUDFLARE_API_TOKEN_ENV, raising=False)
+    monkeypatch.delenv(CLOUDFLARE_ACCOUNT_ID_ENV, raising=False)
+
+    result = CliRunner().invoke(
+        main,
+        ["init"],
+        input="tok\nacct\nprint\n",
+    )
+
+    assert result.exit_code == 0
+    set_mock.assert_not_called()
+    assert f"export {CLOUDFLARE_API_TOKEN_ENV}" in result.output
+
+
+def test_init_kimi_aborts_when_credential_left_empty(mocker, monkeypatch):
+    mocker.patch("conductor.wizard._is_tty", return_value=True)
+
+    from conductor.providers import (
+        ClaudeProvider,
+        CodexProvider,
+        GeminiProvider,
+        KimiProvider,
+        OllamaProvider,
+    )
+
+    for cls in (ClaudeProvider, CodexProvider, GeminiProvider, OllamaProvider):
+        mocker.patch.object(cls, "configured", lambda self: (False, "stubbed"))
+    mocker.patch.object(KimiProvider, "configured", lambda self: (False, "missing"))
+    mocker.patch("conductor.wizard.credentials.get", return_value=None)
+    set_mock = mocker.patch("conductor.wizard.credentials.set_in_keychain")
+
+    monkeypatch.delenv(CLOUDFLARE_API_TOKEN_ENV, raising=False)
+    monkeypatch.delenv(CLOUDFLARE_ACCOUNT_ID_ENV, raising=False)
+
+    # User hits enter at the first prompt (empty value) → wizard skips.
+    result = CliRunner().invoke(main, ["init"], input="\n")
+    assert result.exit_code == 0
+    assert "not provided" in result.output.lower() or "skipping" in result.output.lower()
+    set_mock.assert_not_called()


### PR DESCRIPTION
## Summary
Phase 5 closes out the Conductor v0.1 bootstrap plan with the discovery + setup surface.

New commands:
- ``conductor list [--json]`` — provider menu + ready/not-ready status, default model, tags.
- ``conductor smoke <id>`` / ``conductor smoke --all [--json]`` — cheapest round-trip that proves auth + endpoint work.
- ``conductor doctor [--json]`` — diagnostic: per-provider state, env vars, Keychain entries, install hints.
- ``conductor init [-y]`` — interactive first-run wizard, Doctrine 0002 compliant.

New module: ``conductor.credentials``
- ``get(key)`` resolves env var first, then macOS Keychain (service ``conductor``).
- ``set_in_keychain(key, value)`` wraps ``security add-generic-password -U``.
- Wired into ``kimi.py`` so the CF token + account can come from env OR Keychain transparently.

Init wizard details (``conductor.wizard``):
- Walks every provider; skips ones already configured.
- For credential-bearing adapters (just ``kimi`` today — future API-key adapters drop in): prompts for each required credential, offers **macOS Keychain** / **direnv .envrc** / **print-only** storage, runs the smoke test, reports pass/fail.
- TTY-detected with ``--yes``/``-y`` escape hatch for non-TTY runs.
- Prints flag-form ""next steps"" at the end per Doctrine 0002.

## Deferred (post-v0.1)
- 1Password (``op run``) storage backend in the wizard.
- Streaming, tool use, cost aggregation across providers.
- LLM-based meta-routing for ``--auto`` (today: rule-based tag scoring).
- Brew tap wiring (formula + release flow).

## Test plan
- [x] ``uv run pytest`` — **89 passed** (26 new: 10 credentials + 11 list/smoke/doctor CLI + 5 wizard).
- [x] Live spot-check:
  - ``conductor list`` correctly shows 4 of 5 ready on a dev box without CF creds.
  - ``conductor doctor`` surfaces the missing env vars and pointers.
  - ``conductor --help`` enumerates all six commands cleanly.

## Companion plan
[autumn-garage/.cortex/plans/conductor-bootstrap.md](https://github.com/autumngarage/autumn-garage/blob/main/.cortex/plans/conductor-bootstrap.md) — Phase 5 complete after this merges. v0.1.0 tag follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)