### PR TITLE
feat(v0.3.3): local LLM ergonomics — sensible default, real timeout, silent-fail guard

### DIFF
--- a/src/conductor/providers/ollama.py
+++ b/src/conductor/providers/ollama.py
@@ -32,10 +32,92 @@ from conductor.tools import (
 
 OLLAMA_BASE_URL_ENV = "OLLAMA_BASE_URL"
 OLLAMA_DEFAULT_BASE_URL = "http://localhost:11434"
-OLLAMA_DEFAULT_MODEL = "qwen2.5-coder:14b"
-OLLAMA_REQUEST_TIMEOUT_SEC = 180.0
+# Default bumped 2026-04-24 from qwen2.5-coder:14b to qwen3.6:35b-a3b after
+# dogfood: qwen2.5-coder emits tool calls as markdown-JSON inside content
+# rather than as structured tool_calls (silent-fail for exec() with tools),
+# and qwen3.6:35b-a3b is a MoE that runs ~7x faster than the 27b dense on
+# low-memory-headroom Macs despite the larger total parameter count.
+OLLAMA_DEFAULT_MODEL = "qwen3.6:35b-a3b"
+# Bumped 2026-04-24 from 180s → 600s. Agent-loop dogfood on an M4 Max 36GB
+# showed multi-turn tool-use loops with growing context routinely take
+# 5-15 minutes end-to-end — even for fast MoE models — and each iteration
+# can approach 180s when the prompt grows. Override per-request via the
+# CONDUCTOR_OLLAMA_TIMEOUT_SEC env var.
+OLLAMA_TIMEOUT_ENV = "CONDUCTOR_OLLAMA_TIMEOUT_SEC"
+OLLAMA_REQUEST_TIMEOUT_SEC = 600.0
 OLLAMA_MAX_TOOL_ITERATIONS = 10
 OLLAMA_CONTEXT_SAFETY_MARGIN = 0.1
+
+
+def _find_stealth_tool_call(content: str, tool_names: frozenset[str]) -> str | None:
+    """Return the tool name if ``content`` contains a tool-call-shaped JSON
+    block for one of ``tool_names``, otherwise None.
+
+    The heuristic looks for a JSON object with a ``name`` field whose
+    value is in ``tool_names`` — the shape every qwen-family model emits
+    when its chat template fails to convert the call into a structured
+    ``tool_calls`` field. Covers fenced (```json```) and bare JSON blocks.
+    Deliberately cheap — one regex, one json.loads attempt per candidate;
+    false positives here are not harmful because the diagnostic simply
+    warns that the loop returned without executing tools.
+    """
+    if not content or not tool_names:
+        return None
+    import re
+
+    # Look for JSON-like blocks: fenced markdown first, then any balanced
+    # {...} span that happens to hold a "name" key. Nested braces (e.g.
+    # {"arguments": {"path": "x"}}) defeat a simple [^{}]* match, so we
+    # scan for candidate starts and walk a depth counter to find each
+    # span's end. Keeps us regex-free for the nested case.
+    candidates: list[str] = []
+    for match in re.finditer(
+        r"```(?:json)?\s*(\{.*?\})\s*```", content, flags=re.DOTALL
+    ):
+        candidates.append(match.group(1))
+    if not candidates:
+        for start in range(len(content)):
+            if content[start] != "{":
+                continue
+            depth = 0
+            for end in range(start, len(content)):
+                ch = content[end]
+                if ch == "{":
+                    depth += 1
+                elif ch == "}":
+                    depth -= 1
+                    if depth == 0:
+                        span = content[start : end + 1]
+                        if '"name"' in span:
+                            candidates.append(span)
+                        break
+    for raw in candidates:
+        try:
+            obj = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and obj.get("name") in tool_names:
+            return obj["name"]
+    return None
+
+
+def _resolve_default_timeout() -> float:
+    """Pick the per-request HTTP timeout at instance-init time.
+
+    Env-override flow: ``CONDUCTOR_OLLAMA_TIMEOUT_SEC`` wins if set and
+    parseable as a positive float; otherwise fall back to the baked-in
+    default. Invalid values fall through rather than raising so a typo
+    doesn't brick the provider.
+    """
+    raw = os.environ.get(OLLAMA_TIMEOUT_ENV)
+    if raw:
+        try:
+            override = float(raw)
+            if override > 0:
+                return override
+        except ValueError:
+            pass
+    return OLLAMA_REQUEST_TIMEOUT_SEC
 
 
 class OllamaProvider:
@@ -68,10 +150,14 @@ class OllamaProvider:
         self,
         *,
         base_url: str | None = None,
-        timeout_sec: float = OLLAMA_REQUEST_TIMEOUT_SEC,
+        timeout_sec: float | None = None,
     ) -> None:
         self._base_url_override = base_url
-        self._timeout_sec = timeout_sec
+        # Resolve the timeout once per instance: explicit kwarg wins,
+        # then the CONDUCTOR_OLLAMA_TIMEOUT_SEC env var, then the default.
+        self._timeout_sec = (
+            timeout_sec if timeout_sec is not None else _resolve_default_timeout()
+        )
 
     def _base_url(self) -> str:
         return (
@@ -311,6 +397,26 @@ class OllamaProvider:
             final_text = message.get("content") or ""
 
             if not tool_calls:
+                # Silent-fail guard: some model+template combinations
+                # (notably qwen2.5-coder:* in ollama) emit the tool call
+                # as a markdown-JSON block inside `content` instead of
+                # populating the `tool_calls` field. Without this check
+                # the loop would silently return the model's prose as if
+                # it were the answer — and that prose is usually a
+                # hallucination since no tool actually ran.
+                stealth = _find_stealth_tool_call(final_text, tools)
+                if stealth:
+                    final_text = (
+                        "[conductor: the model "
+                        f"({model}) returned a tool-call-shaped JSON block "
+                        f"for `{stealth}` inside message.content instead of "
+                        "the structured tool_calls field. No tool was "
+                        "actually executed; the response below is the "
+                        "model's unaided prose. Try a model with proper "
+                        "tool-use support (e.g. qwen3.5+ or qwen3.6+, "
+                        "llama3.1+) — qwen2.5-coder is known to have this "
+                        "issue in ollama.]\n\n"
+                    ) + final_text
                 break
 
             if prompt_tokens >= context_ceiling:

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -14,6 +14,7 @@ from conductor.providers.interface import (
 from conductor.providers.ollama import (
     OLLAMA_BASE_URL_ENV,
     OLLAMA_DEFAULT_BASE_URL,
+    OLLAMA_DEFAULT_MODEL,
     OllamaProvider,
 )
 
@@ -48,7 +49,12 @@ def test_default_model_available_true_when_pulled():
         router.get(TAGS_URL).mock(
             return_value=httpx.Response(
                 200,
-                json={"models": [{"name": "qwen2.5-coder:14b"}, {"name": "other:1b"}]},
+                json={
+                    "models": [
+                        {"name": OLLAMA_DEFAULT_MODEL},
+                        {"name": "other:1b"},
+                    ]
+                },
             )
         )
         ok, reason = OllamaProvider().default_model_available()
@@ -64,7 +70,7 @@ def test_default_model_available_false_lists_alternatives():
         )
         ok, reason = OllamaProvider().default_model_available()
     assert ok is False
-    assert "qwen2.5-coder:14b" in reason
+    assert OLLAMA_DEFAULT_MODEL in reason
     assert "ollama pull" in reason
     assert "qwen2.5-coder:7b" in reason  # shows locally installed alternatives
 
@@ -76,7 +82,7 @@ def test_default_model_available_false_when_no_models_pulled():
         )
         ok, reason = OllamaProvider().default_model_available()
     assert ok is False
-    assert "ollama pull qwen2.5-coder:14b" in reason
+    assert f"ollama pull {OLLAMA_DEFAULT_MODEL}" in reason
 
 
 def test_configured_honors_env_override(monkeypatch):
@@ -91,7 +97,7 @@ def test_configured_honors_env_override(monkeypatch):
 
 def test_call_returns_normalized_response():
     body = {
-        "model": "qwen2.5-coder:14b",
+        "model": OLLAMA_DEFAULT_MODEL,
         "message": {"role": "assistant", "content": "hello from ollama"},
         "prompt_eval_count": 8,
         "eval_count": 3,
@@ -103,7 +109,7 @@ def test_call_returns_normalized_response():
 
     assert response.text == "hello from ollama"
     assert response.provider == "ollama"
-    assert response.model == "qwen2.5-coder:14b"
+    assert response.model == OLLAMA_DEFAULT_MODEL
     assert response.usage["input_tokens"] == 8
     assert response.usage["output_tokens"] == 3
     assert response.usage["cached_tokens"] is None
@@ -155,7 +161,7 @@ def test_call_session_id_is_none_for_ollama():
                 200,
                 json={
                     "message": {"content": "ok"},
-                    "model": "qwen2.5-coder:14b",
+                    "model": OLLAMA_DEFAULT_MODEL,
                     "prompt_eval_count": 1,
                     "eval_count": 1,
                 },
@@ -175,7 +181,7 @@ import json as _json  # noqa: E402 — grouped near the exec tests
 
 def _ollama_terminal(content: str) -> dict:
     return {
-        "model": "qwen2.5-coder:14b",
+        "model": OLLAMA_DEFAULT_MODEL,
         "message": {"role": "assistant", "content": content},
         "prompt_eval_count": 5,
         "eval_count": 2,
@@ -191,7 +197,7 @@ def _ollama_tool_turn(name: str, arguments: dict, call_id: str | None = None) ->
     if call_id is not None:
         call["id"] = call_id
     return {
-        "model": "qwen2.5-coder:14b",
+        "model": OLLAMA_DEFAULT_MODEL,
         "message": {
             "role": "assistant",
             "content": "",
@@ -433,3 +439,135 @@ def test_exec_accepts_strict_sandbox(tmp_path):
             cwd=str(tmp_path),
         )
     assert resp.text == "direct answer"
+
+
+# --------------------------------------------------------------------------- #
+# v0.3.3 — local LLM ergonomics (timeout env override, stealth tool-call guard)
+# --------------------------------------------------------------------------- #
+
+
+def test_default_model_points_at_tool_use_capable_qwen():
+    # Guardrail: the default must be a model that actually emits structured
+    # tool_calls in ollama. Bumped from qwen2.5-coder:14b (silent-fail) on
+    # 2026-04-24 after dogfood. If someone rolls this back, fail loud.
+    assert "qwen" in OLLAMA_DEFAULT_MODEL
+    assert "qwen2.5-coder" not in OLLAMA_DEFAULT_MODEL
+
+
+def test_timeout_defaults_to_baked_in_when_env_unset(monkeypatch):
+    from conductor.providers.ollama import OLLAMA_REQUEST_TIMEOUT_SEC
+
+    monkeypatch.delenv("CONDUCTOR_OLLAMA_TIMEOUT_SEC", raising=False)
+    provider = OllamaProvider()
+    assert provider._timeout_sec == OLLAMA_REQUEST_TIMEOUT_SEC
+
+
+def test_timeout_env_override_wins(monkeypatch):
+    monkeypatch.setenv("CONDUCTOR_OLLAMA_TIMEOUT_SEC", "45")
+    provider = OllamaProvider()
+    assert provider._timeout_sec == 45.0
+
+
+def test_timeout_explicit_kwarg_beats_env(monkeypatch):
+    monkeypatch.setenv("CONDUCTOR_OLLAMA_TIMEOUT_SEC", "45")
+    provider = OllamaProvider(timeout_sec=12.0)
+    assert provider._timeout_sec == 12.0
+
+
+def test_timeout_env_invalid_falls_back_to_default(monkeypatch):
+    from conductor.providers.ollama import OLLAMA_REQUEST_TIMEOUT_SEC
+
+    monkeypatch.setenv("CONDUCTOR_OLLAMA_TIMEOUT_SEC", "abc")
+    assert OllamaProvider()._timeout_sec == OLLAMA_REQUEST_TIMEOUT_SEC
+
+
+def test_timeout_env_non_positive_falls_back_to_default(monkeypatch):
+    from conductor.providers.ollama import OLLAMA_REQUEST_TIMEOUT_SEC
+
+    monkeypatch.setenv("CONDUCTOR_OLLAMA_TIMEOUT_SEC", "-5")
+    assert OllamaProvider()._timeout_sec == OLLAMA_REQUEST_TIMEOUT_SEC
+
+
+def test_stealth_tool_call_fenced_markdown_detected():
+    from conductor.providers.ollama import _find_stealth_tool_call
+
+    content = '```json\n{"name": "Read", "arguments": {"path": "a.txt"}}\n```'
+    assert _find_stealth_tool_call(content, frozenset({"Read"})) == "Read"
+
+
+def test_stealth_tool_call_plain_json_detected():
+    from conductor.providers.ollama import _find_stealth_tool_call
+
+    content = 'Here you go: {"name": "Grep", "arguments": {"pattern": "x"}}'
+    assert _find_stealth_tool_call(content, frozenset({"Grep"})) == "Grep"
+
+
+def test_stealth_tool_call_ignored_when_name_not_in_tool_set():
+    from conductor.providers.ollama import _find_stealth_tool_call
+
+    content = '```json\n{"name": "Telepathy", "arguments": {}}\n```'
+    assert _find_stealth_tool_call(content, frozenset({"Read"})) is None
+
+
+def test_stealth_tool_call_ignored_when_no_tools_param():
+    from conductor.providers.ollama import _find_stealth_tool_call
+
+    content = '{"name": "Read"}'
+    assert _find_stealth_tool_call(content, frozenset()) is None
+
+
+def test_stealth_tool_call_ignored_on_plain_prose():
+    from conductor.providers.ollama import _find_stealth_tool_call
+
+    content = "The function _resolve_in_cwd defends against path traversal."
+    assert _find_stealth_tool_call(content, frozenset({"Read"})) is None
+
+
+def test_exec_warns_on_stealth_tool_call(tmp_path):
+    # Simulate qwen2.5-coder-style silent fail: content contains the
+    # tool call as markdown JSON, but tool_calls field is empty. The
+    # loop should inject a visible diagnostic ahead of the prose.
+    stealth_body = {
+        "model": OLLAMA_DEFAULT_MODEL,
+        "message": {
+            "role": "assistant",
+            "content": (
+                '```json\n{"name": "Read", "arguments": '
+                '{"path": "src/conductor/tools/registry.py"}}\n```\n\n'
+                "_resolve_in_cwd blocks path traversal."
+            ),
+            # No tool_calls field — the silent fail pattern.
+        },
+        "prompt_eval_count": 10,
+        "eval_count": 20,
+        "done": True,
+    }
+    with respx.mock() as router:
+        router.post(CHAT_URL).mock(return_value=httpx.Response(200, json=stealth_body))
+        resp = OllamaProvider().exec(
+            "summarize _resolve_in_cwd",
+            tools=frozenset({"Read"}),
+            sandbox="read-only",
+            cwd=str(tmp_path),
+        )
+    assert "[conductor:" in resp.text
+    assert "tool-call-shaped" in resp.text
+    assert "Read" in resp.text
+    # Original model prose still present after the diagnostic.
+    assert "_resolve_in_cwd" in resp.text
+
+
+def test_exec_does_not_warn_on_clean_no_tool_response(tmp_path):
+    # When the model legitimately answers without tool-use, don't spam
+    # the user with a false-positive diagnostic.
+    clean = _ollama_terminal("direct answer without tools")
+    with respx.mock() as router:
+        router.post(CHAT_URL).mock(return_value=httpx.Response(200, json=clean))
+        resp = OllamaProvider().exec(
+            "what is 2+2",
+            tools=frozenset({"Read"}),
+            sandbox="read-only",
+            cwd=str(tmp_path),
+        )
+    assert "[conductor:" not in resp.text
+    assert resp.text == "direct answer without tools"


### PR DESCRIPTION
## Summary

Three fixes from the 2026-04-24 local-LLM dogfood on M4 Max 36GB. Each was necessary to turn the local path from \"plumbed\" into \"actually good.\"

1. **Default model**: \`qwen2.5-coder:14b\` → \`qwen3.6:35b-a3b\`. qwen2.5-coder emits tool calls as markdown-JSON in \`content\` rather than structured \`tool_calls\` — conductor's HTTP loop silently bypasses the tool executor and returns hallucinated prose. qwen3.6 MoE handles structured tool_calls correctly and runs ~7× faster than 27b dense on low-memory Macs (41.76 vs 5.85 tok/s observed).

2. **Timeout**: 180s → 600s + \`CONDUCTOR_OLLAMA_TIMEOUT_SEC\` env override. Real agent loops take 5-15 minutes end-to-end; iterations can approach 180s as context grows. Explicit \`timeout_sec=\` kwarg still wins over env var; invalid env values fall back to default rather than raising.

3. **Silent-fail guard**: when \`tool_calls\` is empty but \`content\` contains a JSON block whose \`name\` matches a sent tool, prepend a visible \`[conductor: ...]\` diagnostic so the user knows the loop returned without executing tools. Balanced-brace walker for detection — regex with \`[^{}]*\` would have missed nested \`{\"arguments\": {...}}\`.

## Test plan

- [x] \`pytest\` — 368 passed (+13 in test_ollama.py: default-bump guardrail, 5 timeout-resolution cases, 7 stealth-detection cases)
- [x] \`ruff check\` — clean
- [x] Verified qwen3.6:35b-a3b round-trips the full v0.3.x agent loop against the real ollama daemon and returns a correct 3/3 answer on a read-file-and-summarize task
- [x] Verified qwen2.5-coder:7b triggers the silent-fail pattern via direct /api/chat probe (the exact failure mode this PR guards against)

## Dogfood findings (will be journaled to autumn-garage)

Full comparison table, hardware notes, and recipe go in \`autumn-garage/.cortex/journal/2026-04-24-local-llm-dogfood.md\` (follow-up commit — this PR is code only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)