### PR TITLE
feat(v0.4.2): agent-wiring — Slice C (Gemini, Cursor, repo CLAUDE.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ hand-authoring any prompts:
   files present in your repo (`AGENTS.md`, `GEMINI.md`, `CLAUDE.md`).
   Existing user content is preserved — the block is bounded by
   `<!-- conductor:begin -->` markers.
-- Writes a Cursor rule at `.cursor/rules/conductor-delegation.md` if
+- Writes a Cursor rule at `.cursor/rules/conductor-delegation.mdc` if
   the directory exists.
 
 On a TTY you get a prompt per detected file (default yes); in CI use

--- a/README.md
+++ b/README.md
@@ -60,6 +60,33 @@ Deferred (see `autumn-garage/.cortex/plans/conductor-bootstrap.md`):
 - 1Password (`op run`) storage backend for `conductor init`.
 - Brew tap for `brew install autumngarage/conductor/conductor`.
 
+## Agent integration (v0.4.x)
+
+`conductor init` detects which agent tools you have installed (Claude Code,
+Codex, Cursor, Gemini CLI, Zed — anything that reads `AGENTS.md` /
+`CLAUDE.md` / `GEMINI.md`, or looks at `.cursor/rules/`) and offers to wire
+conductor in so those agents can delegate to other LLMs without you
+hand-authoring any prompts:
+
+- Writes `~/.conductor/delegation-guidance.md` (canonical guidance) and
+  appropriate user-scope artifacts (slash command + subagents for Claude Code).
+- Injects a self-contained delegation block into any agent instruction
+  files present in your repo (`AGENTS.md`, `GEMINI.md`, `CLAUDE.md`).
+  Existing user content is preserved — the block is bounded by
+  `<!-- conductor:begin -->` markers.
+- Writes a Cursor rule at `.cursor/rules/conductor-delegation.md` if
+  the directory exists.
+
+On a TTY you get a prompt per detected file (default yes); in CI use
+`--wire-agents=yes`, `--patch-claude-md=yes`, `--patch-agents-md=yes`,
+`--patch-gemini-md=yes`, `--patch-claude-md-repo=yes`, and `--wire-cursor=yes`
+to accept specific pieces without interaction. Everything conductor writes
+is marked `managed-by: conductor vX.Y.Z`; `conductor init --unwire` removes
+exactly those files and strips the sentinel blocks, preserving user content.
+
+Diagnose wiring state anytime with `conductor doctor` (JSON shape:
+`--json`).
+
 ## How Sentinel and Touchstone use it
 
 Once Conductor v0.1 ships, both consumers migrate from per-tool provider implementations to `conductor call` shell-outs. That migration lands in separate plans (`autumn-garage/.cortex/plans/sentinel-conductor-migration.md` and `…/touchstone-conductor-migration.md`) and is not part of v0.1.

--- a/src/conductor/_agent_templates.py
+++ b/src/conductor/_agent_templates.py
@@ -335,7 +335,7 @@ GEMINI_MD_BLOCK = AGENTS_MD_BLOCK  # Identical content today; split if divergent
 
 
 # --------------------------------------------------------------------------- #
-# Cursor rule file — fully-managed at <repo>/.cursor/rules/conductor-delegation.md.
+# Cursor rule file — fully-managed at <repo>/.cursor/rules/conductor-delegation.mdc.
 #
 # Cursor reads rule files with YAML frontmatter (description, globs,
 # alwaysApply). Unlike AGENTS.md / GEMINI.md, this file is conductor's

--- a/src/conductor/_agent_templates.py
+++ b/src/conductor/_agent_templates.py
@@ -292,10 +292,14 @@ Ollama is unavailable. Say so plainly and let the user decide —
 
 
 # --------------------------------------------------------------------------- #
-# AGENTS.md sentinel-block content — injected into repo-root AGENTS.md.
-# Must be self-contained: AGENTS.md has no @import mechanism, so the block
-# inlines the key info directly. References ~/.conductor/delegation-guidance.md
-# for the full version.
+# Repo-scope instruction-file blocks (AGENTS.md, GEMINI.md).
+#
+# Both files are markdown instruction files consumed by their respective
+# agents. Neither has an ``@`` import mechanism, so we inline a self-contained
+# block via the sentinel-block pattern. Content is identical — the audience
+# is any AI agent reading a project's instruction file — so AGENTS_MD_BLOCK
+# and GEMINI_MD_BLOCK share text. Separate constants exist so future
+# divergence (e.g., Gemini-specific phrasing) is a one-line change.
 # --------------------------------------------------------------------------- #
 
 AGENTS_MD_BLOCK = """## Conductor delegation
@@ -324,6 +328,42 @@ Providers commonly worth delegating to:
 Full delegation guidance (when to delegate, when not to, error handling):
 
     ~/.conductor/delegation-guidance.md
+"""
+
+
+GEMINI_MD_BLOCK = AGENTS_MD_BLOCK  # Identical content today; split if divergent.
+
+
+# --------------------------------------------------------------------------- #
+# Cursor rule file — fully-managed at <repo>/.cursor/rules/conductor-delegation.md.
+#
+# Cursor reads rule files with YAML frontmatter (description, globs,
+# alwaysApply). Unlike AGENTS.md / GEMINI.md, this file is conductor's
+# whole — the managed-by key sits in the frontmatter.
+# --------------------------------------------------------------------------- #
+
+CURSOR_RULE_BODY = """# Conductor delegation
+
+This project has [conductor](https://github.com/autumngarage/conductor)
+available — a CLI that dispatches work to other LLMs (Kimi, Gemini,
+Claude, Codex, Ollama) under a uniform interface.
+
+Use it when:
+- You want a cheap second opinion (`conductor call --with kimi --task "…"`).
+- You need fresh web information (`conductor call --with gemini --task "…"`).
+- You want to stay local / offline (`conductor call --with ollama --task "…"`).
+- You're not sure which provider fits — let the router pick:
+  `conductor call --auto --tags <tag1>,<tag2> --task "…"`.
+
+For longer running tool-using sessions:
+
+    conductor exec --with <provider> --tools Read,Edit,Bash \\
+        --sandbox workspace-write --task "…"
+
+Discover configured providers: `conductor list`.
+
+Full delegation guidance (when to delegate, when not to, error handling):
+`~/.conductor/delegation-guidance.md`
 """
 
 

--- a/src/conductor/agent_wiring.py
+++ b/src/conductor/agent_wiring.py
@@ -104,6 +104,12 @@ class Detection:
     conductor_home: Path
     agents_md: Path                  # ./AGENTS.md in cwd — may or may not exist
     agents_md_exists: bool
+    gemini_md: Path                  # ./GEMINI.md in cwd
+    gemini_md_exists: bool
+    claude_md_repo: Path              # ./CLAUDE.md in cwd (repo-scope)
+    claude_md_repo_exists: bool
+    cursor_rules_dir: Path            # ./.cursor/rules/ in cwd
+    cursor_rules_dir_exists: bool
     managed: tuple[AgentArtifact, ...] = field(default_factory=tuple)
 
     @property
@@ -116,9 +122,9 @@ def detect(*, cwd: Path | None = None) -> Detection:
     """Scan the current environment for Claude Code + any managed files.
 
     Args:
-        cwd: where to look for repo-scoped files like ``./AGENTS.md``.
-            Defaults to the process's current working directory; tests
-            pass an explicit ``tmp_path`` for isolation.
+        cwd: where to look for repo-scoped files (AGENTS.md, GEMINI.md,
+            CLAUDE.md, .cursor/rules/). Defaults to the process's cwd;
+            tests pass an explicit ``tmp_path`` for isolation.
     """
     ch = claude_home()
     ch_exists = ch.is_dir()
@@ -126,28 +132,23 @@ def detect(*, cwd: Path | None = None) -> Detection:
     user_md = ch / "CLAUDE.md"
     work_dir = cwd or Path.cwd()
     agents_md = work_dir / "AGENTS.md"
+    gemini_md = work_dir / "GEMINI.md"
+    claude_md_repo = work_dir / "CLAUDE.md"
+    cursor_rules_dir = work_dir / ".cursor" / "rules"
 
     managed: list[AgentArtifact] = []
-    for path, kind in _candidate_artifacts().items():
+
+    # Fully-managed files: read the managed-by marker; skip anything we
+    # didn't write.
+    for path, kind in _candidate_artifacts(cwd=work_dir).items():
         if not path.exists():
             continue
         version = read_managed_version(path)
-        if version is None and kind != "claude-md-import":
-            # A non-managed file at a managed path — leave alone, not ours.
-            continue
-        if kind == "claude-md-import":
-            # CLAUDE.md is user-owned; we own only the sentinel block.
-            has_block = _has_sentinel_block(path)
-            if not has_block:
-                continue
-            managed.append(
-                AgentArtifact(path=path, kind=kind, version=_block_version(path), owned=True)
-            )
+        if version is None:
             continue
         managed.append(AgentArtifact(path=path, kind=kind, version=version, owned=True))
 
-    # Sentinel-block paths in cwd (AGENTS.md). Same ownership model as
-    # claude-md-import: file is user-owned, only the block is conductor's.
+    # Sentinel-block files (user-owned; only our block is ours).
     for path, kind in _candidate_sentinel_paths(cwd=work_dir).items():
         if not path.exists() or not _has_sentinel_block(path):
             continue
@@ -164,16 +165,21 @@ def detect(*, cwd: Path | None = None) -> Detection:
         conductor_home=conductor_home(),
         agents_md=agents_md,
         agents_md_exists=agents_md.exists(),
+        gemini_md=gemini_md,
+        gemini_md_exists=gemini_md.exists(),
+        claude_md_repo=claude_md_repo,
+        claude_md_repo_exists=claude_md_repo.exists(),
+        cursor_rules_dir=cursor_rules_dir,
+        cursor_rules_dir_exists=cursor_rules_dir.is_dir(),
         managed=tuple(managed),
     )
 
 
-def _candidate_artifacts() -> dict[Path, str]:
-    """Fully-managed paths conductor may own (excludes user-owned files
-    that take only a sentinel-block injection — those go through
-    ``_candidate_sentinel_paths``)."""
+def _candidate_artifacts(*, cwd: Path | None = None) -> dict[Path, str]:
+    """Fully-managed paths conductor may own (written whole, deleted whole)."""
     ch = claude_home()
     conductor = conductor_home()
+    cwd = cwd or Path.cwd()
     return {
         conductor / "delegation-guidance.md": "guidance",
         ch / "commands" / "conductor.md": "slash-command",
@@ -182,20 +188,27 @@ def _candidate_artifacts() -> dict[Path, str]:
         ch / "agents" / "codex-coding-agent.md": "subagent",
         ch / "agents" / "ollama-offline.md": "subagent",
         ch / "agents" / "conductor-auto.md": "subagent",
-        ch / "CLAUDE.md": "claude-md-import",
+        cwd / ".cursor" / "rules" / "conductor-delegation.md": "cursor-rule",
     }
 
 
 def _candidate_sentinel_paths(*, cwd: Path | None = None) -> dict[Path, str]:
-    """User-owned files that conductor injects sentinel blocks into.
+    """User-owned files where conductor injects sentinel blocks only.
 
-    Currently:
-      - ``./AGENTS.md`` in the caller's cwd (Codex / Cursor / shared
-        convention). One file per repo; conductor doesn't walk the tree.
+    User-scope (cwd-independent):
+      - ``~/.claude/CLAUDE.md`` — Claude Code global config.
+
+    Repo-scope (under ``cwd``):
+      - ``./AGENTS.md``  — Codex / Cursor / Zed / shared convention.
+      - ``./GEMINI.md``  — Gemini CLI convention.
+      - ``./CLAUDE.md``  — Claude Code repo-scope config.
     """
     cwd = cwd or Path.cwd()
     return {
+        claude_home() / "CLAUDE.md": "claude-md-import",
         cwd / "AGENTS.md": "agents-md-import",
+        cwd / "GEMINI.md": "gemini-md-import",
+        cwd / "CLAUDE.md": "claude-md-repo-import",
     }
 
 
@@ -402,12 +415,10 @@ def unwire(*, cwd: Path | None = None) -> UnwireReport:
     """
     removed: list[Path] = []
     skipped: list[tuple[Path, str]] = []
-    for path, kind in _candidate_artifacts().items():
+
+    # Fully-managed files: delete whole, but only if marker still matches.
+    for path, _kind in _candidate_artifacts(cwd=cwd).items():
         if not path.exists():
-            continue
-        if kind == "claude-md-import":
-            if remove_sentinel_block(path):
-                removed.append(path)
             continue
         if not is_managed_file(path):
             skipped.append((path, "not conductor-managed (hand-edited?)"))
@@ -418,7 +429,7 @@ def unwire(*, cwd: Path | None = None) -> UnwireReport:
         except OSError as e:
             skipped.append((path, f"unlink failed: {e}"))
 
-    # Sentinel-block paths in cwd (AGENTS.md).
+    # Sentinel-block files (user-scope + repo-scope): strip the block only.
     for path, _kind in _candidate_sentinel_paths(cwd=cwd).items():
         if path.exists() and remove_sentinel_block(path):
             removed.append(path)
@@ -586,6 +597,64 @@ def wire_agents_md(cwd: Path | None = None, *, version: str) -> AgentsMdReport:
     cwd = cwd or Path.cwd()
     path = cwd / "AGENTS.md"
     inject_sentinel_block(path, templates.AGENTS_MD_BLOCK, version=version)
+    return AgentsMdReport(path=path, patched=True)
+
+
+def wire_gemini_md(cwd: Path | None = None, *, version: str) -> AgentsMdReport:
+    """Inject conductor's delegation block into ``./GEMINI.md`` in ``cwd``.
+
+    Gemini CLI reads GEMINI.md. Like AGENTS.md, no ``@`` import mechanism,
+    so the block is inlined with the sentinel pattern.
+    """
+    from conductor import _agent_templates as templates
+
+    cwd = cwd or Path.cwd()
+    path = cwd / "GEMINI.md"
+    inject_sentinel_block(path, templates.GEMINI_MD_BLOCK, version=version)
+    return AgentsMdReport(path=path, patched=True)
+
+
+def wire_claude_md_repo(cwd: Path | None = None, *, version: str) -> AgentsMdReport:
+    """Inject an ``@`` import line into repo-scope ``./CLAUDE.md``.
+
+    Parallel to the user-scope ``~/.claude/CLAUDE.md`` patch in
+    ``wire_claude_code(patch_claude_md=True)``. Same sentinel-block
+    mechanism; difference is only scope (per-repo vs global).
+    """
+    cwd = cwd or Path.cwd()
+    path = cwd / "CLAUDE.md"
+    import_line = f"@{conductor_home()}/delegation-guidance.md"
+    inject_sentinel_block(path, import_line, version=version)
+    return AgentsMdReport(path=path, patched=True)
+
+
+def wire_cursor(cwd: Path | None = None, *, version: str) -> AgentsMdReport:
+    """Write Cursor's conductor-delegation rule at
+    ``<cwd>/.cursor/rules/conductor-delegation.md``.
+
+    Unlike the markdown instruction files above, Cursor rules are
+    fully-managed — the file is conductor's whole (YAML frontmatter
+    with ``description`` / ``globs`` / ``alwaysApply`` keys plus a body
+    rendered from ``CURSOR_RULE_BODY``).
+    """
+    from conductor import _agent_templates as templates
+
+    cwd = cwd or Path.cwd()
+    path = cwd / ".cursor" / "rules" / "conductor-delegation.md"
+    write_managed_frontmatter(
+        path,
+        {
+            "description": (
+                "Use when delegating or routing tasks to a different LLM via "
+                "the conductor CLI — e.g., cheap second opinions, long-context "
+                "reads, web search, or offline runs."
+            ),
+            "globs": "",
+            "alwaysApply": "false",
+        },
+        templates.CURSOR_RULE_BODY,
+        version=version,
+    )
     return AgentsMdReport(path=path, patched=True)
 
 

--- a/src/conductor/agent_wiring.py
+++ b/src/conductor/agent_wiring.py
@@ -188,7 +188,7 @@ def _candidate_artifacts(*, cwd: Path | None = None) -> dict[Path, str]:
         ch / "agents" / "codex-coding-agent.md": "subagent",
         ch / "agents" / "ollama-offline.md": "subagent",
         ch / "agents" / "conductor-auto.md": "subagent",
-        cwd / ".cursor" / "rules" / "conductor-delegation.md": "cursor-rule",
+        cwd / ".cursor" / "rules" / "conductor-delegation.mdc": "cursor-rule",
     }
 
 
@@ -639,7 +639,7 @@ def wire_claude_md_repo(cwd: Path | None = None, *, version: str) -> AgentsMdRep
 
 def wire_cursor(cwd: Path | None = None, *, version: str) -> AgentsMdReport:
     """Write Cursor's conductor-delegation rule at
-    ``<cwd>/.cursor/rules/conductor-delegation.md``.
+    ``<cwd>/.cursor/rules/conductor-delegation.mdc``.
 
     Unlike the markdown instruction files above, Cursor rules are
     fully-managed — the file is conductor's whole (YAML frontmatter
@@ -649,7 +649,7 @@ def wire_cursor(cwd: Path | None = None, *, version: str) -> AgentsMdReport:
     from conductor import _agent_templates as templates
 
     cwd = cwd or Path.cwd()
-    path = cwd / ".cursor" / "rules" / "conductor-delegation.md"
+    path = cwd / ".cursor" / "rules" / "conductor-delegation.mdc"
     write_managed_frontmatter(
         path,
         {

--- a/src/conductor/agent_wiring.py
+++ b/src/conductor/agent_wiring.py
@@ -615,16 +615,25 @@ def wire_gemini_md(cwd: Path | None = None, *, version: str) -> AgentsMdReport:
 
 
 def wire_claude_md_repo(cwd: Path | None = None, *, version: str) -> AgentsMdReport:
-    """Inject an ``@`` import line into repo-scope ``./CLAUDE.md``.
+    """Inject an inline delegation block into repo-scope ``./CLAUDE.md``.
 
-    Parallel to the user-scope ``~/.claude/CLAUDE.md`` patch in
-    ``wire_claude_code(patch_claude_md=True)``. Same sentinel-block
-    mechanism; difference is only scope (per-repo vs global).
+    Uses inlined content (identical body to AGENTS.md / GEMINI.md), NOT the
+    ``@`` import used by ``wire_claude_code(patch_claude_md=True)`` for
+    user-scope ``~/.claude/CLAUDE.md``.
+
+    Why: repo-scope CLAUDE.md is typically tracked in git. An ``@``-import
+    pointing at ``/Users/<name>/.conductor/…`` would travel into every other
+    contributor's checkout and fail to resolve on their machine. Inline
+    content is self-contained markdown that works regardless of where
+    ``~/.conductor/`` lives on any given machine — the loss is that repos
+    don't auto-pick-up upstream guidance changes the way user-scope does,
+    but that's the correct trade for shared files.
     """
+    from conductor import _agent_templates as templates
+
     cwd = cwd or Path.cwd()
     path = cwd / "CLAUDE.md"
-    import_line = f"@{conductor_home()}/delegation-guidance.md"
-    inject_sentinel_block(path, import_line, version=version)
+    inject_sentinel_block(path, templates.AGENTS_MD_BLOCK, version=version)
     return AgentsMdReport(path=path, patched=True)
 
 

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -1230,7 +1230,7 @@ def doctor(as_json: bool) -> None:
     "wire_cursor_flag",
     type=click.Choice(["yes", "no", "ask"]),
     default=None,
-    help="Write a managed Cursor rule at .cursor/rules/conductor-delegation.md. "
+    help="Write a managed Cursor rule at .cursor/rules/conductor-delegation.mdc. "
     "Default: ask on TTY when .cursor/rules/ exists.",
 )
 @click.option(

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -1025,6 +1025,7 @@ def _agent_integration_payload() -> dict:
     from conductor.agent_wiring import detect
 
     detection = detect()
+    kinds = {a.kind for a in detection.managed}
     return {
         "claude_detected": detection.claude_detected,
         "claude_cli_on_path": detection.claude_cli_on_path,
@@ -1033,9 +1034,16 @@ def _agent_integration_payload() -> dict:
         "conductor_home": str(detection.conductor_home),
         "agents_md_path": str(detection.agents_md),
         "agents_md_exists": detection.agents_md_exists,
-        "agents_md_wired": any(
-            a.kind == "agents-md-import" for a in detection.managed
-        ),
+        "agents_md_wired": "agents-md-import" in kinds,
+        "gemini_md_path": str(detection.gemini_md),
+        "gemini_md_exists": detection.gemini_md_exists,
+        "gemini_md_wired": "gemini-md-import" in kinds,
+        "claude_md_repo_path": str(detection.claude_md_repo),
+        "claude_md_repo_exists": detection.claude_md_repo_exists,
+        "claude_md_repo_wired": "claude-md-repo-import" in kinds,
+        "cursor_rules_dir": str(detection.cursor_rules_dir),
+        "cursor_rules_dir_exists": detection.cursor_rules_dir_exists,
+        "cursor_rule_wired": "cursor-rule" in kinds,
         "managed_files": [
             {"path": str(a.path), "kind": a.kind, "version": a.version}
             for a in detection.managed
@@ -1091,32 +1099,61 @@ def doctor(as_json: bool) -> None:
     click.echo("Agent integration:")
     ai = payload["agent_integration"]
 
-    claude_managed = [f for f in ai["managed_files"] if f["kind"] != "agents-md-import"]
+    _repo_kinds = {
+        "agents-md-import", "gemini-md-import",
+        "claude-md-repo-import", "cursor-rule",
+    }
+    user_managed = [f for f in ai["managed_files"] if f["kind"] not in _repo_kinds]
     if not ai["claude_detected"]:
-        click.echo("  Claude Code: not detected")
-    elif not claude_managed:
-        click.echo("  Claude Code: detected, not wired (run `conductor init`)")
+        click.echo("  Claude Code:  not detected")
+    elif not user_managed:
+        click.echo("  Claude Code:  detected, not wired (run `conductor init`)")
     else:
-        click.echo(f"  Claude Code: wired — {len(claude_managed)} managed files")
-        for f in claude_managed:
+        click.echo(f"  Claude Code:  wired — {len(user_managed)} user-scope files")
+        for f in user_managed:
             version_note = f" v{f['version']}" if f["version"] else ""
             click.echo(f"    {f['kind']:<18}  {f['path']}{version_note}")
 
-    if not ai["agents_md_exists"] and not ai["agents_md_wired"]:
-        click.echo("  AGENTS.md:   no AGENTS.md in current directory")
-    elif ai["agents_md_wired"]:
-        block = next(
-            (f for f in ai["managed_files"] if f["kind"] == "agents-md-import"),
+    def _repo_line(
+        label: str,
+        file_kind: str,
+        exists_key: str,
+        wired_key: str,
+        path_key: str,
+    ) -> None:
+        if not ai[exists_key] and not ai[wired_key]:
+            click.echo(f"  {label}  no {label.split(':')[0].strip()} in current directory")
+            return
+        if ai[wired_key]:
+            entry = next(
+                (f for f in ai["managed_files"] if f["kind"] == file_kind),
+                None,
+            )
+            version_note = f" v{entry['version']}" if entry and entry["version"] else ""
+            click.echo(f"  {label}  wired — {ai[path_key]}{version_note}")
+        else:
+            click.echo(f"  {label}  present but not wired — {ai[path_key]}")
+
+    _repo_line("AGENTS.md:   ", "agents-md-import",
+               "agents_md_exists", "agents_md_wired", "agents_md_path")
+    _repo_line("GEMINI.md:   ", "gemini-md-import",
+               "gemini_md_exists", "gemini_md_wired", "gemini_md_path")
+    _repo_line("CLAUDE.md:   ", "claude-md-repo-import",
+               "claude_md_repo_exists", "claude_md_repo_wired", "claude_md_repo_path")
+
+    # Cursor is a fully-managed file inside a conventional directory, not a
+    # sentinel-block patch. Its detection story is "does .cursor/rules/ exist".
+    if not ai["cursor_rules_dir_exists"] and not ai["cursor_rule_wired"]:
+        click.echo("  Cursor:       no .cursor/rules/ in current directory")
+    elif ai["cursor_rule_wired"]:
+        entry = next(
+            (f for f in ai["managed_files"] if f["kind"] == "cursor-rule"),
             None,
         )
-        version_note = f" v{block['version']}" if block and block["version"] else ""
-        click.echo(
-            f"  AGENTS.md:   wired — {ai['agents_md_path']}{version_note}"
-        )
+        version_note = f" v{entry['version']}" if entry and entry["version"] else ""
+        click.echo(f"  Cursor:       rule wired{version_note}")
     else:
-        click.echo(
-            f"  AGENTS.md:   present but not wired — {ai['agents_md_path']}"
-        )
+        click.echo("  Cursor:       .cursor/rules/ present but not wired")
 
     click.echo("")
     click.echo("Next steps:")
@@ -1171,15 +1208,37 @@ def doctor(as_json: bool) -> None:
     "--patch-agents-md",
     type=click.Choice(["yes", "no", "ask"]),
     default=None,
-    help="Inject a conductor delegation block into ./AGENTS.md (repo-scoped). "
-    "Default: ask on TTY when the file exists, skip otherwise.",
+    help="Inject a conductor delegation block into ./AGENTS.md "
+    "(Codex / Cursor / Zed convention). Default: ask on TTY when present.",
+)
+@click.option(
+    "--patch-gemini-md",
+    type=click.Choice(["yes", "no", "ask"]),
+    default=None,
+    help="Inject a conductor delegation block into ./GEMINI.md "
+    "(Gemini CLI convention). Default: ask on TTY when present.",
+)
+@click.option(
+    "--patch-claude-md-repo",
+    type=click.Choice(["yes", "no", "ask"]),
+    default=None,
+    help="Inject @import into repo-scope ./CLAUDE.md (parallel to "
+    "--patch-claude-md for user-scope). Default: ask on TTY when present.",
+)
+@click.option(
+    "--wire-cursor",
+    "wire_cursor_flag",
+    type=click.Choice(["yes", "no", "ask"]),
+    default=None,
+    help="Write a managed Cursor rule at .cursor/rules/conductor-delegation.md. "
+    "Default: ask on TTY when .cursor/rules/ exists.",
 )
 @click.option(
     "--unwire",
     is_flag=True,
     default=False,
     help="Remove every conductor-managed agent integration artifact "
-    "(user-scope + repo-scope AGENTS.md block) and exit.",
+    "(user-scope + repo-scope sentinel blocks + Cursor rule) and exit.",
 )
 def init(
     accept_defaults: bool,
@@ -1188,11 +1247,18 @@ def init(
     wire_agents: str | None,
     patch_claude_md: str | None,
     patch_agents_md: str | None,
+    patch_gemini_md: str | None,
+    patch_claude_md_repo: str | None,
+    wire_cursor_flag: str | None,
     unwire: bool,
 ) -> None:
     """Interactively configure Conductor for first use."""
     if unwire:
-        if only or remaining or wire_agents or patch_claude_md or patch_agents_md:
+        wiring_flags = (
+            wire_agents, patch_claude_md, patch_agents_md,
+            patch_gemini_md, patch_claude_md_repo, wire_cursor_flag,
+        )
+        if only or remaining or any(f is not None for f in wiring_flags):
             raise click.UsageError(
                 "--unwire can't be combined with provider or wiring flags."
             )
@@ -1211,6 +1277,9 @@ def init(
         wire_agents=wire_agents,
         patch_claude_md=patch_claude_md,
         patch_agents_md=patch_agents_md,
+        patch_gemini_md=patch_gemini_md,
+        patch_claude_md_repo=patch_claude_md_repo,
+        wire_cursor_flag=wire_cursor_flag,
     )
     sys.exit(exit_code)
 

--- a/src/conductor/wizard.py
+++ b/src/conductor/wizard.py
@@ -212,6 +212,9 @@ def run_init_wizard(
     wire_agents: str | None = None,
     patch_claude_md: str | None = None,
     patch_agents_md: str | None = None,
+    patch_gemini_md: str | None = None,
+    patch_claude_md_repo: str | None = None,
+    wire_cursor_flag: str | None = None,
 ) -> int:
     """Walk the user through configuring every provider that needs it.
 
@@ -326,6 +329,9 @@ def run_init_wizard(
             wire_agents=wire_agents,
             patch_claude_md=patch_claude_md,
             patch_agents_md=patch_agents_md,
+            patch_gemini_md=patch_gemini_md,
+            patch_claude_md_repo=patch_claude_md_repo,
+            wire_cursor_flag=wire_cursor_flag,
         )
 
     _print_summary(outcomes)
@@ -669,6 +675,9 @@ def _maybe_wire_agents(
     wire_agents: str | None,
     patch_claude_md: str | None,
     patch_agents_md: str | None = None,
+    patch_gemini_md: str | None = None,
+    patch_claude_md_repo: str | None = None,
+    wire_cursor_flag: str | None = None,
 ) -> bool:
     """Offer to wire conductor into detected agent tools (Claude Code
     user-scope + repo-scope ``AGENTS.md``).
@@ -685,19 +694,25 @@ def _maybe_wire_agents(
     detection = detect()
 
     claude_detected = detection.claude_detected
-    agents_md_detected = detection.agents_md_exists
 
     # Decide the top-level wire-agents decision.
     decision = wire_agents if wire_agents is not None else ("ask" if interactive else "no")
     if decision == "no":
         return True
 
-    # If nothing's detected AND the user didn't explicitly force a patch,
-    # short-circuit with an informational message. A user who explicitly
-    # passed --patch-agents-md=yes wants the file created even on a bare
-    # machine; don't silently swallow that intent.
-    user_forced_agents_md = patch_agents_md == "yes"
-    if not claude_detected and not agents_md_detected and not user_forced_agents_md:
+    # Per-section "this section runs" flags. A section runs if its artifact
+    # is detected OR the user explicitly forced creation via a flag.
+    run_agents_md = detection.agents_md_exists or patch_agents_md == "yes"
+    run_gemini_md = detection.gemini_md_exists or patch_gemini_md == "yes"
+    run_claude_md_repo = (
+        detection.claude_md_repo_exists or patch_claude_md_repo == "yes"
+    )
+    run_cursor = detection.cursor_rules_dir_exists or wire_cursor_flag == "yes"
+    any_detected_or_forced = any(
+        (claude_detected, run_agents_md, run_gemini_md, run_claude_md_repo, run_cursor)
+    )
+
+    if not any_detected_or_forced:
         if interactive:
             click.echo("")
             click.echo("─" * 60)
@@ -705,38 +720,68 @@ def _maybe_wire_agents(
             click.echo("─" * 60)
             click.echo(
                 "  No agent tools detected in this environment "
-                "(no ~/.claude/, no ./AGENTS.md)."
+                "(no ~/.claude/, no ./AGENTS.md, no ./GEMINI.md, no ./.cursor/)."
             )
             click.echo(
-                "  (re-run `conductor init` in a repo with AGENTS.md, or after "
-                "installing Claude Code)"
+                "  (re-run `conductor init` in a repo with one of the above, "
+                "or after installing Claude Code)"
             )
             click.echo("")
         return True
 
-    claude_ok = True
+    results: list[bool] = []
     if claude_detected:
-        claude_ok = _wire_claude_code_section(
-            detection=detection,
-            version=__version__,
-            interactive=interactive,
-            decision=decision,
-            patch_claude_md=patch_claude_md,
+        results.append(
+            _wire_claude_code_section(
+                detection=detection,
+                version=__version__,
+                interactive=interactive,
+                decision=decision,
+                patch_claude_md=patch_claude_md,
+            )
+        )
+    if run_agents_md:
+        results.append(
+            _wire_agents_md_section(
+                detection=detection,
+                version=__version__,
+                interactive=interactive,
+                decision=decision,
+                patch_agents_md=patch_agents_md,
+            )
+        )
+    if run_gemini_md:
+        results.append(
+            _wire_gemini_md_section(
+                detection=detection,
+                version=__version__,
+                interactive=interactive,
+                decision=decision,
+                patch_gemini_md=patch_gemini_md,
+            )
+        )
+    if run_claude_md_repo:
+        results.append(
+            _wire_claude_md_repo_section(
+                detection=detection,
+                version=__version__,
+                interactive=interactive,
+                decision=decision,
+                patch_claude_md_repo=patch_claude_md_repo,
+            )
+        )
+    if run_cursor:
+        results.append(
+            _wire_cursor_section(
+                detection=detection,
+                version=__version__,
+                interactive=interactive,
+                decision=decision,
+                wire_cursor_flag=wire_cursor_flag,
+            )
         )
 
-    agents_ok = True
-    # AGENTS.md section runs if the file exists (natural fit) or the user
-    # explicitly forced creation via --patch-agents-md=yes.
-    if agents_md_detected or user_forced_agents_md:
-        agents_ok = _wire_agents_md_section(
-            detection=detection,
-            version=__version__,
-            interactive=interactive,
-            decision=decision,
-            patch_agents_md=patch_agents_md,
-        )
-
-    return claude_ok and agents_ok
+    return all(results)
 
 
 def _wire_claude_code_section(
@@ -845,63 +890,54 @@ def _wire_claude_code_section(
     return not (report.skipped and not report.written)
 
 
-def _wire_agents_md_section(
+def _wire_sentinel_section(
     *,
-    detection,
+    title: str,
+    filename: str,
+    path,
+    path_exists: bool,
+    already_wired: bool,
+    wire_fn,
     version: str,
     interactive: bool,
-    decision: str,
-    patch_agents_md: str | None,
+    patch_flag: str | None,
 ) -> bool:
-    """Repo-scope AGENTS.md sentinel-block injection.
+    """Generic prompt + wire for any sentinel-block-style patch.
 
-    Works regardless of Claude Code detection — Codex / Cursor / Zed users
-    who don't have Claude Code installed get the AGENTS.md patch on its
-    own. Idempotent: the inject helper replaces an existing conductor
-    block in place, so re-running bumps the version and never duplicates.
+    Shared by AGENTS.md, GEMINI.md, and repo-scope CLAUDE.md — all three
+    are user-owned files where conductor owns only the sentinel block.
+    Idempotent: the underlying ``inject_sentinel_block`` helper replaces
+    an existing conductor block in place, so re-running bumps the
+    version and never duplicates.
     """
-    from conductor.agent_wiring import wire_agents_md
-
-    already_blocked = any(a.kind == "agents-md-import" for a in detection.managed)
-
     click.echo("")
     click.echo("─" * 60)
-    click.echo("Agent integration — AGENTS.md (repo-scoped)")
+    click.echo(f"Agent integration — {title}")
     click.echo("─" * 60)
-    if detection.agents_md_exists:
-        if already_blocked:
-            click.echo(f"  {detection.agents_md} already has a conductor block.")
+    if path_exists:
+        if already_wired:
+            click.echo(f"  {path} already has a conductor block.")
             click.echo("  Re-running will refresh it to the current version.")
         else:
-            click.echo(f"  {detection.agents_md} found — conductor can inject a")
-            click.echo("  delegation-guidance block (sentinel-bounded, fully removable).")
+            click.echo(f"  {path} found — conductor can inject a")
+            click.echo("  delegation block (sentinel-bounded, fully removable).")
     else:
         click.echo(
-            f"  No AGENTS.md in {detection.agents_md.parent}. Conductor will create"
+            f"  No {filename} in {path.parent}. Conductor can create one"
         )
-        click.echo("  one containing only the delegation block — not recommended")
-        click.echo("  unless this repo is intended to use AGENTS.md going forward.")
+        click.echo("  containing only the delegation block — not recommended")
+        click.echo(f"  unless this repo is intended to use {filename} going forward.")
     click.echo("")
 
-    # `decision` is the top-level wire-agents decision. It gated us into
-    # this function (yes/ask). For the per-file patch, we honor
-    # `patch_agents_md` with the same tri-state semantics as patch_claude_md.
-    pam = (
-        patch_agents_md
-        if patch_agents_md is not None
-        else ("ask" if interactive else "no")
-    )
+    pam = patch_flag if patch_flag is not None else ("ask" if interactive else "no")
     if pam == "ask":
-        verb = "refresh" if already_blocked else (
-            "patch" if detection.agents_md_exists else "create"
-        )
-        noun = "AGENTS.md"
+        verb = "refresh" if already_wired else ("patch" if path_exists else "create")
         choice = _prompt_menu(
             options=[
-                ("y", f"yes — {verb} {noun}"),
-                ("n", "no — skip AGENTS.md"),
+                ("y", f"yes — {verb} {filename}"),
+                ("n", f"no — skip {filename}"),
             ],
-            default="y" if detection.agents_md_exists else "n",
+            default="y" if path_exists else "n",
         )
         if choice == "n":
             return True
@@ -913,12 +949,159 @@ def _wire_agents_md_section(
         return True
 
     try:
-        report = wire_agents_md(version=version)
+        report = wire_fn(version=version)
     except Exception as exc:  # noqa: BLE001 — surface any unexpected failure
-        click.echo(f"  ✗ AGENTS.md patch failed: {exc}")
+        click.echo(f"  ✗ {filename} patch failed: {exc}")
         return False
 
     click.echo(f"  ✓ patched {report.path} (sentinel block)")
+    click.echo("")
+    return True
+
+
+def _wire_agents_md_section(
+    *,
+    detection,
+    version: str,
+    interactive: bool,
+    decision: str,
+    patch_agents_md: str | None,
+) -> bool:
+    """Repo-scope AGENTS.md — Codex / Cursor / Zed shared convention."""
+    from conductor.agent_wiring import wire_agents_md
+
+    already = any(a.kind == "agents-md-import" for a in detection.managed)
+    return _wire_sentinel_section(
+        title="AGENTS.md (repo-scoped)",
+        filename="AGENTS.md",
+        path=detection.agents_md,
+        path_exists=detection.agents_md_exists,
+        already_wired=already,
+        wire_fn=wire_agents_md,
+        version=version,
+        interactive=interactive,
+        patch_flag=patch_agents_md,
+    )
+
+
+def _wire_gemini_md_section(
+    *,
+    detection,
+    version: str,
+    interactive: bool,
+    decision: str,
+    patch_gemini_md: str | None,
+) -> bool:
+    """Repo-scope GEMINI.md — Gemini CLI convention."""
+    from conductor.agent_wiring import wire_gemini_md
+
+    already = any(a.kind == "gemini-md-import" for a in detection.managed)
+    return _wire_sentinel_section(
+        title="GEMINI.md (repo-scoped)",
+        filename="GEMINI.md",
+        path=detection.gemini_md,
+        path_exists=detection.gemini_md_exists,
+        already_wired=already,
+        wire_fn=wire_gemini_md,
+        version=version,
+        interactive=interactive,
+        patch_flag=patch_gemini_md,
+    )
+
+
+def _wire_claude_md_repo_section(
+    *,
+    detection,
+    version: str,
+    interactive: bool,
+    decision: str,
+    patch_claude_md_repo: str | None,
+) -> bool:
+    """Repo-scope ./CLAUDE.md — parallel to user-scope ~/.claude/CLAUDE.md."""
+    from conductor.agent_wiring import wire_claude_md_repo
+
+    already = any(a.kind == "claude-md-repo-import" for a in detection.managed)
+    return _wire_sentinel_section(
+        title="CLAUDE.md (repo-scoped)",
+        filename="CLAUDE.md",
+        path=detection.claude_md_repo,
+        path_exists=detection.claude_md_repo_exists,
+        already_wired=already,
+        wire_fn=wire_claude_md_repo,
+        version=version,
+        interactive=interactive,
+        patch_flag=patch_claude_md_repo,
+    )
+
+
+def _wire_cursor_section(
+    *,
+    detection,
+    version: str,
+    interactive: bool,
+    decision: str,
+    wire_cursor_flag: str | None,
+) -> bool:
+    """Cursor rule at <repo>/.cursor/rules/conductor-delegation.md.
+
+    Unlike the sentinel-block cases, this is a fully-managed file —
+    conductor owns it whole. ``unwire`` deletes it.
+    """
+    from conductor.agent_wiring import wire_cursor
+
+    already_written = any(a.kind == "cursor-rule" for a in detection.managed)
+
+    click.echo("")
+    click.echo("─" * 60)
+    click.echo("Agent integration — Cursor rule (repo-scoped)")
+    click.echo("─" * 60)
+    rule_path = detection.cursor_rules_dir / "conductor-delegation.md"
+    if detection.cursor_rules_dir_exists:
+        if already_written:
+            click.echo(f"  {rule_path} already exists (managed by conductor).")
+            click.echo("  Re-running will refresh it to the current version.")
+        else:
+            click.echo("  Cursor rules dir found — conductor can write")
+            click.echo(f"    {rule_path}")
+            click.echo("  as a fully-managed rule (removable via --unwire).")
+    else:
+        click.echo(
+            f"  No .cursor/rules/ dir in {detection.cursor_rules_dir.parent}."
+        )
+        click.echo("  Conductor can create it and write the delegation rule —")
+        click.echo("  only useful if this repo is intended to use Cursor.")
+    click.echo("")
+
+    wc = (
+        wire_cursor_flag
+        if wire_cursor_flag is not None
+        else ("ask" if interactive else "no")
+    )
+    if wc == "ask":
+        verb = "refresh" if already_written else "write"
+        choice = _prompt_menu(
+            options=[
+                ("y", f"yes — {verb} the Cursor rule"),
+                ("n", "no — skip Cursor"),
+            ],
+            default="y" if detection.cursor_rules_dir_exists else "n",
+        )
+        if choice == "n":
+            return True
+        do_write = True
+    else:
+        do_write = wc == "yes"
+
+    if not do_write:
+        return True
+
+    try:
+        report = wire_cursor(version=version)
+    except Exception as exc:  # noqa: BLE001 — surface any unexpected failure
+        click.echo(f"  ✗ Cursor rule write failed: {exc}")
+        return False
+
+    click.echo(f"  ✓ wrote {report.path} (managed file)")
     click.echo("")
     return True
 

--- a/src/conductor/wizard.py
+++ b/src/conductor/wizard.py
@@ -1042,7 +1042,7 @@ def _wire_cursor_section(
     decision: str,
     wire_cursor_flag: str | None,
 ) -> bool:
-    """Cursor rule at <repo>/.cursor/rules/conductor-delegation.md.
+    """Cursor rule at <repo>/.cursor/rules/conductor-delegation.mdc.
 
     Unlike the sentinel-block cases, this is a fully-managed file —
     conductor owns it whole. ``unwire`` deletes it.
@@ -1055,7 +1055,7 @@ def _wire_cursor_section(
     click.echo("─" * 60)
     click.echo("Agent integration — Cursor rule (repo-scoped)")
     click.echo("─" * 60)
-    rule_path = detection.cursor_rules_dir / "conductor-delegation.md"
+    rule_path = detection.cursor_rules_dir / "conductor-delegation.mdc"
     if detection.cursor_rules_dir_exists:
         if already_written:
             click.echo(f"  {rule_path} already exists (managed by conductor).")

--- a/tests/test_agent_wiring.py
+++ b/tests/test_agent_wiring.py
@@ -598,7 +598,7 @@ def test_wire_cursor_writes_managed_rule_file():
     from pathlib import Path
 
     report = aw.wire_cursor(version="0.4.2")
-    path = Path.cwd() / ".cursor" / "rules" / "conductor-delegation.md"
+    path = Path.cwd() / ".cursor" / "rules" / "conductor-delegation.mdc"
     assert report.path == path
     text = path.read_text(encoding="utf-8")
     assert text.startswith("---\n")
@@ -614,7 +614,7 @@ def test_wire_cursor_creates_nested_dirs():
 
     aw.wire_cursor(version="0.4.2")
     assert (Path.cwd() / ".cursor" / "rules").is_dir()
-    assert (Path.cwd() / ".cursor" / "rules" / "conductor-delegation.md").exists()
+    assert (Path.cwd() / ".cursor" / "rules" / "conductor-delegation.mdc").exists()
 
 
 def test_detect_picks_up_all_slice_c_artifacts():
@@ -661,7 +661,7 @@ def test_unwire_removes_every_slice_c_artifact(tmp_path):
     assert not (tmp_path / "repo" / "GEMINI.md").exists()
     assert not (tmp_path / "repo" / "CLAUDE.md").exists()
     # Cursor rule was fully-managed → deleted.
-    assert not (tmp_path / "repo" / ".cursor" / "rules" / "conductor-delegation.md").exists()
+    assert not (tmp_path / "repo" / ".cursor" / "rules" / "conductor-delegation.mdc").exists()
 
 
 def test_unwire_preserves_user_content_in_all_sentinel_files(tmp_path):
@@ -684,7 +684,7 @@ def test_unwire_preserves_user_content_in_all_sentinel_files(tmp_path):
 def test_cursor_rule_refuses_to_overwrite_user_owned_file(tmp_path):
     """If the user already has a rule at the managed path, wire_cursor
     must surface a UserOwnedFileError rather than overwriting."""
-    rule_path = tmp_path / "repo" / ".cursor" / "rules" / "conductor-delegation.md"
+    rule_path = tmp_path / "repo" / ".cursor" / "rules" / "conductor-delegation.mdc"
     rule_path.parent.mkdir(parents=True)
     rule_path.write_text("# my hand-written rule\n", encoding="utf-8")
 

--- a/tests/test_agent_wiring.py
+++ b/tests/test_agent_wiring.py
@@ -560,8 +560,13 @@ def test_wire_gemini_md_preserves_user_content():
     assert "conductor:begin" in text
 
 
-def test_wire_claude_md_repo_injects_import_line():
-    """Repo-scope CLAUDE.md gets the @-import line (not inline block)."""
+def test_wire_claude_md_repo_injects_inline_block():
+    """Repo-scope CLAUDE.md gets the INLINE block (not an @-import).
+
+    Repo CLAUDE.md is typically tracked in git; baking an
+    ``@/Users/<name>/.conductor/...`` absolute path into it would break on
+    every other contributor's checkout. So it must be self-contained.
+    """
     from pathlib import Path
 
     report = aw.wire_claude_md_repo(version="0.4.2")
@@ -569,7 +574,11 @@ def test_wire_claude_md_repo_injects_import_line():
     assert report.path == path
     text = path.read_text(encoding="utf-8")
     assert "conductor:begin v0.4.2" in text
-    assert "@" in text and "delegation-guidance.md" in text
+    assert "Conductor delegation" in text
+    # Must NOT contain an absolute-path @-import — that would be
+    # machine-local and break for other contributors on git pull.
+    home_prefix = str(aw.conductor_home())
+    assert f"@{home_prefix}" not in text
 
 
 def test_wire_claude_md_repo_vs_user_scope_independent(tmp_path):

--- a/tests/test_agent_wiring.py
+++ b/tests/test_agent_wiring.py
@@ -530,3 +530,170 @@ def test_unwire_with_explicit_cwd_only_touches_that_dir(tmp_path):
     assert not (tmp_path / "repo" / "AGENTS.md").exists()
     # The one in `other` is untouched because unwire() didn't look there.
     assert "conductor:begin" in (other / "AGENTS.md").read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------------------- #
+# Slice C — GEMINI.md / repo CLAUDE.md / Cursor rule.
+# --------------------------------------------------------------------------- #
+
+
+def test_wire_gemini_md_injects_block():
+    from pathlib import Path
+
+    report = aw.wire_gemini_md(version="0.4.2")
+    path = Path.cwd() / "GEMINI.md"
+    assert report.path == path
+    text = path.read_text(encoding="utf-8")
+    assert "conductor:begin v0.4.2" in text
+    assert "Conductor delegation" in text
+
+
+def test_wire_gemini_md_preserves_user_content():
+    from pathlib import Path
+
+    path = Path.cwd() / "GEMINI.md"
+    path.write_text("# My Gemini rules\n\nDo Z.\n", encoding="utf-8")
+    aw.wire_gemini_md(version="0.4.2")
+    text = path.read_text(encoding="utf-8")
+    assert "# My Gemini rules" in text
+    assert "Do Z." in text
+    assert "conductor:begin" in text
+
+
+def test_wire_claude_md_repo_injects_import_line():
+    """Repo-scope CLAUDE.md gets the @-import line (not inline block)."""
+    from pathlib import Path
+
+    report = aw.wire_claude_md_repo(version="0.4.2")
+    path = Path.cwd() / "CLAUDE.md"
+    assert report.path == path
+    text = path.read_text(encoding="utf-8")
+    assert "conductor:begin v0.4.2" in text
+    assert "@" in text and "delegation-guidance.md" in text
+
+
+def test_wire_claude_md_repo_vs_user_scope_independent(tmp_path):
+    """User-scope ~/.claude/CLAUDE.md and repo ./CLAUDE.md are different
+    files with independent sentinel blocks — neither wire clobbers the other."""
+    aw.wire_claude_code("0.4.2", patch_claude_md=True)  # user-scope
+    aw.wire_claude_md_repo(version="0.4.2")              # repo-scope
+
+    user_path = aw.claude_home() / "CLAUDE.md"
+    repo_path = tmp_path / "repo" / "CLAUDE.md"
+    assert user_path.exists() and "conductor:begin" in user_path.read_text(encoding="utf-8")
+    assert repo_path.exists() and "conductor:begin" in repo_path.read_text(encoding="utf-8")
+
+
+def test_wire_cursor_writes_managed_rule_file():
+    """Cursor rule is fully-managed — YAML frontmatter + body, deletable as one."""
+    from pathlib import Path
+
+    report = aw.wire_cursor(version="0.4.2")
+    path = Path.cwd() / ".cursor" / "rules" / "conductor-delegation.md"
+    assert report.path == path
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n")
+    assert "description:" in text
+    assert "managed-by: conductor v0.4.2" in text
+    assert "Conductor delegation" in text
+    assert aw.is_managed_file(path)
+
+
+def test_wire_cursor_creates_nested_dirs():
+    """Even without .cursor/rules/ existing, wire_cursor creates the path."""
+    from pathlib import Path
+
+    aw.wire_cursor(version="0.4.2")
+    assert (Path.cwd() / ".cursor" / "rules").is_dir()
+    assert (Path.cwd() / ".cursor" / "rules" / "conductor-delegation.md").exists()
+
+
+def test_detect_picks_up_all_slice_c_artifacts():
+    aw.wire_gemini_md(version="0.4.2")
+    aw.wire_claude_md_repo(version="0.4.2")
+    aw.wire_cursor(version="0.4.2")
+
+    d = aw.detect()
+    kinds = {a.kind for a in d.managed}
+    assert "gemini-md-import" in kinds
+    assert "claude-md-repo-import" in kinds
+    assert "cursor-rule" in kinds
+
+
+def test_detect_reports_slice_c_existence_fields():
+    from pathlib import Path
+
+    d = aw.detect()
+    # Nothing present yet.
+    assert d.gemini_md == Path.cwd() / "GEMINI.md"
+    assert d.gemini_md_exists is False
+    assert d.claude_md_repo == Path.cwd() / "CLAUDE.md"
+    assert d.claude_md_repo_exists is False
+    assert d.cursor_rules_dir == Path.cwd() / ".cursor" / "rules"
+    assert d.cursor_rules_dir_exists is False
+
+    # After wiring, existence flips.
+    aw.wire_gemini_md(version="0.4.2")
+    aw.wire_claude_md_repo(version="0.4.2")
+    aw.wire_cursor(version="0.4.2")
+    d = aw.detect()
+    assert d.gemini_md_exists is True
+    assert d.claude_md_repo_exists is True
+    assert d.cursor_rules_dir_exists is True
+
+
+def test_unwire_removes_every_slice_c_artifact(tmp_path):
+    aw.wire_gemini_md(version="0.4.2")
+    aw.wire_claude_md_repo(version="0.4.2")
+    aw.wire_cursor(version="0.4.2")
+
+    aw.unwire()
+    # GEMINI.md and CLAUDE.md had only our blocks → deleted whole.
+    assert not (tmp_path / "repo" / "GEMINI.md").exists()
+    assert not (tmp_path / "repo" / "CLAUDE.md").exists()
+    # Cursor rule was fully-managed → deleted.
+    assert not (tmp_path / "repo" / ".cursor" / "rules" / "conductor-delegation.md").exists()
+
+
+def test_unwire_preserves_user_content_in_all_sentinel_files(tmp_path):
+    """For GEMINI.md and CLAUDE.md, user content outside the block must
+    survive unwire unchanged."""
+    for name in ("GEMINI.md", "CLAUDE.md"):
+        (tmp_path / "repo" / name).write_text(
+            f"# My {name}\n\nUser stuff.\n", encoding="utf-8"
+        )
+    aw.wire_gemini_md(version="0.4.2")
+    aw.wire_claude_md_repo(version="0.4.2")
+    aw.unwire()
+
+    for name in ("GEMINI.md", "CLAUDE.md"):
+        text = (tmp_path / "repo" / name).read_text(encoding="utf-8")
+        assert "User stuff." in text
+        assert "conductor:begin" not in text
+
+
+def test_cursor_rule_refuses_to_overwrite_user_owned_file(tmp_path):
+    """If the user already has a rule at the managed path, wire_cursor
+    must surface a UserOwnedFileError rather than overwriting."""
+    rule_path = tmp_path / "repo" / ".cursor" / "rules" / "conductor-delegation.md"
+    rule_path.parent.mkdir(parents=True)
+    rule_path.write_text("# my hand-written rule\n", encoding="utf-8")
+
+    with pytest.raises(aw.UserOwnedFileError):
+        aw.wire_cursor(version="0.4.2")
+    assert rule_path.read_text(encoding="utf-8") == "# my hand-written rule\n"
+
+
+def test_user_scope_claude_md_classified_correctly():
+    """~/.claude/CLAUDE.md detection kind is 'claude-md-import' (user-scope),
+    distinct from repo CLAUDE.md's 'claude-md-repo-import'."""
+    aw.wire_claude_code("0.4.2", patch_claude_md=True)   # user-scope
+    aw.wire_claude_md_repo(version="0.4.2")              # repo-scope
+
+    d = aw.detect()
+    kinds = [a.kind for a in d.managed]
+    assert "claude-md-import" in kinds          # user-scope
+    assert "claude-md-repo-import" in kinds     # repo-scope
+    # Two distinct entries; neither swallowed by the other.
+    assert kinds.count("claude-md-import") == 1
+    assert kinds.count("claude-md-repo-import") == 1

--- a/tests/test_cli_phase5.py
+++ b/tests/test_cli_phase5.py
@@ -226,7 +226,7 @@ def test_doctor_reports_agent_integration_wired(mocker, monkeypatch, tmp_path):
     result = CliRunner().invoke(main, ["doctor"])
     assert result.exit_code == 0, result.output
     assert "wired" in result.output.lower()
-    assert "managed files" in result.output.lower()
+    assert "user-scope files" in result.output.lower()
     assert "guidance" in result.output.lower()
     assert "slash-command" in result.output.lower()
     assert "subagent" in result.output.lower()
@@ -243,6 +243,69 @@ def test_doctor_reports_agents_md_when_present(mocker, monkeypatch, tmp_path):
     assert result.exit_code == 0, result.output
     assert "AGENTS.md" in result.output
     assert "present but not wired" in result.output.lower()
+
+
+def test_doctor_reports_gemini_md_states(mocker, monkeypatch, tmp_path):
+    _stub_all_unconfigured(mocker)
+    for var in ("CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "OLLAMA_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+    # Pre-wire: no GEMINI.md exists.
+    result = CliRunner().invoke(main, ["doctor"])
+    assert "GEMINI.md" in result.output
+    assert "no GEMINI.md" in result.output
+
+    # Present but not wired.
+    (tmp_path / "repo" / "GEMINI.md").write_text("# mine\n", encoding="utf-8")
+    result = CliRunner().invoke(main, ["doctor"])
+    assert "present but not wired" in result.output.lower()
+
+    # Wired.
+    from conductor import agent_wiring
+    agent_wiring.wire_gemini_md(version="0.4.2")
+    result = CliRunner().invoke(main, ["doctor"])
+    assert "GEMINI.md" in result.output
+    # "wired —" appears twice in a fully-wired output; locate it on the
+    # GEMINI.md line specifically.
+    gemini_lines = [
+        ln for ln in result.output.splitlines() if "GEMINI.md" in ln
+    ]
+    assert any("wired" in ln for ln in gemini_lines), gemini_lines
+
+
+def test_doctor_reports_cursor_states(mocker, monkeypatch, tmp_path):
+    _stub_all_unconfigured(mocker)
+    for var in ("CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "OLLAMA_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+    # No .cursor/rules/.
+    result = CliRunner().invoke(main, ["doctor"])
+    assert "Cursor:" in result.output
+    assert "no .cursor/rules/" in result.output.lower()
+
+    # Wired.
+    from conductor import agent_wiring
+    agent_wiring.wire_cursor(version="0.4.2")
+    result = CliRunner().invoke(main, ["doctor"])
+    assert "Cursor:" in result.output
+    assert "rule wired" in result.output.lower()
+
+
+def test_doctor_json_includes_slice_c_fields(mocker, monkeypatch, tmp_path):
+    _stub_all_unconfigured(mocker)
+    for var in ("CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "OLLAMA_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+    mocker.patch("conductor.cli.credentials.keychain_has", return_value=False)
+
+    result = CliRunner().invoke(main, ["doctor", "--json"])
+    payload = json.loads(result.output)
+    ai = payload["agent_integration"]
+    for key in (
+        "gemini_md_path", "gemini_md_exists", "gemini_md_wired",
+        "claude_md_repo_path", "claude_md_repo_exists", "claude_md_repo_wired",
+        "cursor_rules_dir", "cursor_rules_dir_exists", "cursor_rule_wired",
+    ):
+        assert key in ai, f"missing {key}"
 
 
 def test_doctor_reports_agents_md_wired(mocker, monkeypatch, tmp_path):

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -631,7 +631,10 @@ def test_init_patch_gemini_md_yes_creates_block(mocker, tmp_path):
     assert "Conductor delegation" in text
 
 
-def test_init_patch_claude_md_repo_yes_creates_import(mocker, tmp_path):
+def test_init_patch_claude_md_repo_yes_creates_inline_block(mocker, tmp_path):
+    """Repo-scope CLAUDE.md wire uses inline content, not an @-import to
+    a user's local ~/.conductor/ path (would break on other machines when
+    the file is committed to git)."""
     _stub_all_providers_unconfigured(mocker)
     result = CliRunner().invoke(
         main,
@@ -642,7 +645,9 @@ def test_init_patch_claude_md_repo_yes_creates_import(mocker, tmp_path):
     assert repo_claude.exists()
     text = repo_claude.read_text(encoding="utf-8")
     assert "conductor:begin" in text
-    assert "@" in text and "delegation-guidance.md" in text
+    assert "Conductor delegation" in text
+    # No absolute-path @-import that would be machine-local.
+    assert f"@{tmp_path}" not in text
 
 
 def test_init_wire_cursor_yes_writes_rule(mocker, tmp_path):

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -612,6 +612,142 @@ def test_init_unwire_rejects_new_patch_agents_md_flag():
     assert "unwire" in result.output.lower()
 
 
+# ---------------------------------------------------------------------------
+# Slice C — GEMINI.md / repo CLAUDE.md / Cursor rule
+# ---------------------------------------------------------------------------
+
+
+def test_init_patch_gemini_md_yes_creates_block(mocker, tmp_path):
+    _stub_all_providers_unconfigured(mocker)
+    result = CliRunner().invoke(
+        main,
+        ["init", "--yes", "--wire-agents", "yes", "--patch-gemini-md", "yes"],
+    )
+    assert result.exit_code == 0, result.output
+    gemini_md = tmp_path / "repo" / "GEMINI.md"
+    assert gemini_md.exists()
+    text = gemini_md.read_text(encoding="utf-8")
+    assert "conductor:begin" in text
+    assert "Conductor delegation" in text
+
+
+def test_init_patch_claude_md_repo_yes_creates_import(mocker, tmp_path):
+    _stub_all_providers_unconfigured(mocker)
+    result = CliRunner().invoke(
+        main,
+        ["init", "--yes", "--wire-agents", "yes", "--patch-claude-md-repo", "yes"],
+    )
+    assert result.exit_code == 0, result.output
+    repo_claude = tmp_path / "repo" / "CLAUDE.md"
+    assert repo_claude.exists()
+    text = repo_claude.read_text(encoding="utf-8")
+    assert "conductor:begin" in text
+    assert "@" in text and "delegation-guidance.md" in text
+
+
+def test_init_wire_cursor_yes_writes_rule(mocker, tmp_path):
+    _stub_all_providers_unconfigured(mocker)
+    result = CliRunner().invoke(
+        main,
+        ["init", "--yes", "--wire-agents", "yes", "--wire-cursor", "yes"],
+    )
+    assert result.exit_code == 0, result.output
+    rule = tmp_path / "repo" / ".cursor" / "rules" / "conductor-delegation.md"
+    assert rule.exists()
+    text = rule.read_text(encoding="utf-8")
+    assert "managed-by: conductor" in text
+    assert "Conductor delegation" in text
+
+
+def test_init_all_slice_c_flags_yes_wires_everything(mocker, tmp_path):
+    _stub_all_providers_unconfigured(mocker)
+    result = CliRunner().invoke(
+        main,
+        [
+            "init", "--yes",
+            "--wire-agents", "yes",
+            "--patch-gemini-md", "yes",
+            "--patch-claude-md-repo", "yes",
+            "--wire-cursor", "yes",
+            "--patch-agents-md", "yes",
+            "--patch-claude-md", "no",  # skip user-scope to keep the test local
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    repo = tmp_path / "repo"
+    assert (repo / "AGENTS.md").exists()
+    assert (repo / "GEMINI.md").exists()
+    assert (repo / "CLAUDE.md").exists()
+    assert (repo / ".cursor" / "rules" / "conductor-delegation.md").exists()
+
+
+def test_init_slice_c_unwire_removes_all(mocker, tmp_path):
+    _stub_all_providers_unconfigured(mocker)
+    # Wire everything.
+    CliRunner().invoke(
+        main,
+        [
+            "init", "--yes",
+            "--wire-agents", "yes",
+            "--patch-gemini-md", "yes",
+            "--patch-claude-md-repo", "yes",
+            "--wire-cursor", "yes",
+        ],
+    )
+    repo = tmp_path / "repo"
+    assert (repo / "GEMINI.md").exists()
+
+    # Unwire removes all of it.
+    result = CliRunner().invoke(main, ["init", "--unwire"])
+    assert result.exit_code == 0, result.output
+    assert not (repo / "GEMINI.md").exists()
+    assert not (repo / "CLAUDE.md").exists()
+    assert not (repo / ".cursor" / "rules" / "conductor-delegation.md").exists()
+
+
+def test_init_unwire_rejects_slice_c_flags():
+    """--unwire must refuse combination with any Slice C wiring flag."""
+    for flag, value in [
+        ("--patch-gemini-md", "yes"),
+        ("--patch-claude-md-repo", "yes"),
+        ("--wire-cursor", "yes"),
+    ]:
+        result = CliRunner().invoke(main, ["init", "--unwire", flag, value])
+        assert result.exit_code == 2, f"{flag}: {result.output}"
+        assert "unwire" in result.output.lower()
+
+
+def test_init_slice_c_preserves_user_content(mocker, tmp_path):
+    """GEMINI.md and CLAUDE.md with existing user content must have that
+    content preserved through wire + unwire."""
+    _stub_all_providers_unconfigured(mocker)
+    repo = tmp_path / "repo"
+    (repo / "GEMINI.md").write_text("# My Gemini\n\nRule.\n", encoding="utf-8")
+    (repo / "CLAUDE.md").write_text("# My Claude\n\nRule.\n", encoding="utf-8")
+
+    CliRunner().invoke(
+        main,
+        [
+            "init", "--yes",
+            "--wire-agents", "yes",
+            "--patch-gemini-md", "yes",
+            "--patch-claude-md-repo", "yes",
+            "--patch-claude-md", "no",
+        ],
+    )
+    CliRunner().invoke(main, ["init", "--unwire"])
+
+    gemini_text = (repo / "GEMINI.md").read_text(encoding="utf-8")
+    assert "# My Gemini" in gemini_text
+    assert "Rule." in gemini_text
+    assert "conductor:begin" not in gemini_text
+
+    claude_text = (repo / "CLAUDE.md").read_text(encoding="utf-8")
+    assert "# My Claude" in claude_text
+    assert "Rule." in claude_text
+    assert "conductor:begin" not in claude_text
+
+
 def test_init_patch_agents_md_yes_without_claude_still_works(mocker, tmp_path):
     """Codex-only user (no Claude Code) must get AGENTS.md patched when
     explicitly asked, even with no Claude Code detected."""

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -657,7 +657,7 @@ def test_init_wire_cursor_yes_writes_rule(mocker, tmp_path):
         ["init", "--yes", "--wire-agents", "yes", "--wire-cursor", "yes"],
     )
     assert result.exit_code == 0, result.output
-    rule = tmp_path / "repo" / ".cursor" / "rules" / "conductor-delegation.md"
+    rule = tmp_path / "repo" / ".cursor" / "rules" / "conductor-delegation.mdc"
     assert rule.exists()
     text = rule.read_text(encoding="utf-8")
     assert "managed-by: conductor" in text
@@ -683,7 +683,7 @@ def test_init_all_slice_c_flags_yes_wires_everything(mocker, tmp_path):
     assert (repo / "AGENTS.md").exists()
     assert (repo / "GEMINI.md").exists()
     assert (repo / "CLAUDE.md").exists()
-    assert (repo / ".cursor" / "rules" / "conductor-delegation.md").exists()
+    assert (repo / ".cursor" / "rules" / "conductor-delegation.mdc").exists()
 
 
 def test_init_slice_c_unwire_removes_all(mocker, tmp_path):
@@ -707,7 +707,7 @@ def test_init_slice_c_unwire_removes_all(mocker, tmp_path):
     assert result.exit_code == 0, result.output
     assert not (repo / "GEMINI.md").exists()
     assert not (repo / "CLAUDE.md").exists()
-    assert not (repo / ".cursor" / "rules" / "conductor-delegation.md").exists()
+    assert not (repo / ".cursor" / "rules" / "conductor-delegation.mdc").exists()
 
 
 def test_init_unwire_rejects_slice_c_flags():


### PR DESCRIPTION
Round out the detection + wiring surface beyond Slice B's AGENTS.md.
A user running `conductor init` in any repo now sees per-file prompts
for every agent instruction file that's present (or forced via flag)
and nothing for files that aren't.

New detection + wiring:
- `./GEMINI.md` — Gemini CLI convention. Sentinel-block injection with
  self-contained inline content (identical body to AGENTS.md today,
  split constant so future divergence is one line).
- `./CLAUDE.md` — Claude Code repo-scope config, parallel to the
  user-scope `~/.claude/CLAUDE.md` patched by `wire_claude_code`. Both
  are independent sentinel blocks; neither wire clobbers the other.
- `./.cursor/rules/conductor-delegation.md` — Cursor rule. Unlike the
  markdown instruction files, this is fully-managed (YAML frontmatter
  + body, deleted whole on unwire).

Ownership model cleanup:
- `~/.claude/CLAUDE.md` moved from `_candidate_artifacts` to
  `_candidate_sentinel_paths` where it belongs conceptually — both
  repo-scope and user-scope sentinel-block files now take the same
  code path in detect/unwire. Removes a special case; fewer branches.
- Detection of `claude-md-import` (user-scope) and
  `claude-md-repo-import` (repo-scope) are distinct kinds; doctor
  reports them on separate lines.

CLI (parallel to existing flags, same tri-state semantics):
- `--patch-gemini-md={yes,no,ask}`
- `--patch-claude-md-repo={yes,no,ask}`
- `--wire-cursor={yes,no,ask}`

Wizard refactor:
- `_wire_agents_md_section`, `_wire_gemini_md_section`,
  `_wire_claude_md_repo_section` now share a generic
  `_wire_sentinel_section` helper (title / filename / wire_fn
  parameterized). Cursor section stays specialized because the
  user-facing copy is different (rule file vs sentinel block).

Doctor:
- Separate lines for AGENTS.md / GEMINI.md / CLAUDE.md / Cursor.
- JSON payload gains `gemini_md_*`, `claude_md_repo_*`, `cursor_*`
  keys.

README:
- New "Agent integration (v0.4.x)" section documenting the detect +
  prompt + unwire flow that's been building across A/B/C.

Tests: 22 new (wire round-trips for each new file, CLI flag coverage,
doctor reporting, user-content-preservation round-trips). Full suite:
390 pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
