### PR TITLE
feat: ASCII hero banner for init + doctor

### DIFF
--- a/src/conductor/banner.py
+++ b/src/conductor/banner.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import os
 import sys
-from collections.abc import Sequence
 
 # Rendered once from `figlet -f standard CONDUCTOR` and embedded here so
 # we don't take a dependency on figlet at runtime. Keep the glyphs

--- a/src/conductor/banner.py
+++ b/src/conductor/banner.py
@@ -1,0 +1,113 @@
+"""ASCII hero banner for `conductor init`, `doctor`, and other splash moments.
+
+Mirrors touchstone's ``tk_hero`` pattern but in Python and without the
+figlet/gum runtime dependency: we ship the banner as a string literal
+so it always renders, then ANSI-color it when a TTY is attached. Call
+``render_banner()`` to get the lines as a list (testable) or
+``print_banner()`` to write to stderr (doesn't interfere with stdout
+capture in scripts).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Sequence
+
+# Rendered once from `figlet -f standard CONDUCTOR` and embedded here so
+# we don't take a dependency on figlet at runtime. Keep the glyphs
+# aligned — editors that strip trailing whitespace may break the art.
+_CONDUCTOR_GLYPHS: tuple[str, ...] = (
+    r"   ___                _            _               ",
+    r"  / __\___  _ __   __| |_   _  ___| |_ ___  _ __   ",
+    r" / /  / _ \| '_ \ / _` | | | |/ __| __/ _ \| '__|  ",
+    r"/ /__| (_) | | | | (_| | |_| | (__| || (_) | |     ",
+    r"\____/\___/|_| |_|\__,_|\__,_|\___|\__\___/|_|     ",
+)
+
+# Deep purple — distinguishes conductor from touchstone's orange and
+# cortex's cyan/green when the four tools print side by side.
+_ANSI_PURPLE = "\033[1;38;5;99m"
+_ANSI_DIM = "\033[2m"
+_ANSI_RESET = "\033[0m"
+
+
+def _color_enabled(stream) -> bool:
+    """True when the stream is a TTY and NO_COLOR is unset."""
+    if os.environ.get("NO_COLOR"):
+        return False
+    if os.environ.get("CLICOLOR") == "0":
+        return False
+    try:
+        return bool(stream.isatty())
+    except (AttributeError, ValueError):
+        return False
+
+
+def render_banner(
+    subtitle: str | None = None,
+    version: str | None = None,
+    *,
+    use_color: bool = True,
+) -> list[str]:
+    """Return the banner as a list of lines (no trailing newline per line).
+
+    When ``use_color`` is True, each glyph line is wrapped with the
+    conductor purple ANSI code; subtitle/version lines use the dim code.
+    Callers writing to a non-TTY should pass ``use_color=False``.
+    """
+    lines: list[str] = [""]
+    for glyph in _CONDUCTOR_GLYPHS:
+        if use_color:
+            lines.append(f"  {_ANSI_PURPLE}{glyph}{_ANSI_RESET}")
+        else:
+            lines.append(f"  {glyph}")
+
+    sub_parts: list[str] = []
+    if subtitle:
+        sub_parts.append(subtitle)
+    if version:
+        sub_parts.append(f"v{version}")
+    if sub_parts:
+        sub_text = "  ·  ".join(sub_parts)
+        if use_color:
+            lines.append(f"  {_ANSI_DIM}{sub_text}{_ANSI_RESET}")
+        else:
+            lines.append(f"  {sub_text}")
+    lines.append("")
+    return lines
+
+
+def print_banner(
+    subtitle: str | None = None,
+    version: str | None = None,
+    *,
+    stream=None,
+) -> None:
+    """Write the banner to ``stream`` (default: stderr).
+
+    Picks color based on whether ``stream`` is a TTY. Scripts that
+    capture conductor's stdout are not disturbed because the banner
+    lives on stderr.
+    """
+    target = stream if stream is not None else sys.stderr
+    use_color = _color_enabled(target)
+    for line in render_banner(subtitle, version, use_color=use_color):
+        print(line, file=target)
+
+
+def conductor_version() -> str | None:
+    """Return the installed conductor version, or None if unknown.
+
+    ``hatch-vcs`` writes ``_version.py`` at build time. Tests and editable
+    installs may not have it, so we fail soft.
+    """
+    try:
+        from conductor._version import __version__
+        return str(__version__)
+    except Exception:
+        return None
+
+
+SUBTITLE_INIT = "pick an LLM, give it a job"
+SUBTITLE_DOCTOR = "provider health check"

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -1035,10 +1035,11 @@ def doctor(as_json: bool) -> None:
         click.echo(json.dumps(payload, indent=2))
         return
 
+    from conductor.banner import SUBTITLE_DOCTOR, print_banner
+
+    print_banner(SUBTITLE_DOCTOR, payload["version"])
     click.echo(
-        f"conductor v{payload['version']}  ·  "
-        f"{payload['platform']}  ·  "
-        f"python {payload['python']}"
+        f"{payload['platform']}  ·  python {payload['python']}"
     )
     click.echo("")
     click.echo("Providers:")

--- a/src/conductor/wizard.py
+++ b/src/conductor/wizard.py
@@ -318,6 +318,13 @@ class _GoBack(Exception):  # noqa: N818  — sentinel, never caught outside this
 
 
 def _print_intro(interactive: bool, *, only: str | None, remaining: bool) -> None:
+    from conductor.banner import (
+        SUBTITLE_INIT,
+        conductor_version,
+        print_banner,
+    )
+
+    print_banner(SUBTITLE_INIT, conductor_version())
     click.echo("conductor init — provider setup")
     click.echo("─" * 60)
     if only:

--- a/tests/test_banner.py
+++ b/tests/test_banner.py
@@ -1,0 +1,61 @@
+"""Tests for conductor.banner — the ASCII hero shared with init/doctor."""
+
+from __future__ import annotations
+
+import io
+
+from conductor.banner import print_banner, render_banner
+
+
+def test_render_without_color_is_plain_ascii():
+    lines = render_banner("pick an LLM", "0.3.0", use_color=False)
+    # No ANSI escape codes anywhere.
+    for line in lines:
+        assert "\033" not in line
+    # Contains the CONDUCTOR glyph-art markers somewhere.
+    joined = "\n".join(lines)
+    assert "__" in joined  # glyph bars
+
+
+def test_render_with_color_wraps_lines_in_ansi():
+    lines = render_banner("pick an LLM", "0.3.0", use_color=True)
+    glyph_lines = [ln for ln in lines if "__" in ln]
+    assert glyph_lines, "expected at least one glyph line"
+    for gl in glyph_lines:
+        assert "\033[" in gl  # starts a color code
+        assert "\033[0m" in gl  # and resets it
+
+
+def test_render_includes_subtitle_and_version_joined():
+    lines = render_banner("for science", "1.2.3", use_color=False)
+    sub_lines = [ln for ln in lines if "for science" in ln]
+    assert sub_lines
+    assert "v1.2.3" in sub_lines[0]
+
+
+def test_render_without_subtitle_or_version_has_blank_padding():
+    lines = render_banner(use_color=False)
+    # First and last lines are blank for visual padding.
+    assert lines[0] == ""
+    assert lines[-1] == ""
+
+
+def test_print_banner_writes_to_supplied_stream():
+    buf = io.StringIO()
+    print_banner("hi", "0.0.1", stream=buf)
+    output = buf.getvalue()
+    assert "hi" in output
+    assert "v0.0.1" in output
+    # StringIO isn't a TTY, so color should be suppressed.
+    assert "\033[" not in output
+
+
+def test_print_banner_respects_no_color_env(monkeypatch):
+    class FakeTTY(io.StringIO):
+        def isatty(self):
+            return True
+
+    buf = FakeTTY()
+    monkeypatch.setenv("NO_COLOR", "1")
+    print_banner("x", stream=buf)
+    assert "\033[" not in buf.getvalue()


### PR DESCRIPTION
## Summary

Visual parity with touchstone's figlet hero, but without the figlet runtime dep.

- Pre-rendered CONDUCTOR glyph art shipped as a Python literal — always renders, no dependency on figlet being installed
- Deep purple (ANSI 256 color 99) differentiates conductor from touchstone's orange and cortex's cyan
- \`print_banner\` writes to stderr so stdout capture in scripts stays clean
- Respects \`NO_COLOR\` and \`CLICOLOR=0\` per convention

Wired into \`conductor init\` (before the provider walk) and \`conductor doctor\` (in front of the status report). JSON output is unchanged — banner is human-facing only.

## Test plan

- [x] 6 new tests in \`tests/test_banner.py\`: plain render, ANSI render, subtitle+version, blank padding, stream redirect, NO_COLOR honored on fake TTY
- [x] \`pytest\` — all 247 pass (includes the 6 new)
- [x] Visually previewed output against touchstone's hero

🤖 Generated with [Claude Code](https://claude.com/claude-code)