### PR TITLE
feat: subagent prompt-drift tests + template coverage fixes (Slice B)

### DIFF
--- a/src/conductor/_agent_templates.py
+++ b/src/conductor/_agent_templates.py
@@ -156,6 +156,10 @@ When invoked:
 
        cat <file> | conductor call --with kimi --task "Summarize." --json
 
+   For long-context work that also needs deeper reasoning, add
+   `--effort high` or `--effort max`. For pure summarization or
+   extraction, omit `--effort` and use the default.
+
 4. Parse the JSON, extract the `text` field, and return it verbatim
    prefixed with "From Kimi:". Include the `model` and `duration_ms` from
    the JSON as a one-line footer for transparency.
@@ -236,7 +240,7 @@ When invoked:
 
 3. Parse the JSON, extract `text`, and return it verbatim prefixed with
    "From Codex:". Note `session_id` in the JSON if present — callers can
-   resume by passing it back as `--resume-session-id`.
+   resume by passing it back as `--resume`.
 
 If the task is a quick one-shot question (no file tools needed), route
 it to a single-turn provider instead — `exec` mode carries more setup
@@ -272,7 +276,13 @@ When invoked:
    than a hosted flagship. If the user's task clearly needs frontier
    reasoning and is NOT privacy-sensitive, say so and ask the parent
    to route elsewhere.
-2. Run:
+2. Run with conductor's explicit offline flag:
+
+       conductor call --offline --task "<prompt>" --json
+
+   This forces the local Ollama provider and records conductor's
+   short-lived offline preference. If the parent explicitly does not want
+   that sticky offline preference, use the explicit provider path instead:
 
        conductor call --with ollama --task "<prompt>" --json
 
@@ -383,15 +393,35 @@ When invoked:
    - `cheap` — user explicitly asked for a cheap run
    - `offline` — user explicitly asked for local-only
    Pick 1–3 tags; do NOT invent new ones.
-2. Run:
+2. For normal single-turn routing, run:
 
-       conductor call --auto --tags <tag1>,<tag2> --task "<prompt>" --json
+       conductor call --auto --tags <tag1>,<tag2> --prefer <mode> \\
+           --task "<prompt>" --json
 
    For the prefer axis:
    - Default: `--prefer balanced` (what conductor does by default).
    - User asked for the cheapest option: `--prefer cheapest`.
    - User asked for the best answer: `--prefer best`.
    - Response-time matters: `--prefer fastest`.
+
+   For the effort axis, omit `--effort` unless the user asks for a
+   different thinking budget. Valid levels are `minimal`, `low`, `medium`,
+   `high`, and `max` (or an integer budget).
+
+   If the task needs file/code tools, use exec mode instead:
+
+       conductor exec --auto --tags tool-use,<tag> \\
+           --tools Read,Grep,Glob,Edit,Write,Bash \\
+           --sandbox <mode> --task "<prompt>" --json
+
+   Sandbox modes are: `read-only` for inspection, `workspace-write` for
+   edits in the workspace, `strict` for the strongest isolation supported
+   by local/HTTP tool loops, and `none` only for text-only work with no
+   tools.
+
+   If the user explicitly requires local/offline execution, prefer the
+   `ollama-offline` subagent. If you must run directly, use `--offline`
+   rather than relying only on the soft `offline` tag.
 3. Parse the JSON, extract `text`, and return it prefixed with
    "From <provider> (auto-routed by conductor):". The chosen provider
    is in the JSON under `provider`.

--- a/tests/test_agent_template_drift.py
+++ b/tests/test_agent_template_drift.py
@@ -1,0 +1,140 @@
+"""Drift tests for conductor's Claude Code subagent prompt templates."""
+
+from __future__ import annotations
+
+from conductor import _agent_templates as templates
+
+EXPECTED_TEMPLATE_COVERAGE = {
+    "kimi-long-context": {
+        "--with kimi",
+        "--effort",
+        "--json",
+        "long-context",
+    },
+    "gemini-web-search": {
+        "--with gemini",
+        "--json",
+        "fresh",
+        "gemini",
+        "web search",
+    },
+    "codex-coding-agent": {
+        "--with codex",
+        "--tools",
+        "--sandbox",
+        "--json",
+        "`--resume`",
+        "Bash",
+        "Edit",
+        "Glob",
+        "Grep",
+        "Read",
+        "Write",
+        "codex",
+        "conductor exec",
+        "workspace-write",
+    },
+    "ollama-offline": {
+        "--offline",
+        "--with ollama",
+        "--json",
+        "local",
+        "offline",
+        "ollama",
+        "privacy-sensitive",
+    },
+    "conductor-auto": {
+        "--auto",
+        "--effort",
+        "--offline",
+        "--prefer",
+        "--sandbox",
+        "--tags",
+        "--tools",
+        "--json",
+        "Bash",
+        "Edit",
+        "Glob",
+        "Grep",
+        "Read",
+        "Write",
+        "balanced",
+        "best",
+        "cheap",
+        "cheapest",
+        "code-review",
+        "conductor call",
+        "conductor exec",
+        "fastest",
+        "high",
+        "long-context",
+        "low",
+        "max",
+        "medium",
+        "minimal",
+        "none",
+        "offline",
+        "read-only",
+        "strict",
+        "tool-use",
+        "vision",
+        "web-search",
+        "workspace-write",
+    },
+}
+
+SUBAGENT_TEMPLATES = {
+    "kimi-long-context": templates.SUBAGENT_KIMI_LONG_CONTEXT,
+    "gemini-web-search": templates.SUBAGENT_GEMINI_WEB_SEARCH,
+    "codex-coding-agent": templates.SUBAGENT_CODEX_CODING_AGENT,
+    "ollama-offline": templates.SUBAGENT_OLLAMA_OFFLINE,
+    "conductor-auto": templates.SUBAGENT_CONDUCTOR_AUTO,
+}
+
+
+def _assert_template_mentions_expected_tokens(subagent_name: str) -> None:
+    template = SUBAGENT_TEMPLATES[subagent_name]
+    expected_tokens = EXPECTED_TEMPLATE_COVERAGE[subagent_name]
+    missing = sorted(token for token in expected_tokens if token not in template)
+    assert not missing, (
+        f"{subagent_name} template missing required token(s): "
+        f"{', '.join(missing)}"
+    )
+
+
+def test_expected_template_coverage_covers_every_subagent_constant():
+    subagent_constants = {
+        name
+        for name, value in vars(templates).items()
+        if name.startswith("SUBAGENT_") and isinstance(value, str)
+    }
+    expected_constants = {
+        "SUBAGENT_KIMI_LONG_CONTEXT",
+        "SUBAGENT_GEMINI_WEB_SEARCH",
+        "SUBAGENT_CODEX_CODING_AGENT",
+        "SUBAGENT_OLLAMA_OFFLINE",
+        "SUBAGENT_CONDUCTOR_AUTO",
+    }
+
+    assert subagent_constants == expected_constants
+    assert set(SUBAGENT_TEMPLATES) == set(EXPECTED_TEMPLATE_COVERAGE)
+
+
+def test_kimi_long_context_template_mentions_required_cli_surface():
+    _assert_template_mentions_expected_tokens("kimi-long-context")
+
+
+def test_gemini_web_search_template_mentions_required_cli_surface():
+    _assert_template_mentions_expected_tokens("gemini-web-search")
+
+
+def test_codex_coding_agent_template_mentions_required_cli_surface():
+    _assert_template_mentions_expected_tokens("codex-coding-agent")
+
+
+def test_ollama_offline_template_mentions_required_cli_surface():
+    _assert_template_mentions_expected_tokens("ollama-offline")
+
+
+def test_conductor_auto_template_mentions_required_cli_surface():
+    _assert_template_mentions_expected_tokens("conductor-auto")


### PR DESCRIPTION
Adds Layer 1 of the subagent prompt-drift testing per
.cortex/plans/conductor-blindspots.md (Slice B). Centralizes a
must-mention coverage dict so adding a new conductor CLI flag
automatically surfaces which subagent templates need updating.

Implementation by Codex; staged-then-shipped because Codex's sandbox
blocked the git/PR step. Verified locally:
- 425 passed, 3 skipped (was 419 + 3; +6 new drift tests).
- Ruff clean.
- Red-then-green confirmed: removing --offline from ollama-offline
  template fails the corresponding test with a clear missing-token
  message.

Template fixes that fell out of writing the tests (each template was
missing required CLI surface coverage):
- ollama-offline: now mentions --offline.
- kimi-long-context: now mentions --effort.
- codex-coding-agent: now mentions --resume.
- conductor-auto: now mentions effort/tools/sandbox/offline guidance.

Layer 2 (live LLM instruction-following test) deferred per the plan.

Co-Authored-By: Codex (OpenAI) <noreply@openai.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
