### PR TITLE
feat(v0.4.1): agent-wiring — Slice B (AGENTS.md + 3 more subagents)

### DIFF
--- a/src/conductor/_agent_templates.py
+++ b/src/conductor/_agent_templates.py
@@ -213,3 +213,156 @@ that needs current information. If Gemini isn't available, say so
 plainly — stale answers labeled as fresh are worse than an explicit
 "I can't reach Gemini right now."
 """
+
+
+SUBAGENT_CODEX_CODING_AGENT = """You are a delegation subagent. Your job is to route
+heavy code-editing tasks to OpenAI's Codex CLI via conductor's `exec`
+mode and return what Codex produced.
+
+Codex is strongest for multi-file coding sessions where a tool-using
+agent loop is expected: refactoring, feature implementation, debugging
+with file-editing over many turns. Use me when the parent agent decides
+it wants a second model to *execute* a coding task in its own agent
+loop rather than answering single-shot.
+
+When invoked:
+
+1. Describe the task precisely — Codex will run its own loop and you
+   are giving it the initial prompt, not mid-conversation context.
+2. Run:
+
+       conductor exec --with codex --tools Read,Grep,Glob,Edit,Write,Bash \\
+           --sandbox workspace-write --task "<prompt>" --json
+
+3. Parse the JSON, extract `text`, and return it verbatim prefixed with
+   "From Codex:". Note `session_id` in the JSON if present — callers can
+   resume by passing it back as `--resume-session-id`.
+
+If the task is a quick one-shot question (no file tools needed), route
+it to a single-turn provider instead — `exec` mode carries more setup
+cost than is warranted for single-turn prompts.
+
+If conductor errors:
+- `no provider...` → codex CLI isn't installed or authed. Tell the user
+  to run `codex login` after installing, then `conductor init`.
+- `UnsupportedCapability` → the sandbox or tool combo isn't supported;
+  relay the error so the user can adjust.
+- Runtime errors → pass through verbatim.
+
+Do NOT attempt the coding task yourself if Codex is unavailable — the
+user asked for Codex specifically for its agent loop behavior.
+"""
+
+
+SUBAGENT_OLLAMA_OFFLINE = """You are a delegation subagent. Your job is to route
+privacy-sensitive or offline-only tasks to a local Ollama model via the
+`conductor` CLI and return the answer.
+
+Ollama runs on the user's machine. Nothing leaves the host. Use me for
+tasks where data must not travel to a hosted API: proprietary code the
+user doesn't want reviewed by a third party, PII-bearing transcripts,
+anything the user flags as sensitive, or work done deliberately
+offline.
+
+When invoked:
+
+1. Confirm the task is actually a fit for local inference. Ollama's
+   default model (qwen3.6:35b-a3b as of conductor v0.3.3) is a capable
+   MoE coder, but complex frontier-tier reasoning will still be worse
+   than a hosted flagship. If the user's task clearly needs frontier
+   reasoning and is NOT privacy-sensitive, say so and ask the parent
+   to route elsewhere.
+2. Run:
+
+       conductor call --with ollama --task "<prompt>" --json
+
+3. Parse the JSON, extract `text`, and return it prefixed with
+   "From Ollama (local):".
+
+If conductor errors:
+- Connection refused / daemon not running → tell the user to
+  `ollama serve` in another terminal (or start the service).
+- Model not pulled → report which model, suggest `ollama pull <model>`.
+- Timeouts → local hardware may be slow; suggest a smaller model.
+
+Never silently route a privacy-sensitive task to a hosted provider if
+Ollama is unavailable. Say so plainly and let the user decide —
+"sensitive data to the cloud" is never a silent fallback.
+"""
+
+
+# --------------------------------------------------------------------------- #
+# AGENTS.md sentinel-block content — injected into repo-root AGENTS.md.
+# Must be self-contained: AGENTS.md has no @import mechanism, so the block
+# inlines the key info directly. References ~/.conductor/delegation-guidance.md
+# for the full version.
+# --------------------------------------------------------------------------- #
+
+AGENTS_MD_BLOCK = """## Conductor delegation
+
+This project has [conductor](https://github.com/autumngarage/conductor)
+available for delegating tasks to other LLMs from inside an agent loop.
+You can shell out to it instead of trying to do everything yourself.
+
+Quick reference:
+
+- `conductor call --with <provider> --task "..."` — single-turn call.
+- `conductor call --auto --tags <tag1>,<tag2> --task "..."` — let the
+  router pick a provider based on task tags.
+- `conductor exec --with <provider> --tools Read,Edit,Bash \\
+       --sandbox workspace-write --task "..."` — agent loop with file
+  tools, in a sandbox.
+- `conductor list` — show configured providers and their tags.
+
+Providers commonly worth delegating to:
+
+- `kimi` — long-context summarization, cheap second opinions.
+- `gemini` — web search, multimodal.
+- `claude` / `codex` — strongest reasoning / coding agent loops.
+- `ollama` — local, offline, privacy-sensitive.
+
+Full delegation guidance (when to delegate, when not to, error handling):
+
+    ~/.conductor/delegation-guidance.md
+"""
+
+
+SUBAGENT_CONDUCTOR_AUTO = """You are a delegation subagent that uses conductor's
+auto-router to pick a provider based on the task's tags — not a fixed
+model. Use me when the parent agent wants to delegate but doesn't know
+which provider is best.
+
+When invoked:
+
+1. Look at the task and decide which capability tags apply:
+   - `long-context` — task involves >50 KB of text
+   - `web-search` — task needs fresh web information
+   - `vision` — task involves images
+   - `tool-use` — task needs file/code tools
+   - `code-review` — reviewing a diff or piece of code
+   - `cheap` — user explicitly asked for a cheap run
+   - `offline` — user explicitly asked for local-only
+   Pick 1–3 tags; do NOT invent new ones.
+2. Run:
+
+       conductor call --auto --tags <tag1>,<tag2> --task "<prompt>" --json
+
+   For the prefer axis:
+   - Default: `--prefer balanced` (what conductor does by default).
+   - User asked for the cheapest option: `--prefer cheapest`.
+   - User asked for the best answer: `--prefer best`.
+   - Response-time matters: `--prefer fastest`.
+3. Parse the JSON, extract `text`, and return it prefixed with
+   "From <provider> (auto-routed by conductor):". The chosen provider
+   is in the JSON under `provider`.
+
+If the task is narrow enough that a specific subagent fits
+(long-context → kimi-long-context, web-search → gemini-web-search,
+coding agent loop → codex-coding-agent, offline → ollama-offline),
+prefer that specific subagent over me. I exist for the "delegate but
+I'm not sure where" case.
+
+If conductor errors with `NoConfiguredProvider`, the user has no
+provider that matches the tags. Suggest either relaxing tags or
+running `conductor init` to configure more providers.
+"""

--- a/src/conductor/agent_wiring.py
+++ b/src/conductor/agent_wiring.py
@@ -102,6 +102,8 @@ class Detection:
     claude_user_md: Path             # ~/.claude/CLAUDE.md — may or may not exist
     claude_user_md_exists: bool
     conductor_home: Path
+    agents_md: Path                  # ./AGENTS.md in cwd — may or may not exist
+    agents_md_exists: bool
     managed: tuple[AgentArtifact, ...] = field(default_factory=tuple)
 
     @property
@@ -110,12 +112,20 @@ class Detection:
         return self.claude_cli_on_path or self.claude_home_exists
 
 
-def detect() -> Detection:
-    """Scan the current environment for Claude Code + any managed files."""
+def detect(*, cwd: Path | None = None) -> Detection:
+    """Scan the current environment for Claude Code + any managed files.
+
+    Args:
+        cwd: where to look for repo-scoped files like ``./AGENTS.md``.
+            Defaults to the process's current working directory; tests
+            pass an explicit ``tmp_path`` for isolation.
+    """
     ch = claude_home()
     ch_exists = ch.is_dir()
     cli_on_path = shutil.which("claude") is not None
     user_md = ch / "CLAUDE.md"
+    work_dir = cwd or Path.cwd()
+    agents_md = work_dir / "AGENTS.md"
 
     managed: list[AgentArtifact] = []
     for path, kind in _candidate_artifacts().items():
@@ -136,6 +146,15 @@ def detect() -> Detection:
             continue
         managed.append(AgentArtifact(path=path, kind=kind, version=version, owned=True))
 
+    # Sentinel-block paths in cwd (AGENTS.md). Same ownership model as
+    # claude-md-import: file is user-owned, only the block is conductor's.
+    for path, kind in _candidate_sentinel_paths(cwd=work_dir).items():
+        if not path.exists() or not _has_sentinel_block(path):
+            continue
+        managed.append(
+            AgentArtifact(path=path, kind=kind, version=_block_version(path), owned=True)
+        )
+
     return Detection(
         claude_cli_on_path=cli_on_path,
         claude_home=ch,
@@ -143,12 +162,16 @@ def detect() -> Detection:
         claude_user_md=user_md,
         claude_user_md_exists=user_md.exists(),
         conductor_home=conductor_home(),
+        agents_md=agents_md,
+        agents_md_exists=agents_md.exists(),
         managed=tuple(managed),
     )
 
 
 def _candidate_artifacts() -> dict[Path, str]:
-    """The set of paths conductor may own. Used by detect() and unwire()."""
+    """Fully-managed paths conductor may own (excludes user-owned files
+    that take only a sentinel-block injection — those go through
+    ``_candidate_sentinel_paths``)."""
     ch = claude_home()
     conductor = conductor_home()
     return {
@@ -156,7 +179,23 @@ def _candidate_artifacts() -> dict[Path, str]:
         ch / "commands" / "conductor.md": "slash-command",
         ch / "agents" / "kimi-long-context.md": "subagent",
         ch / "agents" / "gemini-web-search.md": "subagent",
+        ch / "agents" / "codex-coding-agent.md": "subagent",
+        ch / "agents" / "ollama-offline.md": "subagent",
+        ch / "agents" / "conductor-auto.md": "subagent",
         ch / "CLAUDE.md": "claude-md-import",
+    }
+
+
+def _candidate_sentinel_paths(*, cwd: Path | None = None) -> dict[Path, str]:
+    """User-owned files that conductor injects sentinel blocks into.
+
+    Currently:
+      - ``./AGENTS.md`` in the caller's cwd (Codex / Cursor / shared
+        convention). One file per repo; conductor doesn't walk the tree.
+    """
+    cwd = cwd or Path.cwd()
+    return {
+        cwd / "AGENTS.md": "agents-md-import",
     }
 
 
@@ -349,13 +388,17 @@ class UnwireReport:
     skipped: tuple[tuple[Path, str], ...]  # (path, reason)
 
 
-def unwire() -> UnwireReport:
+def unwire(*, cwd: Path | None = None) -> UnwireReport:
     """Remove every managed file / sentinel block conductor has written.
 
     Fully-managed files (guidance, slash command, subagents) are deleted
     only if their header still marks them as conductor-managed. User-owned
-    files (CLAUDE.md) have their sentinel block removed; the rest of the
-    file is left alone.
+    files (CLAUDE.md, AGENTS.md) have their sentinel block removed; the
+    rest of the file is left alone.
+
+    ``cwd`` controls where ``AGENTS.md`` is looked for. Defaults to the
+    process's current working directory; callers running unwire across
+    multiple repos must invoke from each repo (we never walk the tree).
     """
     removed: list[Path] = []
     skipped: list[tuple[Path, str]] = []
@@ -374,6 +417,12 @@ def unwire() -> UnwireReport:
             removed.append(path)
         except OSError as e:
             skipped.append((path, f"unlink failed: {e}"))
+
+    # Sentinel-block paths in cwd (AGENTS.md).
+    for path, _kind in _candidate_sentinel_paths(cwd=cwd).items():
+        if path.exists() and remove_sentinel_block(path):
+            removed.append(path)
+
     return UnwireReport(removed=tuple(removed), skipped=tuple(skipped))
 
 
@@ -462,6 +511,45 @@ def wire_claude_code(
         },
         templates.SUBAGENT_GEMINI_WEB_SEARCH,
     )
+    _write_fm(
+        ch / "agents" / "codex-coding-agent.md",
+        {
+            "name": "codex-coding-agent",
+            "description": (
+                "Use for heavy multi-file coding tasks where a tool-using agent "
+                "loop is expected. Delegates to OpenAI Codex via `conductor exec "
+                "--with codex` in a workspace-write sandbox."
+            ),
+            "tools": "Bash",
+        },
+        templates.SUBAGENT_CODEX_CODING_AGENT,
+    )
+    _write_fm(
+        ch / "agents" / "ollama-offline.md",
+        {
+            "name": "ollama-offline",
+            "description": (
+                "Use for privacy-sensitive or offline-only tasks. Delegates to a "
+                "local Ollama model via `conductor call --with ollama` — nothing "
+                "leaves the machine."
+            ),
+            "tools": "Bash",
+        },
+        templates.SUBAGENT_OLLAMA_OFFLINE,
+    )
+    _write_fm(
+        ch / "agents" / "conductor-auto.md",
+        {
+            "name": "conductor-auto",
+            "description": (
+                "Use when delegating but unsure which provider fits. Lets "
+                "conductor's auto-router pick by task tags via `conductor call "
+                "--auto --tags <…>`."
+            ),
+            "tools": "Bash",
+        },
+        templates.SUBAGENT_CONDUCTOR_AUTO,
+    )
 
     patched = False
     if patch_claude_md:
@@ -474,6 +562,31 @@ def wire_claude_code(
         skipped=tuple(skipped),
         patched_claude_md=patched,
     )
+
+
+@dataclass(frozen=True)
+class AgentsMdReport:
+    path: Path
+    patched: bool
+
+
+def wire_agents_md(cwd: Path | None = None, *, version: str) -> AgentsMdReport:
+    """Inject conductor's delegation block into ``./AGENTS.md`` in ``cwd``.
+
+    AGENTS.md is the cross-tool convention (Codex, Cursor, Zed, …). It has
+    no ``@`` import mechanism, so we inline the block via the sentinel
+    pattern — user content outside the markers is preserved.
+
+    The block content is self-contained (a quick reference plus a
+    pointer to ``~/.conductor/delegation-guidance.md`` for the full
+    text), so an agent that reads only AGENTS.md still gets enough.
+    """
+    from conductor import _agent_templates as templates
+
+    cwd = cwd or Path.cwd()
+    path = cwd / "AGENTS.md"
+    inject_sentinel_block(path, templates.AGENTS_MD_BLOCK, version=version)
+    return AgentsMdReport(path=path, patched=True)
 
 
 # --------------------------------------------------------------------------- #

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -1031,6 +1031,11 @@ def _agent_integration_payload() -> dict:
         "claude_home": str(detection.claude_home),
         "claude_home_exists": detection.claude_home_exists,
         "conductor_home": str(detection.conductor_home),
+        "agents_md_path": str(detection.agents_md),
+        "agents_md_exists": detection.agents_md_exists,
+        "agents_md_wired": any(
+            a.kind == "agents-md-import" for a in detection.managed
+        ),
         "managed_files": [
             {"path": str(a.path), "kind": a.kind, "version": a.version}
             for a in detection.managed
@@ -1085,17 +1090,33 @@ def doctor(as_json: bool) -> None:
     click.echo("")
     click.echo("Agent integration:")
     ai = payload["agent_integration"]
+
+    claude_managed = [f for f in ai["managed_files"] if f["kind"] != "agents-md-import"]
     if not ai["claude_detected"]:
         click.echo("  Claude Code: not detected")
-    elif not ai["managed_files"]:
+    elif not claude_managed:
         click.echo("  Claude Code: detected, not wired (run `conductor init`)")
     else:
-        click.echo(
-            f"  Claude Code: wired — {len(ai['managed_files'])} managed files"
-        )
-        for f in ai["managed_files"]:
+        click.echo(f"  Claude Code: wired — {len(claude_managed)} managed files")
+        for f in claude_managed:
             version_note = f" v{f['version']}" if f["version"] else ""
-            click.echo(f"    {f['kind']:<15}  {f['path']}{version_note}")
+            click.echo(f"    {f['kind']:<18}  {f['path']}{version_note}")
+
+    if not ai["agents_md_exists"] and not ai["agents_md_wired"]:
+        click.echo("  AGENTS.md:   no AGENTS.md in current directory")
+    elif ai["agents_md_wired"]:
+        block = next(
+            (f for f in ai["managed_files"] if f["kind"] == "agents-md-import"),
+            None,
+        )
+        version_note = f" v{block['version']}" if block and block["version"] else ""
+        click.echo(
+            f"  AGENTS.md:   wired — {ai['agents_md_path']}{version_note}"
+        )
+    else:
+        click.echo(
+            f"  AGENTS.md:   present but not wired — {ai['agents_md_path']}"
+        )
 
     click.echo("")
     click.echo("Next steps:")
@@ -1147,10 +1168,18 @@ def doctor(as_json: bool) -> None:
     "Default: ask on TTY, skip on non-TTY.",
 )
 @click.option(
+    "--patch-agents-md",
+    type=click.Choice(["yes", "no", "ask"]),
+    default=None,
+    help="Inject a conductor delegation block into ./AGENTS.md (repo-scoped). "
+    "Default: ask on TTY when the file exists, skip otherwise.",
+)
+@click.option(
     "--unwire",
     is_flag=True,
     default=False,
-    help="Remove every conductor-managed agent integration artifact and exit.",
+    help="Remove every conductor-managed agent integration artifact "
+    "(user-scope + repo-scope AGENTS.md block) and exit.",
 )
 def init(
     accept_defaults: bool,
@@ -1158,11 +1187,12 @@ def init(
     remaining: bool,
     wire_agents: str | None,
     patch_claude_md: str | None,
+    patch_agents_md: str | None,
     unwire: bool,
 ) -> None:
     """Interactively configure Conductor for first use."""
     if unwire:
-        if only or remaining or wire_agents or patch_claude_md:
+        if only or remaining or wire_agents or patch_claude_md or patch_agents_md:
             raise click.UsageError(
                 "--unwire can't be combined with provider or wiring flags."
             )
@@ -1180,6 +1210,7 @@ def init(
         remaining=remaining,
         wire_agents=wire_agents,
         patch_claude_md=patch_claude_md,
+        patch_agents_md=patch_agents_md,
     )
     sys.exit(exit_code)
 

--- a/src/conductor/wizard.py
+++ b/src/conductor/wizard.py
@@ -211,6 +211,7 @@ def run_init_wizard(
     remaining: bool = False,
     wire_agents: str | None = None,
     patch_claude_md: str | None = None,
+    patch_agents_md: str | None = None,
 ) -> int:
     """Walk the user through configuring every provider that needs it.
 
@@ -220,12 +221,17 @@ def run_init_wizard(
         remaining: skip providers that are already configured (resume flow).
         wire_agents: one of "yes" / "no" / "ask" / None. Controls whether
             the wizard offers to wire conductor into detected agent tools
-            (Claude Code today; more in later slices). None means ask on
-            TTY, skip on non-TTY.
+            (Claude Code user-scope artifacts). None means ask on TTY,
+            skip on non-TTY.
         patch_claude_md: same tri-state, for the one-line ``@import`` edit
             in ``~/.claude/CLAUDE.md``. Separate from ``wire_agents`` so
             users can accept the artifacts while declining the import
             edit (and vice versa).
+        patch_agents_md: same tri-state, for inlining a delegation block
+            into the cwd's ``./AGENTS.md`` (the cross-tool convention used
+            by Codex / Cursor / Zed). Separate from ``patch_claude_md``
+            because user-scope and repo-scope patching are independent
+            consents.
 
     Returns a shell exit code: 0 on success, non-zero if the user
     explicitly aborted.
@@ -319,6 +325,7 @@ def run_init_wizard(
             interactive=interactive,
             wire_agents=wire_agents,
             patch_claude_md=patch_claude_md,
+            patch_agents_md=patch_agents_md,
         )
 
     _print_summary(outcomes)
@@ -661,8 +668,10 @@ def _maybe_wire_agents(
     interactive: bool,
     wire_agents: str | None,
     patch_claude_md: str | None,
+    patch_agents_md: str | None = None,
 ) -> bool:
-    """Offer to wire conductor into detected agent tools (Claude Code).
+    """Offer to wire conductor into detected agent tools (Claude Code
+    user-scope + repo-scope ``AGENTS.md``).
 
     Returns True if no wiring was attempted (skipped, declined, or no
     target detected) or if the wiring fully succeeded. Returns False if
@@ -671,30 +680,75 @@ def _maybe_wire_agents(
     the failure instead of silently exiting 0.
     """
     from conductor import __version__
-    from conductor.agent_wiring import detect, wire_claude_code
+    from conductor.agent_wiring import detect
 
     detection = detect()
 
-    if not detection.claude_detected:
+    claude_detected = detection.claude_detected
+    agents_md_detected = detection.agents_md_exists
+
+    # Decide the top-level wire-agents decision.
+    decision = wire_agents if wire_agents is not None else ("ask" if interactive else "no")
+    if decision == "no":
+        return True
+
+    # If nothing's detected AND the user didn't explicitly force a patch,
+    # short-circuit with an informational message. A user who explicitly
+    # passed --patch-agents-md=yes wants the file created even on a bare
+    # machine; don't silently swallow that intent.
+    user_forced_agents_md = patch_agents_md == "yes"
+    if not claude_detected and not agents_md_detected and not user_forced_agents_md:
         if interactive:
             click.echo("")
             click.echo("─" * 60)
             click.echo("Agent integration")
             click.echo("─" * 60)
             click.echo(
-                "  Claude Code not detected in this environment; nothing to wire."
+                "  No agent tools detected in this environment "
+                "(no ~/.claude/, no ./AGENTS.md)."
             )
             click.echo(
-                "  (re-run `conductor init` after installing Claude Code to enable "
-                "delegation)"
+                "  (re-run `conductor init` in a repo with AGENTS.md, or after "
+                "installing Claude Code)"
             )
             click.echo("")
         return True
 
-    # Decide whether to offer the prompt at all.
-    decision = wire_agents if wire_agents is not None else ("ask" if interactive else "no")
-    if decision == "no":
-        return True
+    claude_ok = True
+    if claude_detected:
+        claude_ok = _wire_claude_code_section(
+            detection=detection,
+            version=__version__,
+            interactive=interactive,
+            decision=decision,
+            patch_claude_md=patch_claude_md,
+        )
+
+    agents_ok = True
+    # AGENTS.md section runs if the file exists (natural fit) or the user
+    # explicitly forced creation via --patch-agents-md=yes.
+    if agents_md_detected or user_forced_agents_md:
+        agents_ok = _wire_agents_md_section(
+            detection=detection,
+            version=__version__,
+            interactive=interactive,
+            decision=decision,
+            patch_agents_md=patch_agents_md,
+        )
+
+    return claude_ok and agents_ok
+
+
+def _wire_claude_code_section(
+    *,
+    detection,
+    version: str,
+    interactive: bool,
+    decision: str,
+    patch_claude_md: str | None,
+) -> bool:
+    """Claude Code user-scope wiring (Slice A behavior, extracted)."""
+    from conductor.agent_wiring import wire_claude_code
 
     already_wired = len(detection.managed) > 0
     click.echo("")
@@ -758,7 +812,7 @@ def _maybe_wire_agents(
         do_patch = pcm == "yes"
 
     try:
-        report = wire_claude_code(__version__, patch_claude_md=do_patch)
+        report = wire_claude_code(version, patch_claude_md=do_patch)
     except Exception as exc:  # noqa: BLE001 — surface any unexpected failure
         click.echo(f"  ✗ wiring failed: {exc}")
         return False
@@ -789,6 +843,84 @@ def _maybe_wire_agents(
     # If every target file was skipped (all user-owned), treat that as a
     # failed wire — the user asked for integration and got nothing.
     return not (report.skipped and not report.written)
+
+
+def _wire_agents_md_section(
+    *,
+    detection,
+    version: str,
+    interactive: bool,
+    decision: str,
+    patch_agents_md: str | None,
+) -> bool:
+    """Repo-scope AGENTS.md sentinel-block injection.
+
+    Works regardless of Claude Code detection — Codex / Cursor / Zed users
+    who don't have Claude Code installed get the AGENTS.md patch on its
+    own. Idempotent: the inject helper replaces an existing conductor
+    block in place, so re-running bumps the version and never duplicates.
+    """
+    from conductor.agent_wiring import wire_agents_md
+
+    already_blocked = any(a.kind == "agents-md-import" for a in detection.managed)
+
+    click.echo("")
+    click.echo("─" * 60)
+    click.echo("Agent integration — AGENTS.md (repo-scoped)")
+    click.echo("─" * 60)
+    if detection.agents_md_exists:
+        if already_blocked:
+            click.echo(f"  {detection.agents_md} already has a conductor block.")
+            click.echo("  Re-running will refresh it to the current version.")
+        else:
+            click.echo(f"  {detection.agents_md} found — conductor can inject a")
+            click.echo("  delegation-guidance block (sentinel-bounded, fully removable).")
+    else:
+        click.echo(
+            f"  No AGENTS.md in {detection.agents_md.parent}. Conductor will create"
+        )
+        click.echo("  one containing only the delegation block — not recommended")
+        click.echo("  unless this repo is intended to use AGENTS.md going forward.")
+    click.echo("")
+
+    # `decision` is the top-level wire-agents decision. It gated us into
+    # this function (yes/ask). For the per-file patch, we honor
+    # `patch_agents_md` with the same tri-state semantics as patch_claude_md.
+    pam = (
+        patch_agents_md
+        if patch_agents_md is not None
+        else ("ask" if interactive else "no")
+    )
+    if pam == "ask":
+        verb = "refresh" if already_blocked else (
+            "patch" if detection.agents_md_exists else "create"
+        )
+        noun = "AGENTS.md"
+        choice = _prompt_menu(
+            options=[
+                ("y", f"yes — {verb} {noun}"),
+                ("n", "no — skip AGENTS.md"),
+            ],
+            default="y" if detection.agents_md_exists else "n",
+        )
+        if choice == "n":
+            return True
+        do_patch = True
+    else:
+        do_patch = pam == "yes"
+
+    if not do_patch:
+        return True
+
+    try:
+        report = wire_agents_md(version=version)
+    except Exception as exc:  # noqa: BLE001 — surface any unexpected failure
+        click.echo(f"  ✗ AGENTS.md patch failed: {exc}")
+        return False
+
+    click.echo(f"  ✓ patched {report.path} (sentinel block)")
+    click.echo("")
+    return True
 
 
 def _print_next_steps(outcomes: list[WizardOutcome]) -> None:

--- a/tests/test_agent_wiring.py
+++ b/tests/test_agent_wiring.py
@@ -14,11 +14,15 @@ from conductor import agent_wiring as aw
 
 @pytest.fixture(autouse=True)
 def _isolated_homes(tmp_path, monkeypatch):
-    """Point every path helper at tmp_path; remove any inherited which()."""
+    """Point every path helper at tmp_path; chdir so repo-scoped checks
+    (``./AGENTS.md``) look inside the tmp dir; remove inherited which()."""
     conductor_dir = tmp_path / ".conductor"
     claude_dir = tmp_path / ".claude"
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
     monkeypatch.setenv("CONDUCTOR_HOME", str(conductor_dir))
     monkeypatch.setenv("CLAUDE_HOME", str(claude_dir))
+    monkeypatch.chdir(repo_dir)
     # Default: claude CLI not on PATH unless a test explicitly patches it.
     monkeypatch.setattr("shutil.which", lambda _cmd: None)
     yield
@@ -237,6 +241,9 @@ def test_wire_claude_code_writes_all_artifacts():
         aw.claude_home() / "commands" / "conductor.md",
         aw.claude_home() / "agents" / "kimi-long-context.md",
         aw.claude_home() / "agents" / "gemini-web-search.md",
+        aw.claude_home() / "agents" / "codex-coding-agent.md",
+        aw.claude_home() / "agents" / "ollama-offline.md",
+        aw.claude_home() / "agents" / "conductor-auto.md",
     }
     assert set(report.written) == expected_paths
     for p in expected_paths:
@@ -369,3 +376,157 @@ def test_managed_path_stays_out_of_arbitrary_dirs(tmp_path):
     # The conductor_home dir now exists, but nothing else was created.
     assert aw.conductor_home().is_dir()
     assert not (tmp_path / "other").exists()
+
+
+# --------------------------------------------------------------------------- #
+# Slice B — AGENTS.md (repo-scoped) wire/unwire round-trip.
+# --------------------------------------------------------------------------- #
+
+
+def test_wire_agents_md_creates_new_file_with_block():
+    """No existing AGENTS.md → create one containing only the block."""
+    from pathlib import Path
+
+    report = aw.wire_agents_md(version="0.4.1")
+    assert report.patched is True
+    assert report.path == Path.cwd() / "AGENTS.md"
+    text = report.path.read_text(encoding="utf-8")
+    assert "conductor:begin v0.4.1" in text
+    assert "conductor:end" in text
+    assert "Conductor delegation" in text
+    # Fully removable via the sentinel markers.
+    assert aw._has_sentinel_block(report.path)
+
+
+def test_wire_agents_md_preserves_existing_user_content(tmp_path):
+    """Existing AGENTS.md → append block; don't touch user content."""
+    from pathlib import Path
+
+    path = Path.cwd() / "AGENTS.md"
+    path.write_text("# My project's reviewer guide\n\nDo X.\n", encoding="utf-8")
+    aw.wire_agents_md(version="0.4.1")
+    text = path.read_text(encoding="utf-8")
+    assert "# My project's reviewer guide" in text
+    assert "Do X." in text
+    assert "conductor:begin" in text
+    # User content comes BEFORE the block.
+    assert text.index("Do X.") < text.index("conductor:begin")
+
+
+def test_wire_agents_md_idempotent_on_rerun():
+    """Second wire replaces the existing block; only one block in the file."""
+    from pathlib import Path
+
+    path = Path.cwd() / "AGENTS.md"
+    path.write_text("# header\n", encoding="utf-8")
+    aw.wire_agents_md(version="0.4.1")
+    aw.wire_agents_md(version="0.4.2")
+    text = path.read_text(encoding="utf-8")
+    assert text.count("conductor:begin") == 1
+    assert "v0.4.2" in text
+    assert "v0.4.1" not in text
+    assert "# header" in text
+
+
+def test_detect_reports_agents_md_exists_and_wired(tmp_path):
+    """detect() in a repo whose AGENTS.md has our block → agents_md_exists
+    True, managed list includes an agents-md-import artifact."""
+    from pathlib import Path
+
+    aw.wire_agents_md(version="0.4.1")
+    d = aw.detect()
+    assert d.agents_md_exists is True
+    assert d.agents_md == Path.cwd() / "AGENTS.md"
+    assert any(a.kind == "agents-md-import" for a in d.managed)
+
+
+def test_detect_ignores_agents_md_without_conductor_block():
+    """AGENTS.md exists but has no conductor block → not claimed."""
+    from pathlib import Path
+
+    (Path.cwd() / "AGENTS.md").write_text("# My file\n", encoding="utf-8")
+    d = aw.detect()
+    assert d.agents_md_exists is True
+    assert not any(a.kind == "agents-md-import" for a in d.managed)
+
+
+def test_unwire_removes_agents_md_block_only():
+    """unwire() removes our block; user-written sections of AGENTS.md are
+    preserved, the file stays on disk if it still has user content."""
+    from pathlib import Path
+
+    path = Path.cwd() / "AGENTS.md"
+    path.write_text("# Reviewer guide\n\nRules.\n", encoding="utf-8")
+    aw.wire_agents_md(version="0.4.1")
+    assert "conductor:begin" in path.read_text(encoding="utf-8")
+
+    report = aw.unwire()
+    assert path in report.removed
+    text = path.read_text(encoding="utf-8")
+    assert "# Reviewer guide" in text
+    assert "Rules." in text
+    assert "conductor:begin" not in text
+
+
+def test_unwire_deletes_agents_md_when_block_was_only_content():
+    """AGENTS.md created solely to hold our block → deleted on unwire."""
+    from pathlib import Path
+
+    aw.wire_agents_md(version="0.4.1")
+    path = Path.cwd() / "AGENTS.md"
+    assert path.exists()
+
+    aw.unwire()
+    assert not path.exists()
+
+
+def test_wire_then_unwire_then_wire_agents_md_round_trip():
+    aw.wire_agents_md(version="0.4.1")
+    aw.unwire()
+    # Second wire succeeds from a clean state.
+    report = aw.wire_agents_md(version="0.4.2")
+    text = report.path.read_text(encoding="utf-8")
+    assert "conductor:begin v0.4.2" in text
+
+
+def test_wire_claude_code_writes_three_new_subagents():
+    """Slice B adds codex, ollama, and conductor-auto subagents."""
+    report = aw.wire_claude_code("0.4.1", patch_claude_md=False)
+    written_names = {p.name for p in report.written}
+    assert "codex-coding-agent.md" in written_names
+    assert "ollama-offline.md" in written_names
+    assert "conductor-auto.md" in written_names
+
+
+def test_new_subagents_have_managed_markers():
+    """Every subagent file written must carry a managed-by marker so
+    unwire can identify it; aliens at the path must not be overwritten."""
+    aw.wire_claude_code("0.4.1", patch_claude_md=False)
+    for name in ("codex-coding-agent", "ollama-offline", "conductor-auto"):
+        path = aw.claude_home() / "agents" / f"{name}.md"
+        assert aw.is_managed_file(path)
+        assert aw.read_managed_version(path) == "0.4.1"
+
+
+def test_wire_agents_md_honors_explicit_cwd_arg(tmp_path):
+    """wire_agents_md(cwd=X) writes into X, not Path.cwd()."""
+    target_dir = tmp_path / "other-repo"
+    target_dir.mkdir()
+    report = aw.wire_agents_md(target_dir, version="0.4.1")
+    assert report.path == target_dir / "AGENTS.md"
+    assert (target_dir / "AGENTS.md").exists()
+    # Default cwd path NOT touched.
+    assert not (tmp_path / "repo" / "AGENTS.md").exists()
+
+
+def test_unwire_with_explicit_cwd_only_touches_that_dir(tmp_path):
+    """unwire(cwd=X) removes X/AGENTS.md block but not Y/AGENTS.md in another dir."""
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    aw.wire_agents_md(other, version="0.4.1")
+    aw.wire_agents_md(version="0.4.1")  # also in default cwd
+
+    aw.unwire()  # cwd=None → defaults to Path.cwd() (the "repo" dir)
+    assert not (tmp_path / "repo" / "AGENTS.md").exists()
+    # The one in `other` is untouched because unwire() didn't look there.
+    assert "conductor:begin" in (other / "AGENTS.md").read_text(encoding="utf-8")

--- a/tests/test_cli_phase5.py
+++ b/tests/test_cli_phase5.py
@@ -13,9 +13,13 @@ from conductor.cli import main
 @pytest.fixture(autouse=True)
 def _isolated_agent_homes(tmp_path, monkeypatch):
     """doctor now reports agent-integration state; isolate so tests don't
-    depend on the developer's real ~/.claude/ or ~/.conductor/ contents."""
+    depend on the developer's real ~/.claude/, ~/.conductor/, or current
+    working directory's AGENTS.md."""
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
     monkeypatch.setenv("CONDUCTOR_HOME", str(tmp_path / ".conductor"))
     monkeypatch.setenv("CLAUDE_HOME", str(tmp_path / ".claude"))
+    monkeypatch.chdir(repo_dir)
     monkeypatch.setattr("shutil.which", lambda _cmd: None)
 
 
@@ -226,6 +230,33 @@ def test_doctor_reports_agent_integration_wired(mocker, monkeypatch, tmp_path):
     assert "guidance" in result.output.lower()
     assert "slash-command" in result.output.lower()
     assert "subagent" in result.output.lower()
+
+
+def test_doctor_reports_agents_md_when_present(mocker, monkeypatch, tmp_path):
+    _stub_all_unconfigured(mocker)
+    agents_md = tmp_path / "repo" / "AGENTS.md"
+    agents_md.write_text("# mine\n", encoding="utf-8")
+    for var in ("CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "OLLAMA_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+    result = CliRunner().invoke(main, ["doctor"])
+    assert result.exit_code == 0, result.output
+    assert "AGENTS.md" in result.output
+    assert "present but not wired" in result.output.lower()
+
+
+def test_doctor_reports_agents_md_wired(mocker, monkeypatch, tmp_path):
+    _stub_all_unconfigured(mocker)
+    for var in ("CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "OLLAMA_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+    from conductor import agent_wiring
+    agent_wiring.wire_agents_md(version="0.4.1")
+
+    result = CliRunner().invoke(main, ["doctor"])
+    assert result.exit_code == 0, result.output
+    assert "AGENTS.md" in result.output
+    assert "wired" in result.output.lower()
 
 
 def test_doctor_json_includes_agent_integration(mocker, monkeypatch, tmp_path):

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -14,10 +14,14 @@ from conductor.providers.kimi import (
 
 @pytest.fixture(autouse=True)
 def _isolated_agent_homes(tmp_path, monkeypatch):
-    """Isolate ~/.claude and ~/.conductor for every wizard test — otherwise
-    a wizard run could write into the developer's real home dir."""
+    """Isolate ~/.claude, ~/.conductor, and cwd for every wizard test —
+    otherwise a wizard run could write into the developer's real home
+    dir, and AGENTS.md detection would see the real repo's file."""
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
     monkeypatch.setenv("CONDUCTOR_HOME", str(tmp_path / ".conductor"))
     monkeypatch.setenv("CLAUDE_HOME", str(tmp_path / ".claude"))
+    monkeypatch.chdir(repo_dir)
     # Default: Claude CLI not on PATH. Tests that need it patch explicitly.
     monkeypatch.setattr("shutil.which", lambda _cmd: None)
 
@@ -507,6 +511,127 @@ def test_init_wiring_failure_exits_non_zero(mocker, tmp_path):
     assert "disk on fire" in result.output
 
 
+def test_init_patch_agents_md_yes_creates_block(mocker, tmp_path):
+    """--patch-agents-md=yes creates AGENTS.md with a conductor block, even
+    when no Claude Code is detected — the two wirings are independent."""
+    _stub_all_providers_unconfigured(mocker)
+    # Claude Code NOT detected; AGENTS.md doesn't exist yet.
+    result = CliRunner().invoke(
+        main,
+        [
+            "init",
+            "--yes",
+            "--wire-agents", "yes",
+            "--patch-agents-md", "yes",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    agents_md = tmp_path / "repo" / "AGENTS.md"
+    assert agents_md.exists()
+    text = agents_md.read_text(encoding="utf-8")
+    assert "conductor:begin" in text
+    assert "Conductor delegation" in text
+
+
+def test_init_patch_agents_md_preserves_user_content(mocker, tmp_path):
+    _stub_all_providers_unconfigured(mocker)
+    agents_md = tmp_path / "repo" / "AGENTS.md"
+    agents_md.write_text("# My own AGENTS.md\n\nDo Y.\n", encoding="utf-8")
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "init",
+            "--yes",
+            "--wire-agents", "yes",
+            "--patch-agents-md", "yes",
+            "--patch-claude-md", "no",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    text = agents_md.read_text(encoding="utf-8")
+    assert "# My own AGENTS.md" in text
+    assert "Do Y." in text
+    assert "conductor:begin" in text
+
+
+def test_init_patch_agents_md_no_leaves_file_alone(mocker, tmp_path):
+    _stub_all_providers_unconfigured(mocker)
+    agents_md = tmp_path / "repo" / "AGENTS.md"
+    original = "# My own AGENTS.md\n\nDo Y.\n"
+    agents_md.write_text(original, encoding="utf-8")
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "init",
+            "--yes",
+            "--wire-agents", "yes",
+            "--patch-agents-md", "no",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert agents_md.read_text(encoding="utf-8") == original
+
+
+def test_init_unwire_removes_agents_md_block(mocker, tmp_path):
+    """unwire in cwd with a wired AGENTS.md must strip the block; user
+    content above/below the block must be preserved."""
+    _stub_all_providers_unconfigured(mocker)
+    agents_md = tmp_path / "repo" / "AGENTS.md"
+    agents_md.write_text("# Reviewer guide\n", encoding="utf-8")
+
+    # Wire first.
+    wire = CliRunner().invoke(
+        main,
+        [
+            "init",
+            "--yes",
+            "--wire-agents", "yes",
+            "--patch-agents-md", "yes",
+            "--patch-claude-md", "no",
+        ],
+    )
+    assert wire.exit_code == 0, wire.output
+    assert "conductor:begin" in agents_md.read_text(encoding="utf-8")
+
+    # Unwire.
+    unwire = CliRunner().invoke(main, ["init", "--unwire"])
+    assert unwire.exit_code == 0, unwire.output
+    text = agents_md.read_text(encoding="utf-8")
+    assert "# Reviewer guide" in text
+    assert "conductor:begin" not in text
+
+
+def test_init_unwire_rejects_new_patch_agents_md_flag():
+    """--unwire must refuse combination with Slice B's --patch-agents-md."""
+    result = CliRunner().invoke(
+        main, ["init", "--unwire", "--patch-agents-md", "yes"]
+    )
+    assert result.exit_code == 2
+    assert "unwire" in result.output.lower()
+
+
+def test_init_patch_agents_md_yes_without_claude_still_works(mocker, tmp_path):
+    """Codex-only user (no Claude Code) must get AGENTS.md patched when
+    explicitly asked, even with no Claude Code detected."""
+    _stub_all_providers_unconfigured(mocker)
+    # Nothing at ~/.claude/; AGENTS.md also doesn't exist yet.
+    result = CliRunner().invoke(
+        main,
+        [
+            "init",
+            "--yes",
+            "--wire-agents", "yes",
+            "--patch-agents-md", "yes",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "repo" / "AGENTS.md").exists()
+    # Still shouldn't create ~/.claude artifacts.
+    assert not (tmp_path / ".claude" / "commands" / "conductor.md").exists()
+
+
 def test_init_wiring_all_user_owned_exits_non_zero(mocker, tmp_path):
     """If every target path is already a user-owned file, wire_claude_code
     skips them all — that's a failed wire from the user's perspective and
@@ -515,12 +640,19 @@ def test_init_wiring_all_user_owned_exits_non_zero(mocker, tmp_path):
     claude_dir = tmp_path / ".claude"
     (claude_dir / "agents").mkdir(parents=True)
     (claude_dir / "commands").mkdir(parents=True)
-    # Drop user-owned files at every managed path.
-    (claude_dir / "agents" / "kimi-long-context.md").write_text("# mine", encoding="utf-8")
-    (claude_dir / "agents" / "gemini-web-search.md").write_text("# mine", encoding="utf-8")
-    (claude_dir / "commands" / "conductor.md").write_text("# mine", encoding="utf-8")
+    # Drop user-owned files at EVERY managed path (Slice A + B).
+    user_owned = "# mine"
+    for relpath in (
+        "agents/kimi-long-context.md",
+        "agents/gemini-web-search.md",
+        "agents/codex-coding-agent.md",
+        "agents/ollama-offline.md",
+        "agents/conductor-auto.md",
+        "commands/conductor.md",
+    ):
+        (claude_dir / relpath).write_text(user_owned, encoding="utf-8")
     (tmp_path / ".conductor").mkdir()
-    (tmp_path / ".conductor" / "delegation-guidance.md").write_text("# mine", encoding="utf-8")
+    (tmp_path / ".conductor" / "delegation-guidance.md").write_text(user_owned, encoding="utf-8")
 
     result = CliRunner().invoke(
         main,


### PR DESCRIPTION
Build on Slice A (#11) by:

1. Wiring repo-scoped `./AGENTS.md` (the cross-tool convention used by
   Codex, Cursor, Zed, Aider). Unlike `~/.claude/CLAUDE.md` which
   supports `@`-imports, AGENTS.md has no import mechanism — so we
   inline a self-contained delegation block via the sentinel-block
   pattern from Slice A. User content outside the markers is preserved
   untouched. `conductor init --unwire` strips the block cleanly.

2. Shipping three more subagent definitions:
   - `codex-coding-agent` — routes heavy multi-file coding tasks to
     `conductor exec --with codex` with workspace-write sandbox.
   - `ollama-offline` — routes privacy-sensitive / offline work to a
     local Ollama model (references v0.3.3's qwen3.6:35b-a3b default).
   - `conductor-auto` — dispatches via the auto-router by task tags,
     for the "delegate but I don't know where" case.

3. Extending `conductor init`:
   - New tri-state `--patch-agents-md={yes,no,ask}` flag, parallel to
     `--patch-claude-md`. Independent consent for user-scope vs
     repo-scope.
   - A Codex-only user (no Claude Code detected) can now wire a repo's
     AGENTS.md without Claude Code artifacts being created.
   - `--unwire` now also strips the AGENTS.md block in cwd.

4. Extending `conductor doctor`:
   - Reports AGENTS.md state (not detected / present but not wired /
     wired with version) as a separate line from Claude Code state.
   - JSON payload gains `agents_md_path`, `agents_md_exists`,
     `agents_md_wired` keys.

Tests: 23 new (agent_wiring round-trips + wizard CLI flows + doctor
coverage), all isolate cwd via `monkeypatch.chdir(tmp_path/"repo")`
in addition to the Slice A home overrides. Full suite: 368 pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
