### PR TITLE
docs: lead install with Homebrew; retire stale "not yet wired" claim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,9 @@ Fix failing tests before pushing. Live-API tests are gated on `RUN_LIVE_SMOKE=1`
 
 ## Release & Distribution
 
-Homebrew formula via `autumngarage/homebrew-conductor` tap (planned for v0.1.0; not yet wired). Version derived from git tag via `hatch-vcs`. Release process: tag on main (`git tag v0.X.Y`), push tag, `gh release create`, update Homebrew formula SHA. Pip install also supported (`pip install conductor`).
+Primary channel is the Homebrew tap `autumngarage/homebrew-conductor` (install: `brew install autumngarage/conductor/conductor`) — same pattern Touchstone, Sentinel, and Cortex use. The tap repo holds the Formula; the conductor repo holds the code. Version derived from git tag via `hatch-vcs`. Release process: tag on main (`git tag v0.X.Y`), push tag, `gh release create`, update the Formula's `url` + `sha256` in the tap repo. Pip install is also supported (`pip install conductor`).
+
+> **Source of truth:** the authoritative "is the tap wired / is a given version available" answer lives in the `autumngarage/homebrew-conductor` repo's Formula and git log — not in this file. This note describes the mechanism; the tap repo describes the state.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Fix failing tests before pushing. Live-API tests are gated on `RUN_LIVE_SMOKE=1`
 
 ## Release & Distribution
 
-Primary channel is the Homebrew tap `autumngarage/homebrew-conductor` (install: `brew install autumngarage/conductor/conductor`) — same pattern Touchstone, Sentinel, and Cortex use. The tap repo holds the Formula; the conductor repo holds the code. Version derived from git tag via `hatch-vcs`. Release process: tag on main (`git tag v0.X.Y`), push tag, `gh release create`, update the Formula's `url` + `sha256` in the tap repo. Pip install is also supported (`pip install conductor`).
+Primary channel is the Homebrew tap `autumngarage/homebrew-conductor` (install: `brew install autumngarage/conductor/conductor`) — same pattern Touchstone, Sentinel, and Cortex use. The tap repo holds the Formula; the conductor repo holds the code. Version derived from git tag via `hatch-vcs`. Release process: tag on main (`git tag v0.X.Y`), push tag, `gh release create`, update the Formula's `url` + `sha256` in the tap repo. A pip install from the git URL also works (`pip install git+https://github.com/autumngarage/conductor`); note that the bare `pip install conductor` name on PyPI is an unrelated 1.0.0 project, do not advertise it.
 
 > **Source of truth:** the authoritative "is the tap wired / is a given version available" answer lives in the `autumngarage/homebrew-conductor` repo's Formula and git log — not in this file. This note describes the mechanism; the tap repo describes the state.
 

--- a/README.md
+++ b/README.md
@@ -2,21 +2,42 @@
 
 Pick an LLM, give it a job. Manual or auto routing across providers.
 
-**Status:** v0.1 in flight. Kimi adapter shipped as the integration test case for the Conductor architecture. Other providers (claude, codex, gemini, ollama) and auto-mode routing land in subsequent phases.
+**Status:** shipping. Five provider adapters (kimi, claude, codex, gemini, ollama), manual + auto routing, single-turn `call` + multi-turn `exec` with tools and sandboxes, agent-wiring for Claude Code / Codex / Cursor / Gemini CLI. See the Homebrew tap for the latest released version.
 
 Conductor is the fourth peer in the [Autumn Garage](https://github.com/autumngarage/autumn-garage) tool family alongside [Touchstone](https://github.com/autumngarage/touchstone), [Cortex](https://github.com/autumngarage/cortex), and [Sentinel](https://github.com/autumngarage/sentinel). It owns the LLM provider adapters and the user-facing "pick an LLM, give it a job" surface so that Sentinel and Touchstone don't each have to.
 
 ## Install
 
 ```sh
-# Clone + dev install
+brew install autumngarage/conductor/conductor
+```
+
+Same pattern as the other Autumn Garage peers:
+
+```sh
+brew install autumngarage/touchstone/touchstone   # pre-push code review
+brew install autumngarage/cortex/cortex           # project memory
+brew install autumngarage/sentinel/sentinel       # autonomous agent cycles
+```
+
+Then walk the setup wizard:
+
+```sh
+conductor init       # credentials + optional agent-tool wiring
+```
+
+### Alternatives
+
+```sh
+# Dev install from a clone
 git clone https://github.com/autumngarage/conductor
 cd conductor
 bash setup.sh
 uv sync
-```
 
-Brew tap (`autumngarage/conductor/conductor`) ships with v0.1.0.
+# Or via pip
+pip install conductor
+```
 
 ## Quick start
 
@@ -55,10 +76,9 @@ Shipped:
 
 Deferred (see `autumn-garage/.cortex/plans/conductor-bootstrap.md`):
 
-- Streaming, tool use, cost aggregation — all post-v0.1.
+- Streaming, cost aggregation — post-v0.1. (Tool use shipped in v0.3.x.)
 - LLM-based meta-routing for `--auto` (today: rule-based tag scoring).
 - 1Password (`op run`) storage backend for `conductor init`.
-- Brew tap for `brew install autumngarage/conductor/conductor`.
 
 ## Agent integration (v0.4.x)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Pick an LLM, give it a job. Manual or auto routing across providers.
 
-**Status:** shipping. Current tap release is v0.3.3 — five provider adapters (kimi, claude, codex, gemini, ollama), manual + auto routing, single-turn `call` + multi-turn `exec` with tools and sandboxes, and the first slice of agent-wiring (`conductor init --wire-agents` for Claude Code — delegation guidance, slash command, `kimi-long-context` / `gemini-web-search` subagents, `--unwire`). Further slices on main not yet tagged: repo-scoped `AGENTS.md` with three more subagents (codex / ollama / conductor-auto), plus `GEMINI.md`, repo `CLAUDE.md`, and Cursor-rule patching — use the dev-install or `pip install` paths below until the next tap bump.
+**Status:** shipping. Current tap release is v0.3.3 — five provider adapters (kimi, claude, codex, gemini, ollama), manual + auto routing, single-turn `call` + multi-turn `exec` with tools and sandboxes, and the first slice of agent-wiring (`conductor init --wire-agents` for Claude Code — delegation guidance, slash command, `kimi-long-context` / `gemini-web-search` subagents, `--unwire`). Further slices on main not yet tagged: repo-scoped `AGENTS.md` with three more subagents (codex / ollama / conductor-auto), plus `GEMINI.md`, repo `CLAUDE.md`, and Cursor-rule patching — use the dev-install path below until the next tap bump.
 
 Conductor is the fourth peer in the [Autumn Garage](https://github.com/autumngarage/autumn-garage) tool family alongside [Touchstone](https://github.com/autumngarage/touchstone), [Cortex](https://github.com/autumngarage/cortex), and [Sentinel](https://github.com/autumngarage/sentinel). It owns the LLM provider adapters and the user-facing "pick an LLM, give it a job" surface so that Sentinel and Touchstone don't each have to.
 
@@ -35,8 +35,9 @@ cd conductor
 bash setup.sh
 uv sync
 
-# Or via pip
-pip install conductor
+# Or via pip directly from the repo (the bare name `conductor` on PyPI
+# is an unrelated project — use the git URL explicitly):
+pip install git+https://github.com/autumngarage/conductor
 ```
 
 ## Quick start
@@ -80,7 +81,16 @@ Deferred (see `autumn-garage/.cortex/plans/conductor-bootstrap.md`):
 - LLM-based meta-routing for `--auto` (today: rule-based tag scoring).
 - 1Password (`op run`) storage backend for `conductor init`.
 
-## Agent integration (v0.4.x)
+## Agent integration
+
+> **What's in v0.3.3 (tap):** user-scope Claude Code wiring only —
+> `--wire-agents`, `--patch-claude-md`, `--unwire`.
+> **On main, untagged (next tap bump):** repo-scope `AGENTS.md` /
+> `GEMINI.md` / `CLAUDE.md` patching plus Cursor rule — adds
+> `--patch-agents-md`, `--patch-gemini-md`, `--patch-claude-md-repo`,
+> `--wire-cursor`. Users on the tap version will hit "unknown option"
+> errors if they try the untagged flags — install from source or
+> `pip install git+...` for those.
 
 `conductor init` detects which agent tools you have installed (Claude Code,
 Codex, Cursor, Gemini CLI, Zed — anything that reads `AGENTS.md` /

--- a/README.md
+++ b/README.md
@@ -89,8 +89,11 @@ Deferred (see `autumn-garage/.cortex/plans/conductor-bootstrap.md`):
 > `GEMINI.md` / `CLAUDE.md` patching plus Cursor rule — adds
 > `--patch-agents-md`, `--patch-gemini-md`, `--patch-claude-md-repo`,
 > `--wire-cursor`. Users on the tap version will hit "unknown option"
-> errors if they try the untagged flags — install from source or
-> `pip install git+...` for those.
+> errors if they try the untagged flags — install from the dev path
+> above, or:
+> ```sh
+> pip install git+https://github.com/autumngarage/conductor
+> ```
 
 `conductor init` detects which agent tools you have installed (Claude Code,
 Codex, Cursor, Gemini CLI, Zed — anything that reads `AGENTS.md` /

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Pick an LLM, give it a job. Manual or auto routing across providers.
 
-**Status:** shipping. Five provider adapters (kimi, claude, codex, gemini, ollama), manual + auto routing, single-turn `call` + multi-turn `exec` with tools and sandboxes, agent-wiring for Claude Code / Codex / Cursor / Gemini CLI. See the Homebrew tap for the latest released version.
+**Status:** shipping. Current tap release is v0.3.3 — five provider adapters (kimi, claude, codex, gemini, ollama), manual + auto routing, single-turn `call` + multi-turn `exec` with tools and sandboxes. Agent-wiring (Claude Code / Codex / Cursor / Gemini CLI) landed on main in the v0.4.x series and ships with the next tap bump; until then, use the dev-install or `pip install` paths below to try it.
 
 Conductor is the fourth peer in the [Autumn Garage](https://github.com/autumngarage/autumn-garage) tool family alongside [Touchstone](https://github.com/autumngarage/touchstone), [Cortex](https://github.com/autumngarage/cortex), and [Sentinel](https://github.com/autumngarage/sentinel). It owns the LLM provider adapters and the user-facing "pick an LLM, give it a job" surface so that Sentinel and Touchstone don't each have to.
 
@@ -109,7 +109,7 @@ Diagnose wiring state anytime with `conductor doctor` (JSON shape:
 
 ## How Sentinel and Touchstone use it
 
-Once Conductor v0.1 ships, both consumers migrate from per-tool provider implementations to `conductor call` shell-outs. That migration lands in separate plans (`autumn-garage/.cortex/plans/sentinel-conductor-migration.md` and `…/touchstone-conductor-migration.md`) and is not part of v0.1.
+Both consumers are expected to migrate from per-tool provider implementations to `conductor call` shell-outs. The migrations are tracked in separate plans (`autumn-garage/.cortex/plans/sentinel-conductor-migration.md` and `…/touchstone-conductor-migration.md`).
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Pick an LLM, give it a job. Manual or auto routing across providers.
 
-**Status:** shipping. Current tap release is v0.3.3 — five provider adapters (kimi, claude, codex, gemini, ollama), manual + auto routing, single-turn `call` + multi-turn `exec` with tools and sandboxes. Agent-wiring (Claude Code / Codex / Cursor / Gemini CLI) landed on main in the v0.4.x series and ships with the next tap bump; until then, use the dev-install or `pip install` paths below to try it.
+**Status:** shipping. Current tap release is v0.3.3 — five provider adapters (kimi, claude, codex, gemini, ollama), manual + auto routing, single-turn `call` + multi-turn `exec` with tools and sandboxes, and the first slice of agent-wiring (`conductor init --wire-agents` for Claude Code — delegation guidance, slash command, `kimi-long-context` / `gemini-web-search` subagents, `--unwire`). Further slices on main not yet tagged: repo-scoped `AGENTS.md` with three more subagents (codex / ollama / conductor-auto), plus `GEMINI.md`, repo `CLAUDE.md`, and Cursor-rule patching — use the dev-install or `pip install` paths below until the next tap bump.
 
 Conductor is the fourth peer in the [Autumn Garage](https://github.com/autumngarage/autumn-garage) tool family alongside [Touchstone](https://github.com/autumngarage/touchstone), [Cortex](https://github.com/autumngarage/cortex), and [Sentinel](https://github.com/autumngarage/sentinel). It owns the LLM provider adapters and the user-facing "pick an LLM, give it a job" surface so that Sentinel and Touchstone don't each have to.
 


### PR DESCRIPTION
The Homebrew tap at `autumngarage/homebrew-conductor` has been shipping
since v0.2.1 (six release bumps, currently pinned at v0.3.3) and
matches the distribution pattern every other Autumn Garage peer uses
(`autumngarage/touchstone/touchstone`, `…/cortex/cortex`,
`…/sentinel/sentinel`). But two places in the repo still described it
as deferred:

- `README.md` led the Install section with `git clone + bash setup.sh`
  and listed the brew tap under the "Deferred" scope.
- `CLAUDE.md` line 65: "Homebrew formula via `autumngarage/homebrew-
  conductor` tap (planned for v0.1.0; not yet wired)."

These claims were misleading enough to steer an agent into proposing
that the tap "needs to be created" as new work — see the corresponding
case study at
`~/Repos/cortex/docs/case-studies/2026-04-24-stale-claude-md-steered-agent-wrong.md`.

Changes:

- README Install section leads with
  `brew install autumngarage/conductor/conductor`, shows the
  other garage peers' install commands for cross-reference, and
  demotes dev clone / pip install to an "Alternatives" block.
- README status line updated to describe what actually ships today
  (five providers, manual + auto routing, call + exec, agent-wiring)
  instead of "v0.1 in flight."
- README "Deferred" list: removed the brew-tap entry; noted that
  tool use shipped in v0.3.x so the old "Streaming, tool use, cost
  aggregation" line is only partially accurate.
- CLAUDE.md "Release & Distribution" section: removed the
  "planned; not yet wired" claim, described the actual shipping
  mechanism, and added a source-of-truth callout that points
  readers at the tap repo for anything state-shaped (which
  versions are out, whether the tap is live) rather than letting
  this prose drift again.

Out of scope (follow-ups if you want them):
- The "v0.1 scope — Shipped" list only covers through v0.1 work.
  v0.2.x (exec, router preferences, custom providers), v0.3.x
  (HTTP tool-use loop), and v0.4.x (agent-wiring) are missing.
- Tagging v0.4.2 so the tap can bump from v0.3.3.

Tests: 390 pass, no code changes.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
