### PR TITLE
feat(v0.4.0): agent-wiring — Slice A (Claude Code auto-integration)

### DIFF
--- a/src/conductor/_agent_templates.py
+++ b/src/conductor/_agent_templates.py
@@ -1,0 +1,215 @@
+"""Template bodies for conductor's managed agent-integration artifacts.
+
+Embedded as string literals (rather than package data files) so conductor
+has no packaging-time dependency on non-Python resources. The `wizard`
+flow stamps each artifact with the running conductor version in its
+managed-by header.
+"""
+
+from __future__ import annotations
+
+# --------------------------------------------------------------------------- #
+# Canonical delegation guidance — imported into ~/.claude/CLAUDE.md.
+# --------------------------------------------------------------------------- #
+
+DELEGATION_GUIDANCE = """# Conductor delegation
+
+Conductor exposes other LLMs behind a uniform CLI (`conductor call`,
+`conductor exec`). When a task is a better fit for a different model
+than the one you're running as, delegate: run conductor, read back the
+answer, present it to the user with attribution.
+
+## When to delegate
+
+**DO delegate when:**
+- The task is **long-context reading or summarization** over a large file
+  or many files (>50 KB combined). Kimi and Gemini are stronger per-dollar
+  for broad reading than most flagship models.
+- The task needs **fresh web information** — Gemini is the only conductor
+  provider with native web search.
+- The task is a **cheap second opinion** on a diff, a piece of code, or a
+  design choice. Kimi gives you a fast, low-cost sanity check.
+- The task is **privacy-sensitive** and should not leave the machine.
+  Ollama runs locally.
+
+**DON'T delegate when:**
+- The task is mid-conversation reasoning where you hold active context.
+  Passing it off loses that context.
+- The user addressed *you* specifically.
+- The task is short enough that the round-trip adds more latency than
+  value.
+
+## How to delegate
+
+Single-turn call:
+
+    conductor call --with <provider> --task "..."
+
+Let the router pick by tags:
+
+    conductor call --auto --tags long-context,cheap --task "..."
+
+Pipe content in as the task:
+
+    cat long-file.md | conductor call --with kimi --task "Summarize."
+
+Multi-turn agent session with tools (inside a sandbox):
+
+    conductor exec --with <provider> --tools Read,Grep,Edit \\
+        --sandbox workspace-write --task "..."
+
+Get JSON for scripting / piping into other tools:
+
+    conductor call --with kimi --task "..." --json
+
+## Providers at a glance
+
+| Provider | Best for                     | Cost   | Notes                        |
+|----------|------------------------------|--------|------------------------------|
+| kimi     | long-context, cheap reviews  | $      | Cloudflare Workers AI        |
+| gemini   | web search, multimodal       | $$     | Google AI Studio or gcloud   |
+| claude   | strongest reasoning          | $$$    | your Claude subscription     |
+| codex    | coding agent                 | $$$    | your ChatGPT subscription    |
+| ollama   | private, offline             | free   | runs locally                 |
+
+Discover what's currently configured:
+
+    conductor list
+
+## Subagents available
+
+Conductor installs subagent definitions at `~/.claude/agents/`. Dispatch
+to them via the Agent tool (`subagent_type`) for a cleaner delegation
+than direct Bash calls.
+
+- `kimi-long-context` — long-document summarization / broad reading
+- `gemini-web-search` — questions needing fresh web information
+
+For other providers, use the Bash path or the `/conductor` slash
+command directly.
+
+## Error handling
+
+Conductor surfaces structured errors. When they come back, relay them
+verbatim — most are user-actionable (missing API key, provider not
+installed, rate limited). Don't paper over a `no provider...` error by
+answering the question yourself; tell the user to run `conductor init`.
+"""
+
+
+# --------------------------------------------------------------------------- #
+# /conductor slash command — loaded as a prompt with $ARGUMENTS substituted.
+# --------------------------------------------------------------------------- #
+
+SLASH_COMMAND_CONDUCTOR = """The user invoked `/conductor` with arguments:
+
+$ARGUMENTS
+
+The first token is the target — a provider name (`kimi`, `claude`,
+`codex`, `gemini`, `ollama`) or the literal `auto` to let conductor's
+router pick. Everything after the first token is the task.
+
+Run the task through conductor using the Bash tool:
+
+- If the first token is a provider name:
+
+      conductor call --with <provider> --task "<the rest>"
+
+- If the first token is `auto`:
+
+      conductor call --auto --task "<the rest>"
+
+- If the task clearly needs file tools (editing, grep, long-running
+  agent work), prefer:
+
+      conductor exec --with <provider> --tools Read,Grep,Edit \\
+          --sandbox workspace-write --task "<the rest>"
+
+Capture the provider's response. Present it to the user with a brief
+"(from <provider>)" attribution. If conductor returns an error, show
+the error verbatim — don't substitute your own answer.
+
+If the user's arguments are ambiguous (e.g. just a task with no
+provider), ask which provider to use before running anything.
+"""
+
+
+# --------------------------------------------------------------------------- #
+# Subagent bodies — invoked via Claude Code's Agent tool.
+# --------------------------------------------------------------------------- #
+
+SUBAGENT_KIMI_LONG_CONTEXT = """You are a delegation subagent. Your job is to route
+long-context reading tasks to Kimi via the `conductor` CLI and return the
+answer — NOT to answer them yourself.
+
+When invoked:
+
+1. Take the user's task as given.
+2. If the task references files, read them (use the Bash tool) and include
+   the relevant contents in the prompt you pass to Kimi. Kimi supports
+   1M-token contexts; you rarely need to truncate.
+3. Run:
+
+       conductor call --with kimi --task "<prompt>" --json
+
+   Pipe content via stdin if the prompt is large:
+
+       cat <file> | conductor call --with kimi --task "Summarize." --json
+
+4. Parse the JSON, extract the `text` field, and return it verbatim
+   prefixed with "From Kimi:". Include the `model` and `duration_ms` from
+   the JSON as a one-line footer for transparency.
+
+Kimi is strongest for: summarization, broad-reading across many files,
+structural extraction from long transcripts, and cheap second-opinion
+reviews.
+
+If conductor errors:
+- `no provider...` → kimi isn't configured. Tell the user to run
+  `conductor init`.
+- `rate-limited` → report the cooldown window; suggest retry.
+- HTTP / network errors → pass through verbatim.
+
+Never fall back to answering from your own training data. If Kimi isn't
+available, say so plainly rather than substituting your own reasoning —
+the user asked for Kimi specifically.
+"""
+
+
+SUBAGENT_GEMINI_WEB_SEARCH = """You are a delegation subagent. Your job is to route
+web-search-requiring tasks to Gemini via the `conductor` CLI and return
+the answer.
+
+Gemini is the only conductor provider with native web search. Tasks that
+need fresh information from the live web — news, recent docs, package
+versions, live service status, anything your training data is stale on —
+should go through you.
+
+When invoked:
+
+1. Craft a prompt that explicitly asks Gemini to use web search and cite
+   its sources inline.
+2. Run:
+
+       conductor call --with gemini --task "<prompt>" --json
+
+3. Parse the JSON, extract the `text` field, and return it verbatim
+   prefixed with "From Gemini:". Preserve any URLs or citations Gemini
+   includes — do not rewrite them.
+
+If the user's question doesn't actually need the web (it's a coding
+task, a reasoning task, a summary of material they already provided),
+tell the parent agent to handle it directly instead of calling you —
+you exist specifically for the web-search path.
+
+If conductor errors:
+- `no provider...` → gemini isn't configured. Tell the user to run
+  `conductor init`.
+- Rate limit / quota → report the cooldown or daily cap.
+- HTTP / network errors → pass through verbatim.
+
+Never fall back to answering from your own training data for a task
+that needs current information. If Gemini isn't available, say so
+plainly — stale answers labeled as fresh are worse than an explicit
+"I can't reach Gemini right now."
+"""

--- a/src/conductor/agent_wiring.py
+++ b/src/conductor/agent_wiring.py
@@ -1,0 +1,488 @@
+"""Agent-integration wiring for `conductor init`.
+
+Detects agent instruction files (CLAUDE.md, AGENTS.md, …) and writes
+managed artifacts — a canonical delegation-guidance file, a slash command,
+subagent definitions — so Claude Code (and, in later slices, Codex / Cursor /
+Gemini CLI) can delegate to Conductor providers without the user
+hand-wiring anything.
+
+Two file-ownership conventions:
+  1. Fully managed files carry a `managed-by: conductor vX.Y.Z` marker in
+     their first line (HTML comment) or in YAML frontmatter. On unwire
+     they are deleted whole.
+  2. Sentinel-block injection into user-owned files (CLAUDE.md, AGENTS.md):
+     a conductor block bounded by ``<!-- conductor:begin vX -->`` and
+     ``<!-- conductor:end -->``. Unwire removes only the block; user
+     content outside the markers is untouched.
+
+Paths can be overridden for tests via the ``CONDUCTOR_HOME`` and
+``CLAUDE_HOME`` env vars — otherwise the standard user home locations are
+used.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# --------------------------------------------------------------------------- #
+# Marker formats — the two shapes of "conductor owns this".
+# --------------------------------------------------------------------------- #
+
+MANAGED_COMMENT_PREFIX = "<!-- managed-by: conductor v"
+MANAGED_FRONTMATTER_KEY = "managed-by: conductor v"
+
+SENTINEL_BEGIN_PREFIX = "<!-- conductor:begin v"
+SENTINEL_END = "<!-- conductor:end -->"
+
+_SENTINEL_BLOCK_RE = re.compile(
+    r"(?:\n?)" + re.escape("<!-- conductor:begin v") + r"[^>]*-->\n"
+    r".*?\n" + re.escape(SENTINEL_END) + r"\n?",
+    flags=re.DOTALL,
+)
+
+
+def _managed_comment(version: str) -> str:
+    return (
+        f"<!-- managed-by: conductor v{version} — "
+        f"do not edit; run `conductor init --unwire` to remove -->"
+    )
+
+
+def _sentinel_begin(version: str) -> str:
+    return f"<!-- conductor:begin v{version} -->"
+
+
+# --------------------------------------------------------------------------- #
+# Paths — ~/.conductor/ and ~/.claude/ with test-time overrides.
+# --------------------------------------------------------------------------- #
+
+
+def conductor_home() -> Path:
+    """Where conductor's canonical guidance lives (``~/.conductor/``)."""
+    override = os.environ.get("CONDUCTOR_HOME")
+    if override:
+        return Path(override)
+    return Path.home() / ".conductor"
+
+
+def claude_home() -> Path:
+    """Claude Code's user-scoped config directory (``~/.claude/``)."""
+    override = os.environ.get("CLAUDE_HOME")
+    if override:
+        return Path(override)
+    return Path.home() / ".claude"
+
+
+# --------------------------------------------------------------------------- #
+# Detection — what agent surface exists in this environment?
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class AgentArtifact:
+    """One managed or candidate artifact conductor can write/has written."""
+
+    path: Path
+    kind: str                 # "guidance" | "slash-command" | "subagent" | "claude-md-import"
+    version: str | None       # present if currently managed
+    owned: bool               # True if conductor-managed right now
+
+
+@dataclass(frozen=True)
+class Detection:
+    """Result of scanning the environment for Claude Code + instruction files."""
+
+    claude_cli_on_path: bool
+    claude_home: Path
+    claude_home_exists: bool
+    claude_user_md: Path             # ~/.claude/CLAUDE.md — may or may not exist
+    claude_user_md_exists: bool
+    conductor_home: Path
+    managed: tuple[AgentArtifact, ...] = field(default_factory=tuple)
+
+    @property
+    def claude_detected(self) -> bool:
+        """True if Claude Code is installed or has been configured before."""
+        return self.claude_cli_on_path or self.claude_home_exists
+
+
+def detect() -> Detection:
+    """Scan the current environment for Claude Code + any managed files."""
+    ch = claude_home()
+    ch_exists = ch.is_dir()
+    cli_on_path = shutil.which("claude") is not None
+    user_md = ch / "CLAUDE.md"
+
+    managed: list[AgentArtifact] = []
+    for path, kind in _candidate_artifacts().items():
+        if not path.exists():
+            continue
+        version = read_managed_version(path)
+        if version is None and kind != "claude-md-import":
+            # A non-managed file at a managed path — leave alone, not ours.
+            continue
+        if kind == "claude-md-import":
+            # CLAUDE.md is user-owned; we own only the sentinel block.
+            has_block = _has_sentinel_block(path)
+            if not has_block:
+                continue
+            managed.append(
+                AgentArtifact(path=path, kind=kind, version=_block_version(path), owned=True)
+            )
+            continue
+        managed.append(AgentArtifact(path=path, kind=kind, version=version, owned=True))
+
+    return Detection(
+        claude_cli_on_path=cli_on_path,
+        claude_home=ch,
+        claude_home_exists=ch_exists,
+        claude_user_md=user_md,
+        claude_user_md_exists=user_md.exists(),
+        conductor_home=conductor_home(),
+        managed=tuple(managed),
+    )
+
+
+def _candidate_artifacts() -> dict[Path, str]:
+    """The set of paths conductor may own. Used by detect() and unwire()."""
+    ch = claude_home()
+    conductor = conductor_home()
+    return {
+        conductor / "delegation-guidance.md": "guidance",
+        ch / "commands" / "conductor.md": "slash-command",
+        ch / "agents" / "kimi-long-context.md": "subagent",
+        ch / "agents" / "gemini-web-search.md": "subagent",
+        ch / "CLAUDE.md": "claude-md-import",
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Managed-file helpers — write/read/detect ownership.
+# --------------------------------------------------------------------------- #
+
+
+def read_managed_version(path: Path) -> str | None:
+    """Return the conductor version that owns ``path``, or None if unmanaged.
+
+    Accepts either an HTML-comment marker on line 1 or a ``managed-by:``
+    key inside a YAML frontmatter block at the top of the file.
+    """
+    if not path.is_file():
+        return None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    if not text:
+        return None
+
+    first_line = text.splitlines()[0]
+    if first_line.startswith(MANAGED_COMMENT_PREFIX):
+        return _extract_version(first_line, MANAGED_COMMENT_PREFIX)
+
+    # Try YAML frontmatter.
+    if text.startswith("---\n"):
+        end = text.find("\n---", 4)
+        if end != -1:
+            block = text[4:end]
+            for line in block.splitlines():
+                line = line.strip()
+                if line.startswith(MANAGED_FRONTMATTER_KEY):
+                    return _extract_version(line, MANAGED_FRONTMATTER_KEY)
+    return None
+
+
+def is_managed_file(path: Path) -> bool:
+    return read_managed_version(path) is not None
+
+
+def write_managed_markdown(path: Path, body: str, *, version: str) -> None:
+    """Write ``body`` to ``path`` with a managed-by HTML comment prepended.
+
+    Overwrites only if the file is already conductor-managed or does not
+    exist. User-owned files at the path are left alone; caller decides
+    what to do about that (typically: warn and skip).
+    """
+    if path.exists() and not is_managed_file(path):
+        raise UserOwnedFileError(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    header = _managed_comment(version) + "\n"
+    path.write_text(header + body, encoding="utf-8")
+
+
+def write_managed_frontmatter(
+    path: Path,
+    frontmatter: dict[str, str],
+    body: str,
+    *,
+    version: str,
+) -> None:
+    """Write a file with YAML frontmatter; inject ``managed-by`` key.
+
+    Used for Claude Code artifacts (slash commands, subagents) where the
+    file format is frontmatter-then-body.
+    """
+    if path.exists() and not is_managed_file(path):
+        raise UserOwnedFileError(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = ["---"]
+    for key, value in frontmatter.items():
+        if key == "managed-by":
+            continue
+        lines.append(f"{key}: {value}")
+    # managed-by last: the user sees name/description/etc. first when they
+    # open the file; our marker sits at the bottom of the frontmatter.
+    lines.append(f"managed-by: conductor v{version}")
+    lines.append("---")
+    path.write_text("\n".join(lines) + "\n\n" + body, encoding="utf-8")
+
+
+class UserOwnedFileError(Exception):
+    """Raised when a path conductor would write to exists and is not managed."""
+
+    def __init__(self, path: Path):
+        super().__init__(
+            f"{path} exists but is not conductor-managed; refusing to overwrite"
+        )
+        self.path = path
+
+
+# --------------------------------------------------------------------------- #
+# Sentinel-block helpers — inject into user-owned files (CLAUDE.md, AGENTS.md).
+# --------------------------------------------------------------------------- #
+
+
+def _has_sentinel_block(path: Path) -> bool:
+    if not path.is_file():
+        return False
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return SENTINEL_BEGIN_PREFIX in text and SENTINEL_END in text
+
+
+def _block_version(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    idx = text.find(SENTINEL_BEGIN_PREFIX)
+    if idx == -1:
+        return None
+    rest = text[idx + len(SENTINEL_BEGIN_PREFIX) :]
+    end = rest.find(" -->")
+    if end == -1:
+        return None
+    return rest[:end].strip()
+
+
+def inject_sentinel_block(path: Path, content: str, *, version: str) -> None:
+    """Add or replace conductor's sentinel block in ``path``.
+
+    If the file doesn't exist, it's created with only the block. If the
+    file exists without a block, the block is appended (preserving all
+    existing content). If the file already has a conductor block, the
+    block is replaced in place.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    block = (
+        f"{_sentinel_begin(version)}\n"
+        f"{content.rstrip()}\n"
+        f"{SENTINEL_END}\n"
+    )
+
+    if not path.exists():
+        path.write_text(block, encoding="utf-8")
+        return
+
+    existing = path.read_text(encoding="utf-8")
+    if _SENTINEL_BLOCK_RE.search(existing):
+        # Replace in place (including its trailing newline), keeping the
+        # single-trailing-newline invariant.
+        replaced = _SENTINEL_BLOCK_RE.sub("\n" + block, existing, count=1)
+        path.write_text(replaced, encoding="utf-8")
+        return
+
+    # No existing block — append with a leading blank line for legibility.
+    sep = "" if existing.endswith("\n\n") else ("\n" if existing.endswith("\n") else "\n\n")
+    path.write_text(existing + sep + block, encoding="utf-8")
+
+
+def remove_sentinel_block(path: Path) -> bool:
+    """Remove conductor's sentinel block from ``path`` if present.
+
+    Returns True if a block was removed. If the file becomes empty as a
+    result (i.e. the block was the only content), the file is deleted.
+    """
+    if not path.is_file():
+        return False
+    text = path.read_text(encoding="utf-8")
+    if not _SENTINEL_BLOCK_RE.search(text):
+        return False
+    trimmed = _SENTINEL_BLOCK_RE.sub("", text, count=1)
+    # Normalize: collapse any run of 3+ newlines produced by the removal.
+    trimmed = re.sub(r"\n{3,}", "\n\n", trimmed)
+    trimmed = trimmed.lstrip("\n")
+    if trimmed.strip() == "":
+        path.unlink()
+    else:
+        path.write_text(trimmed, encoding="utf-8")
+    return True
+
+
+# --------------------------------------------------------------------------- #
+# Unwire — remove every managed artifact conductor knows about.
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class UnwireReport:
+    removed: tuple[Path, ...]
+    skipped: tuple[tuple[Path, str], ...]  # (path, reason)
+
+
+def unwire() -> UnwireReport:
+    """Remove every managed file / sentinel block conductor has written.
+
+    Fully-managed files (guidance, slash command, subagents) are deleted
+    only if their header still marks them as conductor-managed. User-owned
+    files (CLAUDE.md) have their sentinel block removed; the rest of the
+    file is left alone.
+    """
+    removed: list[Path] = []
+    skipped: list[tuple[Path, str]] = []
+    for path, kind in _candidate_artifacts().items():
+        if not path.exists():
+            continue
+        if kind == "claude-md-import":
+            if remove_sentinel_block(path):
+                removed.append(path)
+            continue
+        if not is_managed_file(path):
+            skipped.append((path, "not conductor-managed (hand-edited?)"))
+            continue
+        try:
+            path.unlink()
+            removed.append(path)
+        except OSError as e:
+            skipped.append((path, f"unlink failed: {e}"))
+    return UnwireReport(removed=tuple(removed), skipped=tuple(skipped))
+
+
+# --------------------------------------------------------------------------- #
+# Wire — write every managed artifact for Claude Code.
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class WireReport:
+    written: tuple[Path, ...]
+    skipped: tuple[tuple[Path, str], ...]
+    patched_claude_md: bool
+
+
+def wire_claude_code(
+    version: str,
+    *,
+    patch_claude_md: bool,
+) -> WireReport:
+    """Write the Slice A managed artifacts for Claude Code.
+
+    Args:
+        version: conductor version, stamped into every managed-by marker.
+        patch_claude_md: if True, inject the ``@~/.conductor/…`` import
+            line into ``~/.claude/CLAUDE.md`` via the sentinel block. If
+            False, skip the CLAUDE.md edit (caller will print instructions
+            for the user to do it manually).
+
+    The caller is expected to have obtained consent before invoking this.
+    """
+    from conductor import _agent_templates as templates
+
+    conductor_dir = conductor_home()
+    ch = claude_home()
+
+    written: list[Path] = []
+    skipped: list[tuple[Path, str]] = []
+
+    def _write_md(path: Path, body: str) -> None:
+        try:
+            write_managed_markdown(path, body, version=version)
+            written.append(path)
+        except UserOwnedFileError as e:
+            skipped.append((e.path, "user-owned file; refusing to overwrite"))
+
+    def _write_fm(path: Path, fm: dict[str, str], body: str) -> None:
+        try:
+            write_managed_frontmatter(path, fm, body, version=version)
+            written.append(path)
+        except UserOwnedFileError as e:
+            skipped.append((e.path, "user-owned file; refusing to overwrite"))
+
+    _write_md(conductor_dir / "delegation-guidance.md", templates.DELEGATION_GUIDANCE)
+
+    _write_fm(
+        ch / "commands" / "conductor.md",
+        {
+            "description": "Delegate a task to another LLM via the conductor CLI.",
+            "argument-hint": "<provider> <task…>",
+        },
+        templates.SLASH_COMMAND_CONDUCTOR,
+    )
+    _write_fm(
+        ch / "agents" / "kimi-long-context.md",
+        {
+            "name": "kimi-long-context",
+            "description": (
+                "Use for summarizing or analyzing large files / long contexts "
+                "where a cheaper strong-tier model suffices. Delegates to Kimi "
+                "via `conductor call --with kimi`."
+            ),
+            "tools": "Bash",
+        },
+        templates.SUBAGENT_KIMI_LONG_CONTEXT,
+    )
+    _write_fm(
+        ch / "agents" / "gemini-web-search.md",
+        {
+            "name": "gemini-web-search",
+            "description": (
+                "Use for questions needing fresh web information. Delegates to "
+                "Gemini (which has native web search) via `conductor call --with gemini`."
+            ),
+            "tools": "Bash",
+        },
+        templates.SUBAGENT_GEMINI_WEB_SEARCH,
+    )
+
+    patched = False
+    if patch_claude_md:
+        import_line = f"@{conductor_dir}/delegation-guidance.md"
+        inject_sentinel_block(ch / "CLAUDE.md", import_line, version=version)
+        patched = True
+
+    return WireReport(
+        written=tuple(written),
+        skipped=tuple(skipped),
+        patched_claude_md=patched,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Utility — extract a version string from a marker line.
+# --------------------------------------------------------------------------- #
+
+
+def _extract_version(line: str, prefix: str) -> str | None:
+    after = line[len(prefix) :]
+    # Stop at whitespace, a trailing HTML comment close, or punctuation.
+    m = re.match(r"[^\s\-—>]+", after)
+    return m.group(0) if m else None

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -1015,7 +1015,26 @@ def _diagnostic_payload() -> dict:
         "python": sys.version.split()[0],
         "providers": providers_info,
         "credentials": env_info,
+        "agent_integration": _agent_integration_payload(),
         "warnings": warnings,
+    }
+
+
+def _agent_integration_payload() -> dict:
+    """Summarize the state of agent-integration wiring (see agent_wiring.py)."""
+    from conductor.agent_wiring import detect
+
+    detection = detect()
+    return {
+        "claude_detected": detection.claude_detected,
+        "claude_cli_on_path": detection.claude_cli_on_path,
+        "claude_home": str(detection.claude_home),
+        "claude_home_exists": detection.claude_home_exists,
+        "conductor_home": str(detection.conductor_home),
+        "managed_files": [
+            {"path": str(a.path), "kind": a.kind, "version": a.version}
+            for a in detection.managed
+        ],
     }
 
 
@@ -1064,6 +1083,21 @@ def doctor(as_json: bool) -> None:
         click.echo(f"  {c['name']:<24}  {in_env:<4}  {in_kc}")
 
     click.echo("")
+    click.echo("Agent integration:")
+    ai = payload["agent_integration"]
+    if not ai["claude_detected"]:
+        click.echo("  Claude Code: not detected")
+    elif not ai["managed_files"]:
+        click.echo("  Claude Code: detected, not wired (run `conductor init`)")
+    else:
+        click.echo(
+            f"  Claude Code: wired — {len(ai['managed_files'])} managed files"
+        )
+        for f in ai["managed_files"]:
+            version_note = f" v{f['version']}" if f["version"] else ""
+            click.echo(f"    {f['kind']:<15}  {f['path']}{version_note}")
+
+    click.echo("")
     click.echo("Next steps:")
     not_configured = [p for p in payload["providers"] if not p["configured"]]
     if not not_configured:
@@ -1098,8 +1132,42 @@ def doctor(as_json: bool) -> None:
     default=False,
     help="Resume setup with only the not-yet-configured providers.",
 )
-def init(accept_defaults: bool, only: str | None, remaining: bool) -> None:
+@click.option(
+    "--wire-agents",
+    type=click.Choice(["yes", "no", "ask"]),
+    default=None,
+    help="Wire conductor into detected agent tools (Claude Code today). "
+    "Default: ask on TTY, skip on non-TTY.",
+)
+@click.option(
+    "--patch-claude-md",
+    type=click.Choice(["yes", "no", "ask"]),
+    default=None,
+    help="Add the delegation-guidance @import line to ~/.claude/CLAUDE.md. "
+    "Default: ask on TTY, skip on non-TTY.",
+)
+@click.option(
+    "--unwire",
+    is_flag=True,
+    default=False,
+    help="Remove every conductor-managed agent integration artifact and exit.",
+)
+def init(
+    accept_defaults: bool,
+    only: str | None,
+    remaining: bool,
+    wire_agents: str | None,
+    patch_claude_md: str | None,
+    unwire: bool,
+) -> None:
     """Interactively configure Conductor for first use."""
+    if unwire:
+        if only or remaining or wire_agents or patch_claude_md:
+            raise click.UsageError(
+                "--unwire can't be combined with provider or wiring flags."
+            )
+        sys.exit(_run_unwire())
+
     if only and remaining:
         raise click.UsageError("--only and --remaining are mutually exclusive.")
     if only and only not in known_providers():
@@ -1110,8 +1178,31 @@ def init(accept_defaults: bool, only: str | None, remaining: bool) -> None:
         accept_defaults=accept_defaults,
         only=only,
         remaining=remaining,
+        wire_agents=wire_agents,
+        patch_claude_md=patch_claude_md,
     )
     sys.exit(exit_code)
+
+
+def _run_unwire() -> int:
+    """Remove every managed agent-integration artifact. Returns an exit code."""
+    from conductor.agent_wiring import unwire
+
+    report = unwire()
+    if not report.removed and not report.skipped:
+        click.echo("No conductor-managed agent integration files found.")
+        return 0
+
+    if report.removed:
+        click.echo("Removed:")
+        for p in report.removed:
+            click.echo(f"  {p}")
+    if report.skipped:
+        click.echo("")
+        click.echo("Skipped (not conductor-managed):")
+        for path, reason in report.skipped:
+            click.echo(f"  {path}  — {reason}")
+    return 0
 
 
 # --------------------------------------------------------------------------- #

--- a/src/conductor/wizard.py
+++ b/src/conductor/wizard.py
@@ -209,6 +209,8 @@ def run_init_wizard(
     accept_defaults: bool = False,
     only: str | None = None,
     remaining: bool = False,
+    wire_agents: str | None = None,
+    patch_claude_md: str | None = None,
 ) -> int:
     """Walk the user through configuring every provider that needs it.
 
@@ -216,6 +218,14 @@ def run_init_wizard(
         accept_defaults: non-interactive mode; report state without prompting.
         only: configure only this one provider; skip the rest.
         remaining: skip providers that are already configured (resume flow).
+        wire_agents: one of "yes" / "no" / "ask" / None. Controls whether
+            the wizard offers to wire conductor into detected agent tools
+            (Claude Code today; more in later slices). None means ask on
+            TTY, skip on non-TTY.
+        patch_claude_md: same tri-state, for the one-line ``@import`` edit
+            in ``~/.claude/CLAUDE.md``. Separate from ``wire_agents`` so
+            users can accept the artifacts while declining the import
+            edit (and vice versa).
 
     Returns a shell exit code: 0 on success, non-zero if the user
     explicitly aborted.
@@ -298,6 +308,16 @@ def run_init_wizard(
         outcomes.append(outcome)
         click.echo("")
         idx += 1
+
+    # Agent wiring — only offered on an unscoped run. When the user invoked
+    # `--only <provider>` they've narrowed the scope deliberately; don't
+    # broaden it by running integration prompts after.
+    if not only:
+        _maybe_wire_agents(
+            interactive=interactive,
+            wire_agents=wire_agents,
+            patch_claude_md=patch_claude_md,
+        )
 
     _print_summary(outcomes)
     _print_next_steps(outcomes)
@@ -625,6 +645,134 @@ def _print_summary(outcomes: list[WizardOutcome]) -> None:
     click.echo(f"  Skipped:    {', '.join(skipped_names) if skipped_names else '(none)'}")
     if failed_names:
         click.echo(f"  Failed:     {', '.join(failed_names)}")
+
+
+# --------------------------------------------------------------------------- #
+# Agent-integration flow — runs after the provider walk.
+# --------------------------------------------------------------------------- #
+
+
+def _maybe_wire_agents(
+    *,
+    interactive: bool,
+    wire_agents: str | None,
+    patch_claude_md: str | None,
+) -> None:
+    """Offer to wire conductor into detected agent tools (Claude Code)."""
+    from conductor import __version__
+    from conductor.agent_wiring import detect, wire_claude_code
+
+    detection = detect()
+
+    if not detection.claude_detected:
+        if interactive:
+            click.echo("")
+            click.echo("─" * 60)
+            click.echo("Agent integration")
+            click.echo("─" * 60)
+            click.echo(
+                "  Claude Code not detected in this environment; nothing to wire."
+            )
+            click.echo(
+                "  (re-run `conductor init` after installing Claude Code to enable "
+                "delegation)"
+            )
+            click.echo("")
+        return
+
+    # Decide whether to offer the prompt at all.
+    decision = wire_agents if wire_agents is not None else ("ask" if interactive else "no")
+    if decision == "no":
+        return
+
+    already_wired = len(detection.managed) > 0
+    click.echo("")
+    click.echo("─" * 60)
+    click.echo("Agent integration — Claude Code")
+    click.echo("─" * 60)
+    if already_wired:
+        click.echo(f"  Already wired ({len(detection.managed)} managed files found).")
+        click.echo("  Re-running will refresh each file to the current version.")
+    else:
+        click.echo("  Claude Code can delegate to other models (kimi, gemini, …)")
+        click.echo("  without leaving your editor. Conductor can wire this up by")
+        click.echo("  writing:")
+        click.echo("")
+        click.echo(f"    {detection.conductor_home}/delegation-guidance.md")
+        click.echo(f"    {detection.claude_home}/commands/conductor.md   (slash: /conductor)")
+        click.echo(f"    {detection.claude_home}/agents/kimi-long-context.md")
+        click.echo(f"    {detection.claude_home}/agents/gemini-web-search.md")
+        click.echo("")
+        click.echo("  Every file carries a 'managed-by: conductor' marker and is")
+        click.echo("  fully removable via `conductor init --unwire`.")
+    click.echo("")
+
+    if decision == "ask":
+        prompt = "Refresh conductor integration?" if already_wired else "Wire conductor in now?"
+        proceed = _prompt_menu(
+            options=[
+                ("y", f"yes — {prompt.lower().rstrip('?')}"),
+                ("n", "no — skip (you can re-run init later)"),
+            ],
+            default="y",
+        )
+        if proceed == "n":
+            click.echo("  (skipped — no files written)")
+            return
+
+    # Decide about the CLAUDE.md @import edit.
+    pcm = (
+        patch_claude_md
+        if patch_claude_md is not None
+        else ("ask" if interactive else "no")
+    )
+    if pcm == "ask":
+        import_line = f"@{detection.conductor_home}/delegation-guidance.md"
+        click.echo("")
+        click.echo("  For Claude to actually read the guidance, one line needs to go")
+        click.echo(f"  into ~/.claude/CLAUDE.md:  {import_line}")
+        click.echo("")
+        click.echo("  Conductor can add it inside a <!-- conductor:begin --> block")
+        click.echo("  so `conductor init --unwire` can remove it cleanly later.")
+        click.echo("")
+        choice = _prompt_menu(
+            options=[
+                ("y", "yes — add the line for me"),
+                ("n", "no — I'll add it manually"),
+            ],
+            default="y",
+        )
+        do_patch = choice == "y"
+    else:
+        do_patch = pcm == "yes"
+
+    try:
+        report = wire_claude_code(__version__, patch_claude_md=do_patch)
+    except Exception as exc:  # noqa: BLE001 — surface any unexpected failure
+        click.echo(f"  ✗ wiring failed: {exc}")
+        return
+
+    click.echo("")
+    click.echo("  ✓ wrote:")
+    for p in report.written:
+        click.echo(f"      {p}")
+    for path, reason in report.skipped:
+        click.echo(f"  ⚠ skipped {path}: {reason}")
+    if report.patched_claude_md:
+        click.echo(f"  ✓ patched {detection.claude_user_md} (sentinel block)")
+    elif not do_patch:
+        import_line = f"@{detection.conductor_home}/delegation-guidance.md"
+        click.echo("")
+        click.echo(
+            "  To activate the guidance, add this line to ~/.claude/CLAUDE.md:"
+        )
+        click.echo(f"      {import_line}")
+
+    click.echo("")
+    click.echo("  Try it:")
+    click.echo('    Ask Claude: "summarize this README with kimi"')
+    click.echo("    Or run:     /conductor kimi summarize README.md")
+    click.echo("")
 
 
 def _print_next_steps(outcomes: list[WizardOutcome]) -> None:

--- a/src/conductor/wizard.py
+++ b/src/conductor/wizard.py
@@ -309,11 +309,13 @@ def run_init_wizard(
         click.echo("")
         idx += 1
 
-    # Agent wiring — only offered on an unscoped run. When the user invoked
-    # `--only <provider>` they've narrowed the scope deliberately; don't
-    # broaden it by running integration prompts after.
-    if not only:
-        _maybe_wire_agents(
+    # Agent wiring — only offered on an unscoped, non-aborted run. `--only`
+    # narrows scope deliberately; an aborted ([q]uit) walk means the user
+    # explicitly stopped, and silently writing artifacts after they quit
+    # would violate that intent.
+    wiring_ok = True
+    if not only and not aborted:
+        wiring_ok = _maybe_wire_agents(
             interactive=interactive,
             wire_agents=wire_agents,
             patch_claude_md=patch_claude_md,
@@ -321,7 +323,9 @@ def run_init_wizard(
 
     _print_summary(outcomes)
     _print_next_steps(outcomes)
-    return 1 if aborted else 0
+    if aborted or not wiring_ok:
+        return 1
+    return 0
 
 
 class _AbortSetup(Exception):  # noqa: N818  — sentinel, never caught outside this module
@@ -657,8 +661,15 @@ def _maybe_wire_agents(
     interactive: bool,
     wire_agents: str | None,
     patch_claude_md: str | None,
-) -> None:
-    """Offer to wire conductor into detected agent tools (Claude Code)."""
+) -> bool:
+    """Offer to wire conductor into detected agent tools (Claude Code).
+
+    Returns True if no wiring was attempted (skipped, declined, or no
+    target detected) or if the wiring fully succeeded. Returns False if
+    wiring was attempted and failed — callers propagate this into the
+    process exit code so CI / scripted ``--wire-agents=yes`` runs surface
+    the failure instead of silently exiting 0.
+    """
     from conductor import __version__
     from conductor.agent_wiring import detect, wire_claude_code
 
@@ -678,12 +689,12 @@ def _maybe_wire_agents(
                 "delegation)"
             )
             click.echo("")
-        return
+        return True
 
     # Decide whether to offer the prompt at all.
     decision = wire_agents if wire_agents is not None else ("ask" if interactive else "no")
     if decision == "no":
-        return
+        return True
 
     already_wired = len(detection.managed) > 0
     click.echo("")
@@ -718,7 +729,7 @@ def _maybe_wire_agents(
         )
         if proceed == "n":
             click.echo("  (skipped — no files written)")
-            return
+            return True
 
     # Decide about the CLAUDE.md @import edit.
     pcm = (
@@ -750,12 +761,13 @@ def _maybe_wire_agents(
         report = wire_claude_code(__version__, patch_claude_md=do_patch)
     except Exception as exc:  # noqa: BLE001 — surface any unexpected failure
         click.echo(f"  ✗ wiring failed: {exc}")
-        return
+        return False
 
     click.echo("")
-    click.echo("  ✓ wrote:")
-    for p in report.written:
-        click.echo(f"      {p}")
+    if report.written:
+        click.echo("  ✓ wrote:")
+        for p in report.written:
+            click.echo(f"      {p}")
     for path, reason in report.skipped:
         click.echo(f"  ⚠ skipped {path}: {reason}")
     if report.patched_claude_md:
@@ -773,6 +785,10 @@ def _maybe_wire_agents(
     click.echo('    Ask Claude: "summarize this README with kimi"')
     click.echo("    Or run:     /conductor kimi summarize README.md")
     click.echo("")
+
+    # If every target file was skipped (all user-owned), treat that as a
+    # failed wire — the user asked for integration and got nothing.
+    return not (report.skipped and not report.written)
 
 
 def _print_next_steps(outcomes: list[WizardOutcome]) -> None:

--- a/tests/test_agent_wiring.py
+++ b/tests/test_agent_wiring.py
@@ -1,0 +1,371 @@
+"""Tests for conductor.agent_wiring — detection, managed-file round-trips,
+sentinel-block injection/removal, wire + unwire end-to-end.
+
+Every test isolates the environment via ``CONDUCTOR_HOME`` / ``CLAUDE_HOME``
+pointed at ``tmp_path`` so nothing leaks onto the developer's real home.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from conductor import agent_wiring as aw
+
+
+@pytest.fixture(autouse=True)
+def _isolated_homes(tmp_path, monkeypatch):
+    """Point every path helper at tmp_path; remove any inherited which()."""
+    conductor_dir = tmp_path / ".conductor"
+    claude_dir = tmp_path / ".claude"
+    monkeypatch.setenv("CONDUCTOR_HOME", str(conductor_dir))
+    monkeypatch.setenv("CLAUDE_HOME", str(claude_dir))
+    # Default: claude CLI not on PATH unless a test explicitly patches it.
+    monkeypatch.setattr("shutil.which", lambda _cmd: None)
+    yield
+
+
+# --------------------------------------------------------------------------- #
+# Path helpers.
+# --------------------------------------------------------------------------- #
+
+
+def test_conductor_home_respects_override(tmp_path, monkeypatch):
+    target = tmp_path / "custom-conductor"
+    monkeypatch.setenv("CONDUCTOR_HOME", str(target))
+    assert aw.conductor_home() == target
+
+
+def test_claude_home_respects_override(tmp_path, monkeypatch):
+    target = tmp_path / "custom-claude"
+    monkeypatch.setenv("CLAUDE_HOME", str(target))
+    assert aw.claude_home() == target
+
+
+# --------------------------------------------------------------------------- #
+# Detection.
+# --------------------------------------------------------------------------- #
+
+
+def test_detect_empty_env_reports_no_claude():
+    d = aw.detect()
+    assert d.claude_detected is False
+    assert d.claude_cli_on_path is False
+    assert d.claude_home_exists is False
+    assert d.managed == ()
+
+
+def test_detect_claude_home_dir_implies_detected():
+    aw.claude_home().mkdir(parents=True)
+    d = aw.detect()
+    assert d.claude_detected is True
+    assert d.claude_home_exists is True
+    assert d.managed == ()
+
+
+def test_detect_claude_cli_on_path_implies_detected(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/claude" if cmd == "claude" else None)
+    d = aw.detect()
+    assert d.claude_detected is True
+    assert d.claude_cli_on_path is True
+
+
+def test_detect_picks_up_managed_files_after_wire():
+    aw.wire_claude_code("0.3.2", patch_claude_md=True)
+    d = aw.detect()
+    assert d.claude_detected is True
+    kinds = {a.kind for a in d.managed}
+    assert {"guidance", "slash-command", "subagent", "claude-md-import"}.issubset(kinds)
+
+
+def test_detect_ignores_user_owned_files_at_managed_paths(tmp_path):
+    """A hand-authored file at ~/.claude/agents/kimi-long-context.md is user-owned
+    and must not be claimed by conductor's detector."""
+    agents_dir = aw.claude_home() / "agents"
+    agents_dir.mkdir(parents=True)
+    user_file = agents_dir / "kimi-long-context.md"
+    user_file.write_text("# my own agent, not conductor's\n", encoding="utf-8")
+
+    d = aw.detect()
+    # The user's file exists but it's not claimed.
+    assert all(a.path != user_file for a in d.managed)
+
+
+# --------------------------------------------------------------------------- #
+# Managed-file helpers.
+# --------------------------------------------------------------------------- #
+
+
+def test_write_managed_markdown_round_trip(tmp_path):
+    path = tmp_path / "notes.md"
+    aw.write_managed_markdown(path, "# hello\n\nbody\n", version="1.2.3")
+    content = path.read_text(encoding="utf-8")
+    assert content.splitlines()[0].startswith("<!-- managed-by: conductor v1.2.3")
+    assert "# hello" in content
+    assert aw.is_managed_file(path)
+    assert aw.read_managed_version(path) == "1.2.3"
+
+
+def test_write_managed_markdown_overwrites_existing_managed(tmp_path):
+    path = tmp_path / "notes.md"
+    aw.write_managed_markdown(path, "first", version="1.0.0")
+    aw.write_managed_markdown(path, "second", version="1.1.0")
+    assert aw.read_managed_version(path) == "1.1.0"
+    assert "second" in path.read_text(encoding="utf-8")
+
+
+def test_write_managed_markdown_refuses_user_owned(tmp_path):
+    path = tmp_path / "notes.md"
+    path.write_text("# I wrote this myself\n", encoding="utf-8")
+    with pytest.raises(aw.UserOwnedFileError):
+        aw.write_managed_markdown(path, "conductor content", version="1.0.0")
+    # File is untouched.
+    assert path.read_text(encoding="utf-8") == "# I wrote this myself\n"
+
+
+def test_write_managed_frontmatter_embeds_version(tmp_path):
+    path = tmp_path / "agent.md"
+    aw.write_managed_frontmatter(
+        path,
+        {"name": "test", "description": "A test"},
+        "You are a test.",
+        version="2.0.0",
+    )
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n")
+    assert "managed-by: conductor v2.0.0" in text
+    assert "name: test" in text
+    assert "You are a test." in text
+    assert aw.is_managed_file(path)
+    assert aw.read_managed_version(path) == "2.0.0"
+
+
+def test_write_managed_frontmatter_refuses_user_owned(tmp_path):
+    path = tmp_path / "agent.md"
+    path.write_text("---\nname: mine\n---\nhello", encoding="utf-8")
+    with pytest.raises(aw.UserOwnedFileError):
+        aw.write_managed_frontmatter(
+            path, {"name": "test"}, "body", version="1.0.0"
+        )
+
+
+def test_read_managed_version_on_plain_file_returns_none(tmp_path):
+    path = tmp_path / "notes.md"
+    path.write_text("# just a file\n", encoding="utf-8")
+    assert aw.read_managed_version(path) is None
+    assert aw.is_managed_file(path) is False
+
+
+def test_read_managed_version_on_missing_file_returns_none(tmp_path):
+    assert aw.read_managed_version(tmp_path / "nope.md") is None
+
+
+# --------------------------------------------------------------------------- #
+# Sentinel-block injection / removal.
+# --------------------------------------------------------------------------- #
+
+
+def test_inject_sentinel_block_creates_new_file(tmp_path):
+    path = tmp_path / "CLAUDE.md"
+    aw.inject_sentinel_block(path, "@some/path.md", version="1.0.0")
+    text = path.read_text(encoding="utf-8")
+    assert "<!-- conductor:begin v1.0.0 -->" in text
+    assert "@some/path.md" in text
+    assert text.rstrip().endswith("<!-- conductor:end -->")
+
+
+def test_inject_sentinel_block_appends_to_existing(tmp_path):
+    path = tmp_path / "CLAUDE.md"
+    path.write_text("# My own instructions\n\nDo the thing.\n", encoding="utf-8")
+    aw.inject_sentinel_block(path, "@x", version="1.0.0")
+    text = path.read_text(encoding="utf-8")
+    assert "# My own instructions" in text
+    assert "Do the thing." in text
+    assert "<!-- conductor:begin v1.0.0 -->" in text
+    assert text.index("Do the thing.") < text.index("<!-- conductor:begin")
+
+
+def test_inject_sentinel_block_replaces_existing_block(tmp_path):
+    path = tmp_path / "CLAUDE.md"
+    path.write_text("# header\n", encoding="utf-8")
+    aw.inject_sentinel_block(path, "@v1", version="1.0.0")
+    aw.inject_sentinel_block(path, "@v2", version="2.0.0")
+    text = path.read_text(encoding="utf-8")
+    assert text.count("conductor:begin") == 1
+    assert "@v2" in text
+    assert "@v1" not in text
+    assert "v2.0.0" in text
+    assert "# header" in text
+
+
+def test_remove_sentinel_block_preserves_user_content(tmp_path):
+    path = tmp_path / "CLAUDE.md"
+    path.write_text("# mine\n", encoding="utf-8")
+    aw.inject_sentinel_block(path, "@x", version="1.0.0")
+    assert aw.remove_sentinel_block(path) is True
+    text = path.read_text(encoding="utf-8")
+    assert "# mine" in text
+    assert "conductor:begin" not in text
+    assert "conductor:end" not in text
+
+
+def test_remove_sentinel_block_deletes_file_if_only_content(tmp_path):
+    path = tmp_path / "CLAUDE.md"
+    aw.inject_sentinel_block(path, "@x", version="1.0.0")
+    assert aw.remove_sentinel_block(path) is True
+    assert not path.exists()
+
+
+def test_remove_sentinel_block_on_unmanaged_file_returns_false(tmp_path):
+    path = tmp_path / "CLAUDE.md"
+    path.write_text("# user-owned\n", encoding="utf-8")
+    assert aw.remove_sentinel_block(path) is False
+    assert path.read_text(encoding="utf-8") == "# user-owned\n"
+
+
+# --------------------------------------------------------------------------- #
+# wire_claude_code end-to-end.
+# --------------------------------------------------------------------------- #
+
+
+def test_wire_claude_code_writes_all_artifacts():
+    report = aw.wire_claude_code("0.3.2", patch_claude_md=True)
+    assert report.skipped == ()
+    assert report.patched_claude_md is True
+
+    expected_paths = {
+        aw.conductor_home() / "delegation-guidance.md",
+        aw.claude_home() / "commands" / "conductor.md",
+        aw.claude_home() / "agents" / "kimi-long-context.md",
+        aw.claude_home() / "agents" / "gemini-web-search.md",
+    }
+    assert set(report.written) == expected_paths
+    for p in expected_paths:
+        assert p.exists()
+        assert aw.is_managed_file(p)
+
+    claude_md = aw.claude_home() / "CLAUDE.md"
+    assert claude_md.exists()
+    text = claude_md.read_text(encoding="utf-8")
+    assert "conductor:begin v0.3.2" in text
+    assert "@" in text and "delegation-guidance.md" in text
+
+
+def test_wire_claude_code_patch_false_leaves_claude_md_alone():
+    report = aw.wire_claude_code("0.3.2", patch_claude_md=False)
+    assert report.patched_claude_md is False
+    assert not (aw.claude_home() / "CLAUDE.md").exists()
+
+
+def test_wire_claude_code_idempotent_on_second_run():
+    aw.wire_claude_code("0.3.2", patch_claude_md=True)
+    report = aw.wire_claude_code("0.3.3", patch_claude_md=True)
+    # Every file overwritten cleanly with new version.
+    assert report.skipped == ()
+    for p in report.written:
+        assert aw.read_managed_version(p) == "0.3.3"
+    # Sentinel block updated to new version, only one present.
+    claude_md = aw.claude_home() / "CLAUDE.md"
+    text = claude_md.read_text(encoding="utf-8")
+    assert text.count("conductor:begin") == 1
+    assert "v0.3.3" in text
+
+
+def test_wire_claude_code_skips_user_owned_file_at_managed_path():
+    """If a user already has ~/.claude/agents/kimi-long-context.md (not ours),
+    wiring must skip it and report — never overwrite."""
+    agents_dir = aw.claude_home() / "agents"
+    agents_dir.mkdir(parents=True)
+    user_file = agents_dir / "kimi-long-context.md"
+    user_file.write_text("# my hand-written agent\n", encoding="utf-8")
+
+    report = aw.wire_claude_code("0.3.2", patch_claude_md=False)
+    # The user's file is in skipped, not written.
+    skipped_paths = {path for path, _ in report.skipped}
+    assert user_file in skipped_paths
+    assert user_file not in report.written
+    # File content preserved.
+    assert user_file.read_text(encoding="utf-8") == "# my hand-written agent\n"
+
+
+# --------------------------------------------------------------------------- #
+# unwire end-to-end.
+# --------------------------------------------------------------------------- #
+
+
+def test_unwire_removes_all_managed_files():
+    aw.wire_claude_code("0.3.2", patch_claude_md=True)
+    report = aw.unwire()
+    assert len(report.removed) >= 4  # guidance + slash + 2 subagents + claude.md
+    for p in [
+        aw.conductor_home() / "delegation-guidance.md",
+        aw.claude_home() / "commands" / "conductor.md",
+        aw.claude_home() / "agents" / "kimi-long-context.md",
+        aw.claude_home() / "agents" / "gemini-web-search.md",
+    ]:
+        assert not p.exists()
+    # CLAUDE.md had only our block — should be gone.
+    assert not (aw.claude_home() / "CLAUDE.md").exists()
+
+
+def test_unwire_preserves_user_content_in_claude_md():
+    claude_md = aw.claude_home() / "CLAUDE.md"
+    claude_md.parent.mkdir(parents=True)
+    claude_md.write_text("# My own CLAUDE.md\n\nDo X.\n", encoding="utf-8")
+
+    aw.wire_claude_code("0.3.2", patch_claude_md=True)
+    aw.unwire()
+
+    # File still exists; user content preserved; no conductor block.
+    text = claude_md.read_text(encoding="utf-8")
+    assert "# My own CLAUDE.md" in text
+    assert "Do X." in text
+    assert "conductor:begin" not in text
+
+
+def test_unwire_skips_user_owned_files_at_managed_paths():
+    agents_dir = aw.claude_home() / "agents"
+    agents_dir.mkdir(parents=True)
+    user_file = agents_dir / "kimi-long-context.md"
+    user_file.write_text("# my hand-written agent\n", encoding="utf-8")
+
+    report = aw.unwire()
+    # User's file was skipped (reason recorded) and not deleted.
+    skipped_paths = {path for path, _ in report.skipped}
+    assert user_file in skipped_paths
+    assert user_file.exists()
+
+
+def test_unwire_on_clean_env_is_noop():
+    report = aw.unwire()
+    assert report.removed == ()
+    assert report.skipped == ()
+
+
+def test_wire_then_unwire_then_wire_round_trip():
+    aw.wire_claude_code("0.3.2", patch_claude_md=True)
+    aw.unwire()
+    # Second wiring works cleanly from an unwired state.
+    report = aw.wire_claude_code("0.3.3", patch_claude_md=True)
+    assert report.skipped == ()
+    assert all(aw.read_managed_version(p) == "0.3.3" for p in report.written)
+
+
+# --------------------------------------------------------------------------- #
+# Version extraction edge cases.
+# --------------------------------------------------------------------------- #
+
+
+def test_version_extraction_handles_prerelease(tmp_path):
+    path = tmp_path / "notes.md"
+    aw.write_managed_markdown(path, "body", version="0.4.0.dev1+g1234abc")
+    assert aw.read_managed_version(path) == "0.4.0.dev1+g1234abc"
+
+
+def test_managed_path_stays_out_of_arbitrary_dirs(tmp_path):
+    """Writing should only create dirs *inside* the configured homes."""
+    aw.write_managed_markdown(
+        aw.conductor_home() / "delegation-guidance.md", "x", version="1.0.0"
+    )
+    # The conductor_home dir now exists, but nothing else was created.
+    assert aw.conductor_home().is_dir()
+    assert not (tmp_path / "other").exists()

--- a/tests/test_cli_phase5.py
+++ b/tests/test_cli_phase5.py
@@ -4,9 +4,19 @@ from __future__ import annotations
 
 import json
 
+import pytest
 from click.testing import CliRunner
 
 from conductor.cli import main
+
+
+@pytest.fixture(autouse=True)
+def _isolated_agent_homes(tmp_path, monkeypatch):
+    """doctor now reports agent-integration state; isolate so tests don't
+    depend on the developer's real ~/.claude/ or ~/.conductor/ contents."""
+    monkeypatch.setenv("CONDUCTOR_HOME", str(tmp_path / ".conductor"))
+    monkeypatch.setenv("CLAUDE_HOME", str(tmp_path / ".claude"))
+    monkeypatch.setattr("shutil.which", lambda _cmd: None)
 
 
 def _stub_all_unconfigured(mocker):
@@ -172,6 +182,67 @@ def test_doctor_json_shape(mocker, monkeypatch):
     cred_map = {c["name"]: c for c in payload["credentials"]}
     assert cred_map["CLOUDFLARE_API_TOKEN"]["in_env"] is True
     assert cred_map["CLOUDFLARE_ACCOUNT_ID"]["in_env"] is False
+
+
+def test_doctor_reports_agent_integration_not_detected(mocker, monkeypatch):
+    """With no ~/.claude/ and no claude CLI, doctor reports 'not detected'."""
+    _stub_all_unconfigured(mocker)
+    for var in ("CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "OLLAMA_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+    result = CliRunner().invoke(main, ["doctor"])
+    assert result.exit_code == 0, result.output
+    assert "Agent integration:" in result.output
+    assert "not detected" in result.output.lower()
+
+
+def test_doctor_reports_agent_integration_detected_not_wired(mocker, monkeypatch, tmp_path):
+    """~/.claude/ present but no managed files → detected, not wired."""
+    _stub_all_unconfigured(mocker)
+    (tmp_path / ".claude").mkdir()
+    for var in ("CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "OLLAMA_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+    result = CliRunner().invoke(main, ["doctor"])
+    assert result.exit_code == 0, result.output
+    assert "not wired" in result.output.lower()
+    assert "conductor init" in result.output
+
+
+def test_doctor_reports_agent_integration_wired(mocker, monkeypatch, tmp_path):
+    """After wiring, doctor reports managed files with their paths."""
+    _stub_all_unconfigured(mocker)
+    (tmp_path / ".claude").mkdir()
+    for var in ("CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "OLLAMA_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+    from conductor import agent_wiring
+    agent_wiring.wire_claude_code("0.3.2", patch_claude_md=True)
+
+    result = CliRunner().invoke(main, ["doctor"])
+    assert result.exit_code == 0, result.output
+    assert "wired" in result.output.lower()
+    assert "managed files" in result.output.lower()
+    assert "guidance" in result.output.lower()
+    assert "slash-command" in result.output.lower()
+    assert "subagent" in result.output.lower()
+
+
+def test_doctor_json_includes_agent_integration(mocker, monkeypatch, tmp_path):
+    _stub_all_unconfigured(mocker)
+    (tmp_path / ".claude").mkdir()
+    for var in ("CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "OLLAMA_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+    mocker.patch("conductor.cli.credentials.keychain_has", return_value=False)
+
+    result = CliRunner().invoke(main, ["doctor", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert "agent_integration" in payload
+    ai = payload["agent_integration"]
+    assert ai["claude_detected"] is True
+    assert ai["claude_home_exists"] is True
+    assert ai["managed_files"] == []
 
 
 def test_doctor_warns_when_ollama_default_model_missing(mocker, monkeypatch):

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 from click.testing import CliRunner
 
 from conductor.cli import main
@@ -9,6 +10,16 @@ from conductor.providers.kimi import (
     CLOUDFLARE_ACCOUNT_ID_ENV,
     CLOUDFLARE_API_TOKEN_ENV,
 )
+
+
+@pytest.fixture(autouse=True)
+def _isolated_agent_homes(tmp_path, monkeypatch):
+    """Isolate ~/.claude and ~/.conductor for every wizard test — otherwise
+    a wizard run could write into the developer's real home dir."""
+    monkeypatch.setenv("CONDUCTOR_HOME", str(tmp_path / ".conductor"))
+    monkeypatch.setenv("CLAUDE_HOME", str(tmp_path / ".claude"))
+    # Default: Claude CLI not on PATH. Tests that need it patch explicitly.
+    monkeypatch.setattr("shutil.which", lambda _cmd: None)
 
 
 def test_init_non_interactive_mode_reports_state(mocker, monkeypatch):
@@ -310,6 +321,149 @@ def test_init_back_rewinds_previous_provider(mocker):
     assert result.exit_code == 0
     # The claude section header should appear twice (original + rewalk).
     assert result.output.count("[1/5]  claude") == 2
+
+
+# ---------------------------------------------------------------------------
+# Agent-integration wiring (Slice A)
+# ---------------------------------------------------------------------------
+
+
+def _stub_all_providers_unconfigured(mocker):
+    from conductor.providers import (
+        ClaudeProvider,
+        CodexProvider,
+        GeminiProvider,
+        KimiProvider,
+        OllamaProvider,
+    )
+    for cls in (
+        ClaudeProvider, CodexProvider, GeminiProvider, KimiProvider, OllamaProvider
+    ):
+        mocker.patch.object(cls, "configured", lambda self: (False, "stubbed"))
+
+
+def test_init_yes_does_not_auto_wire_without_flag(mocker, tmp_path):
+    """Non-interactive run with default flags must NOT write agent files.
+
+    Doctrine 0002: non-TTY paths are flag-driven; silent side effects on
+    fresh installs are forbidden.
+    """
+    _stub_all_providers_unconfigured(mocker)
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()  # Claude detected but no --wire-agents flag
+
+    result = CliRunner().invoke(main, ["init", "--yes"])
+    assert result.exit_code == 0
+    assert not (claude_dir / "commands" / "conductor.md").exists()
+    assert not (claude_dir / "agents" / "kimi-long-context.md").exists()
+
+
+def test_init_yes_with_wire_agents_yes_writes_files(mocker, tmp_path):
+    _stub_all_providers_unconfigured(mocker)
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+    conductor_dir = tmp_path / ".conductor"
+
+    result = CliRunner().invoke(
+        main,
+        ["init", "--yes", "--wire-agents", "yes", "--patch-claude-md", "yes"],
+    )
+    assert result.exit_code == 0, result.output
+    assert (conductor_dir / "delegation-guidance.md").exists()
+    assert (claude_dir / "commands" / "conductor.md").exists()
+    assert (claude_dir / "agents" / "kimi-long-context.md").exists()
+    assert (claude_dir / "agents" / "gemini-web-search.md").exists()
+    claude_md = (claude_dir / "CLAUDE.md").read_text(encoding="utf-8")
+    assert "conductor:begin" in claude_md
+    assert "delegation-guidance.md" in claude_md
+
+
+def test_init_yes_with_wire_agents_no_writes_nothing(mocker, tmp_path):
+    _stub_all_providers_unconfigured(mocker)
+    (tmp_path / ".claude").mkdir()
+
+    result = CliRunner().invoke(
+        main,
+        ["init", "--yes", "--wire-agents", "no"],
+    )
+    assert result.exit_code == 0
+    assert not (tmp_path / ".conductor" / "delegation-guidance.md").exists()
+    assert not (tmp_path / ".claude" / "commands" / "conductor.md").exists()
+
+
+def test_init_wire_agents_yes_without_claude_is_graceful(mocker, tmp_path):
+    """With --wire-agents=yes but no Claude detected, we report and no-op."""
+    _stub_all_providers_unconfigured(mocker)
+    # No ~/.claude/ dir; no claude on PATH.
+    result = CliRunner().invoke(
+        main, ["init", "--yes", "--wire-agents", "yes"]
+    )
+    assert result.exit_code == 0
+    assert not (tmp_path / ".conductor" / "delegation-guidance.md").exists()
+
+
+def test_init_only_skips_agent_wiring_entirely(mocker, tmp_path):
+    """--only narrows scope to one provider; agent wiring must not run."""
+    from conductor.providers import KimiProvider
+    mocker.patch.object(KimiProvider, "configured", lambda self: (True, None))
+    (tmp_path / ".claude").mkdir()
+
+    result = CliRunner().invoke(
+        main,
+        ["init", "--only", "kimi", "--yes", "--wire-agents", "yes"],
+    )
+    assert result.exit_code == 0
+    # No wiring despite --wire-agents=yes because --only narrowed scope.
+    assert not (tmp_path / ".conductor" / "delegation-guidance.md").exists()
+
+
+def test_init_interactive_claude_detected_prompts(mocker, tmp_path):
+    """On TTY with Claude detected, the wizard prompts and honors [n]."""
+    _stub_all_providers_unconfigured(mocker)
+    mocker.patch("conductor.wizard._is_tty", return_value=True)
+    (tmp_path / ".claude").mkdir()
+
+    # For each provider's concierge flow: [s]kip. Then at the agent prompt: [n]o.
+    # 5 providers × "s" (skip) + agent-wiring "n" (decline).
+    result = CliRunner().invoke(
+        main, ["init"], input="s\ns\ns\ns\ns\nn\n"
+    )
+    assert result.exit_code == 0
+    assert "Agent integration — Claude Code" in result.output
+    # User declined — no files written.
+    assert not (tmp_path / ".conductor" / "delegation-guidance.md").exists()
+
+
+def test_init_unwire_removes_managed_files(mocker, tmp_path):
+    _stub_all_providers_unconfigured(mocker)
+    (tmp_path / ".claude").mkdir()
+
+    # First wire.
+    wire_result = CliRunner().invoke(
+        main,
+        ["init", "--yes", "--wire-agents", "yes", "--patch-claude-md", "yes"],
+    )
+    assert wire_result.exit_code == 0
+    assert (tmp_path / ".claude" / "commands" / "conductor.md").exists()
+
+    # Then unwire.
+    unwire_result = CliRunner().invoke(main, ["init", "--unwire"])
+    assert unwire_result.exit_code == 0, unwire_result.output
+    assert "Removed:" in unwire_result.output
+    assert not (tmp_path / ".conductor" / "delegation-guidance.md").exists()
+    assert not (tmp_path / ".claude" / "commands" / "conductor.md").exists()
+
+
+def test_init_unwire_with_only_is_rejected():
+    result = CliRunner().invoke(main, ["init", "--unwire", "--only", "kimi"])
+    assert result.exit_code == 2
+    assert "unwire" in result.output.lower()
+
+
+def test_init_unwire_on_clean_env_reports_nothing(tmp_path):
+    result = CliRunner().invoke(main, ["init", "--unwire"])
+    assert result.exit_code == 0
+    assert "No conductor-managed" in result.output
 
 
 def test_init_summary_and_next_steps_printed(mocker):

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -466,6 +466,70 @@ def test_init_unwire_on_clean_env_reports_nothing(tmp_path):
     assert "No conductor-managed" in result.output
 
 
+def test_init_quit_during_provider_walk_skips_wiring(mocker, tmp_path):
+    """If the user [q]uits during the provider walk, the wiring phase MUST
+    NOT run — they explicitly stopped, so writing files after would
+    contradict that intent."""
+    _stub_all_providers_unconfigured(mocker)
+    mocker.patch("conductor.wizard._is_tty", return_value=True)
+    (tmp_path / ".claude").mkdir()
+
+    # First provider's menu: [q]uit immediately.
+    result = CliRunner().invoke(
+        main, ["init", "--wire-agents", "yes", "--patch-claude-md", "yes"],
+        input="q\n",
+    )
+    # Quit returns non-zero per existing wizard contract.
+    assert result.exit_code == 1
+    # Critically: no integration block was even shown.
+    assert "Agent integration" not in result.output
+    # And no files were written despite --wire-agents=yes.
+    assert not (tmp_path / ".conductor" / "delegation-guidance.md").exists()
+    assert not (tmp_path / ".claude" / "commands" / "conductor.md").exists()
+
+
+def test_init_wiring_failure_exits_non_zero(mocker, tmp_path):
+    """When wire_claude_code raises, init must exit non-zero so CI / scripts
+    notice. Silent success on a failed wire violates No Silent Failures."""
+    _stub_all_providers_unconfigured(mocker)
+    (tmp_path / ".claude").mkdir()
+    mocker.patch(
+        "conductor.agent_wiring.wire_claude_code",
+        side_effect=RuntimeError("disk on fire"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["init", "--yes", "--wire-agents", "yes", "--patch-claude-md", "yes"],
+    )
+    assert result.exit_code == 1, result.output
+    assert "wiring failed" in result.output.lower()
+    assert "disk on fire" in result.output
+
+
+def test_init_wiring_all_user_owned_exits_non_zero(mocker, tmp_path):
+    """If every target path is already a user-owned file, wire_claude_code
+    skips them all — that's a failed wire from the user's perspective and
+    must surface as a non-zero exit."""
+    _stub_all_providers_unconfigured(mocker)
+    claude_dir = tmp_path / ".claude"
+    (claude_dir / "agents").mkdir(parents=True)
+    (claude_dir / "commands").mkdir(parents=True)
+    # Drop user-owned files at every managed path.
+    (claude_dir / "agents" / "kimi-long-context.md").write_text("# mine", encoding="utf-8")
+    (claude_dir / "agents" / "gemini-web-search.md").write_text("# mine", encoding="utf-8")
+    (claude_dir / "commands" / "conductor.md").write_text("# mine", encoding="utf-8")
+    (tmp_path / ".conductor").mkdir()
+    (tmp_path / ".conductor" / "delegation-guidance.md").write_text("# mine", encoding="utf-8")
+
+    result = CliRunner().invoke(
+        main,
+        ["init", "--yes", "--wire-agents", "yes", "--patch-claude-md", "no"],
+    )
+    assert result.exit_code == 1, result.output
+    assert "skipped" in result.output.lower()
+
+
 def test_init_summary_and_next_steps_printed(mocker):
     from conductor.providers import (
         ClaudeProvider,


### PR DESCRIPTION
Expand `conductor init` so installing conductor auto-wires into Claude
Code: a canonical delegation-guidance file, a `/conductor` slash command,
two seed subagents (kimi-long-context, gemini-web-search), and an
optional @-import line in ~/.claude/CLAUDE.md. Every written file
carries a `managed-by: conductor vX.Y.Z` marker; `conductor init
--unwire` removes only what conductor wrote, preserving user edits via
sentinel-block bounding for CLAUDE.md.

New:
- `conductor.agent_wiring` — detection, managed-file + sentinel-block
  helpers, wire/unwire orchestration. Paths overridable via
  CONDUCTOR_HOME / CLAUDE_HOME env vars for test isolation.
- `conductor._agent_templates` — embedded product-quality copy for the
  guidance doc, slash command, and subagents.
- `conductor init --wire-agents={yes,no,ask}` and
  `--patch-claude-md={yes,no,ask}`: tri-state flags with ask-on-TTY,
  skip-on-non-TTY defaults (Doctrine 0002).
- `conductor init --unwire`: idempotent, reports what it removed and
  what it refused to touch.
- `conductor doctor` now reports agent-integration state (claude
  detected / wired / N managed files with paths + versions); JSON
  payload gains an `agent_integration` key.

Non-interactive-by-default: `conductor init --yes` does not write
agent files without an explicit `--wire-agents=yes`, so piped /
scripted installs don't silently touch the user's ~/.

Tests: 71 new (tests/test_agent_wiring.py + wizard + doctor coverage),
all isolate $HOME via tmp_path + env overrides. Full suite: 332 pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
