### PR TITLE
feat(v0.3.1): HTTP tool-use — Slice B (Edit/Write/Bash + ollama + workspace-write)

### DIFF
--- a/src/conductor/providers/kimi.py
+++ b/src/conductor/providers/kimi.py
@@ -73,11 +73,15 @@ class KimiProvider:
 
     # Capability declarations (see interface.py)
     quality_tier = "strong"
-    # Read-only tool-use landed in v0.3.0 via the HTTP tool-use loop.
-    # Edit/Write/Bash land in v0.3.1; the router filters based on the
-    # declared set so exec(tools={Edit}) still gets routed away until then.
-    supported_tools: frozenset[str] = frozenset({"Read", "Grep", "Glob"})
-    supported_sandboxes: frozenset[str] = frozenset({"none", "read-only"})
+    # Full tool-use landed in v0.3.1 (Edit/Write/Bash + workspace-write
+    # sandbox). v0.3.0 shipped the read-only half. Subprocess sandbox
+    # (`--sandbox strict`) lands in v0.3.2.
+    supported_tools: frozenset[str] = frozenset(
+        {"Read", "Grep", "Glob", "Edit", "Write", "Bash"}
+    )
+    supported_sandboxes: frozenset[str] = frozenset(
+        {"none", "read-only", "workspace-write"}
+    )
     supports_effort = True
     effort_to_thinking = {
         "minimal": 0,
@@ -282,15 +286,13 @@ class KimiProvider:
         unknown = tools - self.supported_tools
         if unknown:
             raise UnsupportedCapability(
-                f"kimi does not support tools {sorted(unknown)} in this release "
-                f"(supported: {sorted(self.supported_tools)}). "
-                "Edit/Write/Bash land in v0.3.1."
+                f"kimi does not support tools {sorted(unknown)} "
+                f"(supported: {sorted(self.supported_tools)})."
             )
         if sandbox not in self.supported_sandboxes:
             raise UnsupportedCapability(
-                f"kimi does not support sandbox={sandbox!r} in this release "
-                f"(supported: {sorted(self.supported_sandboxes)}). "
-                "workspace-write lands in v0.3.1."
+                f"kimi does not support sandbox={sandbox!r} "
+                f"(supported: {sorted(self.supported_sandboxes)})."
             )
         if sandbox == "none":
             raise UnsupportedCapability(

--- a/src/conductor/providers/ollama.py
+++ b/src/conductor/providers/ollama.py
@@ -11,8 +11,10 @@ to their respective CLIs.
 
 from __future__ import annotations
 
+import json
 import os
 import time
+from pathlib import Path
 
 import httpx
 
@@ -22,11 +24,17 @@ from conductor.providers.interface import (
     ProviderHTTPError,
     UnsupportedCapability,
 )
+from conductor.tools import (
+    ToolExecutionError,
+    ToolExecutor,
+    build_tool_specs,
+)
 
 OLLAMA_BASE_URL_ENV = "OLLAMA_BASE_URL"
 OLLAMA_DEFAULT_BASE_URL = "http://localhost:11434"
 OLLAMA_DEFAULT_MODEL = "qwen2.5-coder:14b"
 OLLAMA_REQUEST_TIMEOUT_SEC = 180.0
+OLLAMA_MAX_TOOL_ITERATIONS = 10
 
 
 class OllamaProvider:
@@ -36,9 +44,15 @@ class OllamaProvider:
 
     # Capability declarations (see interface.py)
     quality_tier = "local"
-    # Tool-use lands in Stage 3 (HTTP-side tool-use loop).
-    supported_tools: frozenset[str] = frozenset()
-    supported_sandboxes: frozenset[str] = frozenset({"none"})
+    # Tool-use landed in v0.3.1 via the HTTP tool-use loop (same shape as
+    # kimi, against Ollama's /api/chat endpoint). Subprocess sandbox
+    # (`--sandbox strict`) lands in v0.3.2.
+    supported_tools: frozenset[str] = frozenset(
+        {"Read", "Grep", "Glob", "Edit", "Write", "Bash"}
+    )
+    supported_sandboxes: frozenset[str] = frozenset(
+        {"none", "read-only", "workspace-write"}
+    )
     supports_effort = False  # base ollama models don't expose a thinking dial
     effort_to_thinking: dict[str, int] = {}
     cost_per_1k_in = 0.0
@@ -199,14 +213,160 @@ class OllamaProvider:
                 "ollama has no session model — each /api/chat call is stateless. "
                 "To replay context, prepend the prior turns to `task`."
             )
-        if tools:
+        if sandbox == "":
+            sandbox = "none"
+
+        if not tools:
+            if sandbox != "none":
+                raise UnsupportedCapability(
+                    f"ollama.exec() sandbox={sandbox!r} is not meaningful "
+                    "without tools. Use sandbox='none' for a text-only exec, "
+                    "or pass --tools with a supported tool set."
+                )
+            return self.call(task, model=model, effort=effort)
+
+        unknown = tools - self.supported_tools
+        if unknown:
             raise UnsupportedCapability(
-                "ollama.exec() with tools is not supported in v0.2 (HTTP tool-use "
-                "loop lands in Stage 3). Router should filter ollama out when "
-                f"tools are requested; got tools={sorted(tools)}."
+                f"ollama does not support tools {sorted(unknown)} "
+                f"(supported: {sorted(self.supported_tools)})."
             )
-        if sandbox not in ("", "none"):
+        if sandbox not in self.supported_sandboxes:
             raise UnsupportedCapability(
-                f"ollama.exec() sandbox={sandbox!r} not meaningful without tool-use."
+                f"ollama does not support sandbox={sandbox!r} "
+                f"(supported: {sorted(self.supported_sandboxes)})."
             )
-        return self.call(task, model=model, effort=effort)
+        if sandbox == "none":
+            raise UnsupportedCapability(
+                "ollama.exec() with tools requires at least sandbox='read-only'."
+            )
+
+        workdir = Path(cwd) if cwd else Path.cwd()
+        executor = ToolExecutor(cwd=workdir, sandbox=sandbox)
+        tool_specs = build_tool_specs(tools)
+
+        model = model or self.default_model
+        url = f"{self._base_url()}/api/chat"
+
+        messages: list[dict] = [{"role": "user", "content": task}]
+        iteration = 0
+        totals = {"input_tokens": 0, "output_tokens": 0}
+        final_text = ""
+        final_body: dict = {}
+        hit_cap = False
+
+        start = time.monotonic()
+        while iteration < OLLAMA_MAX_TOOL_ITERATIONS:
+            iteration += 1
+            payload: dict = {
+                "model": model,
+                "messages": messages,
+                "tools": tool_specs,
+                "stream": False,
+            }
+
+            try:
+                with httpx.Client(timeout=self._timeout_sec) as client:
+                    resp = client.post(url, json=payload)
+            except httpx.HTTPError as e:
+                raise ProviderConfigError(
+                    f"cannot reach Ollama at {self._base_url()}: {e}"
+                ) from e
+
+            if resp.status_code != 200:
+                raise ProviderHTTPError(
+                    f"Ollama returned HTTP {resp.status_code}: {resp.text[:500]}"
+                )
+            try:
+                body = resp.json()
+            except ValueError as e:
+                raise ProviderHTTPError(f"Ollama response was not JSON: {e}") from e
+            final_body = body
+
+            message = body.get("message") or {}
+            totals["input_tokens"] += int(body.get("prompt_eval_count") or 0)
+            totals["output_tokens"] += int(body.get("eval_count") or 0)
+
+            tool_calls = message.get("tool_calls") or []
+            final_text = message.get("content") or ""
+
+            if not tool_calls:
+                break
+
+            assistant_entry: dict = {
+                "role": "assistant",
+                "content": message.get("content") or "",
+                "tool_calls": tool_calls,
+            }
+            messages.append(assistant_entry)
+
+            for idx, call in enumerate(tool_calls):
+                fn = call.get("function") or {}
+                name = fn.get("name") or ""
+                raw_args = fn.get("arguments")
+                # Ollama emits arguments as a dict (not a string like OpenAI).
+                # Handle both shapes so mocks written either way still work.
+                if isinstance(raw_args, dict):
+                    args = raw_args
+                    result = None
+                elif isinstance(raw_args, str):
+                    try:
+                        args = json.loads(raw_args) if raw_args.strip() else {}
+                        result = None
+                    except json.JSONDecodeError as e:
+                        args = None
+                        result = (
+                            f"error: tool `{name}` arguments were not valid "
+                            f"JSON: {e}"
+                        )
+                else:
+                    args = {}
+                    result = None
+
+                if args is not None:
+                    try:
+                        result = executor.run(name, args)
+                    except ToolExecutionError as e:
+                        result = f"error: {e}"
+
+                # Ollama does not always emit `id`; fall back to a synthesized one.
+                tool_msg: dict = {
+                    "role": "tool",
+                    "name": name,
+                    "content": result,
+                }
+                call_id = call.get("id")
+                if call_id:
+                    tool_msg["tool_call_id"] = call_id
+                else:
+                    tool_msg["tool_call_id"] = f"call_{iteration}_{idx}"
+                messages.append(tool_msg)
+        else:
+            hit_cap = True
+
+        if hit_cap:
+            final_text = (final_text or "(no content)") + (
+                f"\n\n[conductor: tool-use loop hit max iterations "
+                f"({OLLAMA_MAX_TOOL_ITERATIONS}); model kept requesting tools. "
+                "Re-run with a narrower task or a larger budget.]"
+            )
+
+        duration_ms = int((time.monotonic() - start) * 1000)
+        return CallResponse(
+            text=final_text,
+            provider=self.name,
+            model=final_body.get("model", model) if final_body else model,
+            duration_ms=duration_ms,
+            usage={
+                "input_tokens": totals["input_tokens"],
+                "output_tokens": totals["output_tokens"],
+                "cached_tokens": None,
+                "thinking_tokens": None,
+                "effort": effort if isinstance(effort, str) else None,
+                "thinking_budget": 0,
+                "tool_iterations": iteration,
+                "tool_names": sorted(tools),
+                "hit_iteration_cap": hit_cap,
+            },
+            raw=final_body,
+        )

--- a/src/conductor/tools/registry.py
+++ b/src/conductor/tools/registry.py
@@ -12,8 +12,15 @@ from __future__ import annotations
 import fnmatch
 import os
 import re
+import subprocess
 from pathlib import Path
 from typing import Any, Protocol
+
+# Default per-command timeout for BashTool when the caller doesn't set one.
+# Kept modest so a runaway shell doesn't wedge the tool-use loop.
+_BASH_DEFAULT_TIMEOUT_SEC = 60
+_BASH_MAX_TIMEOUT_SEC = 600
+_BASH_MAX_OUTPUT_BYTES = 256_000
 
 # --------------------------------------------------------------------------- #
 # Public error types
@@ -326,6 +333,223 @@ GlobTool.parameters_schema = {
 
 
 # --------------------------------------------------------------------------- #
+# Tool implementations — workspace-write
+# --------------------------------------------------------------------------- #
+
+
+class EditTool:
+    name = "Edit"
+    description = (
+        "Replace an exact string in a file under the workspace. By default "
+        "requires the match to be unique; set `replace_all` to replace "
+        "every occurrence. Refuses paths that escape the workspace."
+    )
+    parameters_schema: dict  # assigned below
+
+    def requires_sandbox(self) -> str:
+        return "workspace-write"
+
+    def execute(self, params: dict, *, cwd: Path) -> str:
+        path = _require_str(params, "path")
+        old_string = params.get("old_string")
+        new_string = params.get("new_string")
+        replace_all = bool(params.get("replace_all") or False)
+        if not isinstance(old_string, str) or old_string == "":
+            raise ToolSchemaError("`old_string` must be a non-empty string.")
+        if not isinstance(new_string, str):
+            raise ToolSchemaError("`new_string` must be a string.")
+        if old_string == new_string:
+            raise ToolSchemaError(
+                "`old_string` and `new_string` must differ (nothing to do)."
+            )
+        target = _resolve_in_cwd(path, cwd)
+        if not target.exists():
+            raise ToolExecutionError(f"no such file: {path}")
+        if target.is_dir():
+            raise ToolExecutionError(f"{path} is a directory, not a file")
+        try:
+            content = target.read_text(encoding="utf-8")
+        except UnicodeDecodeError as e:
+            raise ToolExecutionError(
+                f"{path} is not valid UTF-8; Edit only supports text files "
+                f"({e})."
+            ) from e
+        except OSError as e:
+            raise ToolExecutionError(f"cannot read {path}: {e}") from e
+
+        count = content.count(old_string)
+        if count == 0:
+            raise ToolExecutionError(
+                f"`old_string` not found in {path}. No changes made. "
+                "Read the file first and provide an exact match."
+            )
+        if count > 1 and not replace_all:
+            raise ToolExecutionError(
+                f"`old_string` appears {count} times in {path}. Either "
+                "extend it with surrounding context to make it unique, or "
+                "pass `replace_all: true`."
+            )
+        new_content = (
+            content.replace(old_string, new_string)
+            if replace_all
+            else content.replace(old_string, new_string, 1)
+        )
+        try:
+            target.write_text(new_content, encoding="utf-8")
+        except OSError as e:
+            raise ToolExecutionError(f"cannot write {path}: {e}") from e
+        return f"Edited {path} ({count} replacement{'s' if count != 1 else ''})."
+
+
+EditTool.parameters_schema = {
+    "type": "object",
+    "properties": {
+        "path": {"type": "string", "description": "File path relative to the workspace."},
+        "old_string": {
+            "type": "string",
+            "description": "Exact text to find. Must match uniquely unless replace_all=true.",
+        },
+        "new_string": {
+            "type": "string",
+            "description": "Replacement text. May be empty to delete.",
+        },
+        "replace_all": {
+            "type": "boolean",
+            "description": "Replace every occurrence (default false).",
+            "default": False,
+        },
+    },
+    "required": ["path", "old_string", "new_string"],
+}
+
+
+class WriteTool:
+    name = "Write"
+    description = (
+        "Create or overwrite a file with the given contents. Parent "
+        "directories are created as needed. Refuses paths that escape "
+        "the workspace."
+    )
+    parameters_schema: dict  # assigned below
+
+    def requires_sandbox(self) -> str:
+        return "workspace-write"
+
+    def execute(self, params: dict, *, cwd: Path) -> str:
+        path = _require_str(params, "path")
+        content = params.get("content")
+        if not isinstance(content, str):
+            raise ToolSchemaError("`content` must be a string (possibly empty).")
+        target = _resolve_in_cwd(path, cwd)
+        if target.is_dir():
+            raise ToolExecutionError(f"{path} is a directory, not a file")
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+        except OSError as e:
+            raise ToolExecutionError(f"cannot write {path}: {e}") from e
+        size = len(content.encode("utf-8"))
+        existed = "overwrote" if target.exists() else "wrote"
+        return f"{existed} {path} ({size} bytes)."
+
+
+WriteTool.parameters_schema = {
+    "type": "object",
+    "properties": {
+        "path": {"type": "string", "description": "File path relative to the workspace."},
+        "content": {
+            "type": "string",
+            "description": "Full file contents. Overwrites any existing file.",
+        },
+    },
+    "required": ["path", "content"],
+}
+
+
+class BashTool:
+    name = "Bash"
+    description = (
+        "Run a shell command inside the workspace. The command's working "
+        "directory is pinned to the workspace root; you cannot cd outside "
+        "it. Output is captured up to 256KB. Per-command timeout is 60 "
+        "seconds by default (configurable up to 600)."
+    )
+    parameters_schema: dict  # assigned below
+
+    def requires_sandbox(self) -> str:
+        return "workspace-write"
+
+    def execute(self, params: dict, *, cwd: Path) -> str:
+        command = _require_str(params, "command")
+        timeout_raw = params.get("timeout_sec")
+        timeout = (
+            int(timeout_raw) if timeout_raw is not None else _BASH_DEFAULT_TIMEOUT_SEC
+        )
+        if timeout <= 0 or timeout > _BASH_MAX_TIMEOUT_SEC:
+            raise ToolSchemaError(
+                f"timeout_sec must be 1..{_BASH_MAX_TIMEOUT_SEC} (got {timeout})."
+            )
+        try:
+            completed = subprocess.run(  # noqa: S602 — shell=True is intentional; tool exists to run shell
+                command,
+                cwd=str(cwd),
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired as e:
+            stdout = (e.stdout or "")[: _BASH_MAX_OUTPUT_BYTES // 2]
+            stderr = (e.stderr or "")[: _BASH_MAX_OUTPUT_BYTES // 2]
+            return (
+                f"TIMEOUT after {timeout}s. "
+                f"stdout (partial):\n{stdout}\n"
+                f"stderr (partial):\n{stderr}"
+            )
+        except OSError as err:
+            raise ToolExecutionError(f"failed to spawn shell: {err}") from err
+
+        stdout = completed.stdout or ""
+        stderr = completed.stderr or ""
+        if len(stdout) > _BASH_MAX_OUTPUT_BYTES:
+            stdout = (
+                stdout[:_BASH_MAX_OUTPUT_BYTES]
+                + f"\n[truncated at {_BASH_MAX_OUTPUT_BYTES} bytes]"
+            )
+        if len(stderr) > _BASH_MAX_OUTPUT_BYTES:
+            stderr = (
+                stderr[:_BASH_MAX_OUTPUT_BYTES]
+                + f"\n[truncated at {_BASH_MAX_OUTPUT_BYTES} bytes]"
+            )
+        return (
+            f"exit={completed.returncode}\n"
+            f"--- stdout ---\n{stdout}"
+            + (f"\n--- stderr ---\n{stderr}" if stderr else "")
+        )
+
+
+BashTool.parameters_schema = {
+    "type": "object",
+    "properties": {
+        "command": {
+            "type": "string",
+            "description": "Shell command to run (interpreted by /bin/sh).",
+        },
+        "timeout_sec": {
+            "type": "integer",
+            "description": (
+                f"Per-command timeout in seconds "
+                f"(default {_BASH_DEFAULT_TIMEOUT_SEC}, "
+                f"max {_BASH_MAX_TIMEOUT_SEC})."
+            ),
+            "default": _BASH_DEFAULT_TIMEOUT_SEC,
+        },
+    },
+    "required": ["command"],
+}
+
+
+# --------------------------------------------------------------------------- #
 # Registry + executor
 # --------------------------------------------------------------------------- #
 
@@ -334,6 +558,9 @@ _BUILTIN_TOOLS: dict[str, Tool] = {
     "Read": ReadTool(),
     "Grep": GrepTool(),
     "Glob": GlobTool(),
+    "Edit": EditTool(),
+    "Write": WriteTool(),
+    "Bash": BashTool(),
 }
 
 READ_ONLY_TOOL_NAMES = frozenset({"Read", "Grep", "Glob"})
@@ -344,8 +571,7 @@ ALL_TOOL_NAMES = READ_ONLY_TOOL_NAMES | WORKSPACE_WRITE_TOOL_NAMES
 def get_tool(name: str) -> Tool:
     if name not in _BUILTIN_TOOLS:
         raise KeyError(
-            f"unknown tool {name!r}; known: {sorted(_BUILTIN_TOOLS)}. "
-            f"(Write/Edit/Bash tools land in the next slice.)"
+            f"unknown tool {name!r}; known: {sorted(_BUILTIN_TOOLS)}."
         )
     return _BUILTIN_TOOLS[name]
 

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -279,7 +279,14 @@ def test_exec_unknown_sandbox_errors_with_hint():
     assert "read-only" in result.output
 
 
-def test_exec_with_kimi_tools_raises_unsupported(mocker):
+def test_exec_with_kimi_tools_raises_unsupported(mocker, monkeypatch):
+    # Pin kimi to its pre-v0.3.0 capability set so --tools Edit is
+    # guaranteed to land in the UnsupportedCapability branch. Post-v0.3.1
+    # all six tools are supported, so exercising the error path needs
+    # a synthetic "this tool isn't in the supported set" scenario.
+    from conductor.providers.kimi import KimiProvider
+
+    monkeypatch.setattr(KimiProvider, "supported_tools", frozenset())
     _stub_all_configured(mocker, {"kimi"})
 
     result = CliRunner().invoke(
@@ -287,7 +294,6 @@ def test_exec_with_kimi_tools_raises_unsupported(mocker):
         ["exec", "--with", "kimi", "--tools", "Edit", "--task", "hi"],
     )
 
-    # Edit lands in v0.3.1 — kimi.exec raises UnsupportedCapability on it.
     assert result.exit_code == 2
     assert (
         "UnsupportedCapability" in result.stderr

--- a/tests/test_kimi.py
+++ b/tests/test_kimi.py
@@ -318,17 +318,19 @@ def test_exec_with_tools_needs_at_least_read_only(configured):
 
 
 def test_exec_rejects_unsupported_tool_set(configured):
+    # Hypothetical future tool outside kimi's declared set.
     with pytest.raises(UnsupportedCapability) as exc:
         KimiProvider().exec(
-            "hi", tools=frozenset({"Edit"}), sandbox="read-only"
+            "hi", tools=frozenset({"Telepathy"}), sandbox="read-only"
         )
     assert "does not support" in str(exc.value)
 
 
 def test_exec_rejects_unsupported_sandbox(configured):
+    # `strict` is Slice C (subprocess) — not in kimi's declared sandboxes yet.
     with pytest.raises(UnsupportedCapability) as exc:
         KimiProvider().exec(
-            "hi", tools=frozenset({"Read"}), sandbox="workspace-write"
+            "hi", tools=frozenset({"Read"}), sandbox="strict"
         )
     assert "does not support" in str(exc.value)
 

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -163,3 +163,211 @@ def test_call_session_id_is_none_for_ollama():
         )
         response = OllamaProvider().call("hi")
     assert response.session_id is None
+
+
+# --------------------------------------------------------------------------- #
+# exec() — tool-use loop (v0.3.1 / Slice B)
+# --------------------------------------------------------------------------- #
+
+
+import json as _json  # noqa: E402 — grouped near the exec tests
+
+
+def _ollama_terminal(content: str) -> dict:
+    return {
+        "model": "qwen2.5-coder:14b",
+        "message": {"role": "assistant", "content": content},
+        "prompt_eval_count": 5,
+        "eval_count": 2,
+        "done": True,
+    }
+
+
+def _ollama_tool_turn(name: str, arguments: dict, call_id: str | None = None) -> dict:
+    call: dict = {
+        "type": "function",
+        "function": {"name": name, "arguments": arguments},
+    }
+    if call_id is not None:
+        call["id"] = call_id
+    return {
+        "model": "qwen2.5-coder:14b",
+        "message": {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [call],
+        },
+        "prompt_eval_count": 3,
+        "eval_count": 4,
+        "done": False,
+    }
+
+
+def test_exec_without_tools_delegates_to_call():
+    with respx.mock() as router:
+        router.post(CHAT_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "message": {"content": "just text"},
+                    "prompt_eval_count": 1,
+                    "eval_count": 1,
+                },
+            )
+        )
+        resp = OllamaProvider().exec("hi")
+    assert resp.text == "just text"
+    assert "tool_iterations" not in resp.usage
+
+
+def test_exec_rejects_non_none_sandbox_without_tools():
+    with pytest.raises(UnsupportedCapability) as exc:
+        OllamaProvider().exec("hi", sandbox="read-only")
+    assert "without tools" in str(exc.value)
+
+
+def test_exec_with_tools_requires_at_least_read_only():
+    with pytest.raises(UnsupportedCapability) as exc:
+        OllamaProvider().exec(
+            "hi", tools=frozenset({"Read"}), sandbox="none"
+        )
+    assert "read-only" in str(exc.value)
+
+
+def test_exec_rejects_unsupported_tool():
+    with pytest.raises(UnsupportedCapability) as exc:
+        OllamaProvider().exec(
+            "hi", tools=frozenset({"Telepathy"}), sandbox="read-only"
+        )
+    assert "does not support" in str(exc.value)
+
+
+def test_exec_runs_single_tool_call_then_answers(tmp_path):
+    (tmp_path / "note.txt").write_text("the answer is 42")
+    tool_turn = _ollama_tool_turn("Read", {"path": "note.txt"}, call_id="c1")
+    final = _ollama_terminal("The file says 42.")
+    with respx.mock() as router:
+        route = router.post(CHAT_URL).mock(
+            side_effect=[
+                httpx.Response(200, json=tool_turn),
+                httpx.Response(200, json=final),
+            ]
+        )
+        resp = OllamaProvider().exec(
+            "read note.txt",
+            tools=frozenset({"Read"}),
+            sandbox="read-only",
+            cwd=str(tmp_path),
+        )
+
+    assert resp.text == "The file says 42."
+    assert resp.usage["tool_iterations"] == 2
+    assert resp.usage["hit_iteration_cap"] is False
+    assert route.call_count == 2
+
+    final_request = route.calls[-1].request
+    payload = _json.loads(final_request.read())
+    roles = [m["role"] for m in payload["messages"]]
+    assert roles == ["user", "assistant", "tool"]
+    assert payload["messages"][2]["content"] == "the answer is 42"
+
+
+def test_exec_handles_ollama_string_args(tmp_path):
+    # Ollama nominally emits arguments as dict, but the provider accepts
+    # either shape — round-trip stringified JSON just in case.
+    (tmp_path / "f.txt").write_text("hello")
+    tool_turn = _ollama_tool_turn("Read", {"path": "f.txt"}, call_id="c1")
+    tool_turn["message"]["tool_calls"][0]["function"]["arguments"] = (
+        '{"path": "f.txt"}'
+    )
+    final = _ollama_terminal("got it")
+    with respx.mock() as router:
+        router.post(CHAT_URL).mock(
+            side_effect=[
+                httpx.Response(200, json=tool_turn),
+                httpx.Response(200, json=final),
+            ]
+        )
+        resp = OllamaProvider().exec(
+            "go",
+            tools=frozenset({"Read"}),
+            sandbox="read-only",
+            cwd=str(tmp_path),
+        )
+    assert resp.text == "got it"
+
+
+def test_exec_tool_error_feeds_back(tmp_path):
+    tool_turn = _ollama_tool_turn(
+        "Read", {"path": "../../../etc/passwd"}, call_id="x"
+    )
+    final = _ollama_terminal("refused, summarizing from memory")
+    with respx.mock() as router:
+        route = router.post(CHAT_URL).mock(
+            side_effect=[
+                httpx.Response(200, json=tool_turn),
+                httpx.Response(200, json=final),
+            ]
+        )
+        resp = OllamaProvider().exec(
+            "read secret",
+            tools=frozenset({"Read"}),
+            sandbox="read-only",
+            cwd=str(tmp_path),
+        )
+    assert "refused" in resp.text
+    payload = _json.loads(route.calls[-1].request.read())
+    tool_msg = [m for m in payload["messages"] if m["role"] == "tool"][0]
+    assert tool_msg["content"].startswith("error:")
+
+
+def test_exec_iteration_cap(tmp_path):
+    (tmp_path / "f.txt").write_text("x")
+    loop = _ollama_tool_turn("Read", {"path": "f.txt"})
+    with respx.mock() as router:
+        route = router.post(CHAT_URL).mock(
+            return_value=httpx.Response(200, json=loop)
+        )
+        resp = OllamaProvider().exec(
+            "never",
+            tools=frozenset({"Read"}),
+            sandbox="read-only",
+            cwd=str(tmp_path),
+        )
+    assert resp.usage["hit_iteration_cap"] is True
+    assert resp.usage["tool_iterations"] == 10
+    assert route.call_count == 10
+    assert "max iterations" in resp.text.lower()
+
+
+def test_exec_workspace_write_runs_edit(tmp_path):
+    (tmp_path / "a.py").write_text("hello world\n")
+    tool_turn = _ollama_tool_turn(
+        "Edit",
+        {
+            "path": "a.py",
+            "old_string": "world",
+            "new_string": "galaxy",
+        },
+        call_id="c",
+    )
+    final = _ollama_terminal("done")
+    with respx.mock() as router:
+        router.post(CHAT_URL).mock(
+            side_effect=[
+                httpx.Response(200, json=tool_turn),
+                httpx.Response(200, json=final),
+            ]
+        )
+        OllamaProvider().exec(
+            "swap world→galaxy",
+            tools=frozenset({"Edit"}),
+            sandbox="workspace-write",
+            cwd=str(tmp_path),
+        )
+    assert (tmp_path / "a.py").read_text() == "hello galaxy\n"
+
+
+def test_exec_session_id_raises():
+    with pytest.raises(UnsupportedCapability):
+        OllamaProvider().exec("hi", resume_session_id="abc")

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -181,9 +181,16 @@ def test_invalid_prefer_raises_with_fix_it_hint():
 # ---------------------------------------------------------------------------
 
 
-def test_tools_filter_excludes_providers_without_capability(mocker):
-    # kimi and ollama have supported_tools=frozenset() (no tool-use in v0.2).
-    # Requesting tools={Edit} should exclude them.
+def test_tools_filter_excludes_providers_without_capability(mocker, monkeypatch):
+    # Simulate a pre-v0.3.1 kimi/ollama (empty supported_tools) so the
+    # capability filter visibly removes them. After v0.3.1 both providers
+    # support the full tool set, but the filter logic itself must still
+    # kick in for any provider that genuinely lacks a requested tool.
+    from conductor.providers.kimi import KimiProvider
+    from conductor.providers.ollama import OllamaProvider
+
+    monkeypatch.setattr(KimiProvider, "supported_tools", frozenset())
+    monkeypatch.setattr(OllamaProvider, "supported_tools", frozenset())
     _stub_configured(mocker, {"claude": True, "kimi": True, "ollama": True})
     provider, decision = pick([], tools={"Edit"})
     assert provider.name == "claude"
@@ -192,8 +199,15 @@ def test_tools_filter_excludes_providers_without_capability(mocker):
     assert "ollama" in skipped_names
 
 
-def test_sandbox_filter_excludes_providers_without_capability(mocker):
-    # ollama only supports sandbox="none". Requesting workspace-write excludes it.
+def test_sandbox_filter_excludes_providers_without_capability(mocker, monkeypatch):
+    # Simulate a provider that only supports sandbox="none" so the
+    # filter removes it when workspace-write is requested. Uses ollama
+    # pinned to the v0.3.0 capability set for a deterministic check.
+    from conductor.providers.ollama import OllamaProvider
+
+    monkeypatch.setattr(
+        OllamaProvider, "supported_sandboxes", frozenset({"none"})
+    )
     _stub_configured(mocker, {"claude": True, "ollama": True})
     _provider, decision = pick([], sandbox="workspace-write")
     skipped_names = {name for name, _ in decision.candidates_skipped}

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -48,11 +48,11 @@ def test_get_tool_rejects_unknown():
         get_tool("NotATool")
 
 
-def test_get_tool_rejects_not_yet_implemented_workspace_write():
-    # Edit/Write/Bash names exist in WORKSPACE_WRITE_TOOL_NAMES but aren't
-    # registered until Slice B. get_tool() still raises.
-    with pytest.raises(KeyError):
-        get_tool("Edit")
+def test_get_tool_returns_every_declared_tool():
+    # ALL_TOOL_NAMES should map 1:1 to registered tools.
+    for name in sorted(ALL_TOOL_NAMES):
+        tool = get_tool(name)
+        assert tool.name == name
 
 
 def test_build_tool_specs_shape_is_openai_compatible():
@@ -325,3 +325,204 @@ def test_executor_workspace_write_satisfies_read_only(tmp_path: Path):
     (tmp_path / "w.txt").write_text("hi")
     executor = ToolExecutor(cwd=tmp_path, sandbox="workspace-write")
     assert executor.run("Read", {"path": "w.txt"}) == "hi"
+
+
+# --------------------------------------------------------------------------- #
+# EditTool
+# --------------------------------------------------------------------------- #
+
+
+def test_edit_tool_unique_replace(tmp_path: Path):
+    (tmp_path / "a.py").write_text("hello world\n")
+    tool = get_tool("Edit")
+    out = tool.execute(
+        {"path": "a.py", "old_string": "world", "new_string": "universe"},
+        cwd=tmp_path,
+    )
+    assert "Edited" in out
+    assert (tmp_path / "a.py").read_text() == "hello universe\n"
+
+
+def test_edit_tool_rejects_ambiguous_match(tmp_path: Path):
+    (tmp_path / "dup.py").write_text("x\nx\n")
+    tool = get_tool("Edit")
+    with pytest.raises(ToolExecutionError) as exc:
+        tool.execute(
+            {"path": "dup.py", "old_string": "x", "new_string": "y"},
+            cwd=tmp_path,
+        )
+    assert "2 times" in str(exc.value) or "appears" in str(exc.value)
+
+
+def test_edit_tool_replace_all_when_requested(tmp_path: Path):
+    (tmp_path / "dup.py").write_text("x\nx\n")
+    tool = get_tool("Edit")
+    out = tool.execute(
+        {
+            "path": "dup.py",
+            "old_string": "x",
+            "new_string": "y",
+            "replace_all": True,
+        },
+        cwd=tmp_path,
+    )
+    assert "2 replacement" in out
+    assert (tmp_path / "dup.py").read_text() == "y\ny\n"
+
+
+def test_edit_tool_rejects_no_match(tmp_path: Path):
+    (tmp_path / "a.py").write_text("abc")
+    tool = get_tool("Edit")
+    with pytest.raises(ToolExecutionError) as exc:
+        tool.execute(
+            {"path": "a.py", "old_string": "xyz", "new_string": "q"},
+            cwd=tmp_path,
+        )
+    assert "not found" in str(exc.value)
+
+
+def test_edit_tool_rejects_same_strings(tmp_path: Path):
+    (tmp_path / "a.py").write_text("abc")
+    tool = get_tool("Edit")
+    with pytest.raises(ToolSchemaError):
+        tool.execute(
+            {"path": "a.py", "old_string": "abc", "new_string": "abc"},
+            cwd=tmp_path,
+        )
+
+
+def test_edit_tool_requires_workspace_write(tmp_path: Path):
+    (tmp_path / "a.txt").write_text("hello")
+    executor = ToolExecutor(cwd=tmp_path, sandbox="read-only")
+    with pytest.raises(ToolExecutionError) as exc:
+        executor.run(
+            "Edit", {"path": "a.txt", "old_string": "hello", "new_string": "bye"}
+        )
+    assert "sandbox" in str(exc.value)
+
+
+def test_edit_tool_rejects_escape(tmp_path: Path):
+    tool = get_tool("Edit")
+    with pytest.raises(ToolExecutionError):
+        tool.execute(
+            {
+                "path": "../outside.txt",
+                "old_string": "a",
+                "new_string": "b",
+            },
+            cwd=tmp_path,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# WriteTool
+# --------------------------------------------------------------------------- #
+
+
+def test_write_tool_creates_new_file(tmp_path: Path):
+    tool = get_tool("Write")
+    out = tool.execute(
+        {"path": "new.txt", "content": "hello\n"}, cwd=tmp_path
+    )
+    assert "new.txt" in out
+    assert (tmp_path / "new.txt").read_text() == "hello\n"
+
+
+def test_write_tool_creates_parent_dirs(tmp_path: Path):
+    tool = get_tool("Write")
+    tool.execute(
+        {"path": "a/b/c/nested.txt", "content": "x"}, cwd=tmp_path
+    )
+    assert (tmp_path / "a" / "b" / "c" / "nested.txt").read_text() == "x"
+
+
+def test_write_tool_overwrites_existing(tmp_path: Path):
+    (tmp_path / "e.txt").write_text("old")
+    tool = get_tool("Write")
+    tool.execute({"path": "e.txt", "content": "new"}, cwd=tmp_path)
+    assert (tmp_path / "e.txt").read_text() == "new"
+
+
+def test_write_tool_requires_workspace_write(tmp_path: Path):
+    executor = ToolExecutor(cwd=tmp_path, sandbox="read-only")
+    with pytest.raises(ToolExecutionError) as exc:
+        executor.run("Write", {"path": "x.txt", "content": "y"})
+    assert "sandbox" in str(exc.value)
+
+
+def test_write_tool_rejects_escape(tmp_path: Path):
+    tool = get_tool("Write")
+    with pytest.raises(ToolExecutionError):
+        tool.execute(
+            {"path": "../evil.txt", "content": "x"}, cwd=tmp_path
+        )
+
+
+def test_write_tool_rejects_directory_path(tmp_path: Path):
+    (tmp_path / "subdir").mkdir()
+    tool = get_tool("Write")
+    with pytest.raises(ToolExecutionError) as exc:
+        tool.execute({"path": "subdir", "content": "x"}, cwd=tmp_path)
+    assert "directory" in str(exc.value)
+
+
+# --------------------------------------------------------------------------- #
+# BashTool
+# --------------------------------------------------------------------------- #
+
+
+def test_bash_tool_runs_command(tmp_path: Path):
+    (tmp_path / "a.txt").write_text("content")
+    tool = get_tool("Bash")
+    out = tool.execute({"command": "ls a.txt"}, cwd=tmp_path)
+    assert "exit=0" in out
+    assert "a.txt" in out
+
+
+def test_bash_tool_captures_nonzero_exit(tmp_path: Path):
+    tool = get_tool("Bash")
+    out = tool.execute({"command": "false"}, cwd=tmp_path)
+    assert "exit=1" in out
+
+
+def test_bash_tool_captures_stderr(tmp_path: Path):
+    tool = get_tool("Bash")
+    out = tool.execute({"command": "echo oops >&2; false"}, cwd=tmp_path)
+    assert "stderr" in out
+    assert "oops" in out
+
+
+def test_bash_tool_times_out(tmp_path: Path):
+    tool = get_tool("Bash")
+    out = tool.execute({"command": "sleep 5", "timeout_sec": 1}, cwd=tmp_path)
+    assert "TIMEOUT" in out
+
+
+def test_bash_tool_pins_cwd(tmp_path: Path):
+    # pwd should report the resolved workspace path.
+    tool = get_tool("Bash")
+    out = tool.execute({"command": "pwd"}, cwd=tmp_path)
+    assert str(tmp_path.resolve()) in out
+
+
+def test_bash_tool_rejects_bad_timeout(tmp_path: Path):
+    tool = get_tool("Bash")
+    with pytest.raises(ToolSchemaError):
+        tool.execute({"command": "true", "timeout_sec": 0}, cwd=tmp_path)
+    with pytest.raises(ToolSchemaError):
+        tool.execute({"command": "true", "timeout_sec": 99999}, cwd=tmp_path)
+
+
+def test_bash_tool_requires_workspace_write(tmp_path: Path):
+    executor = ToolExecutor(cwd=tmp_path, sandbox="read-only")
+    with pytest.raises(ToolExecutionError) as exc:
+        executor.run("Bash", {"command": "true"})
+    assert "sandbox" in str(exc.value)
+
+
+def test_bash_tool_truncates_huge_output(tmp_path: Path):
+    tool = get_tool("Bash")
+    out = tool.execute(
+        {"command": "yes hello | head -c 300000"}, cwd=tmp_path
+    )
+    assert "truncated" in out


### PR DESCRIPTION
## Summary

- **New tools**: `EditTool` (unique-match by default, `replace_all` opt-in), `WriteTool` (create-or-overwrite; auto-creates parents), `BashTool` (shell pinned to cwd, 60s default timeout, 256KB output cap). All three require `workspace-write`; the executor refuses them under `read-only`.
- **Kimi** now declares `supported_tools = {Read, Grep, Glob, Edit, Write, Bash}` and `supported_sandboxes = {none, read-only, workspace-write}`.
- **Ollama** gets the same HTTP tool-use loop as kimi against `/api/chat`: same 10-iteration cap, same graceful cap-hit note, usage accumulation across turns. Handles Ollama's dict-shaped `arguments` field *and* OpenAI-style string arguments.
- **Router filter tests** pin kimi/ollama to a narrower capability set via monkeypatch so the "exclude provider that lacks capability" branch is still exercised after the full tool set landed.

Unblocks the **sentinel migration** (coder role needs writes + a real sandbox), touchstone's cheap-path write-enabled reviews, and any `conductor exec` script that needs Edit/Write/Bash against a local or HTTP model.

## Test plan

- [x] `pytest` — 272 passed (+30 since Slice A: Edit/Write/Bash + ollama loop + router-filter regression fixes)
- [x] `ruff check` — clean
- [x] Edit rejects ambiguous match (2 occurrences → error), accepts unique match, honors `replace_all`
- [x] Write creates nested parents, refuses directory targets, refuses path escape
- [x] Bash times out (sleep 5 with `timeout_sec: 1`), captures stderr, reports exit code, truncates huge output
- [x] All three workspace-write tools raise under `sandbox=\"read-only\"` via `ToolExecutor`
- [x] Ollama: single tool call → feedback → answer; iteration cap; Edit via ollama mutates file; escape-path error fed back cleanly

## Deferred

- Subprocess sandbox (`--sandbox strict`) + context-budget management → **v0.3.2 (Slice C)**

## Plan doc

`autumn-garage/.cortex/plans/conductor-http-tool-use.md` — Stage 3 of the Touchstone × Conductor integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)