### PR TITLE
feat: caller-attribution banner for `call` / `exec`

### DIFF
--- a/src/conductor/banner.py
+++ b/src/conductor/banner.py
@@ -110,3 +110,90 @@ def conductor_version() -> str | None:
 
 SUBTITLE_INIT = "pick an LLM, give it a job"
 SUBTITLE_DOCTOR = "provider health check"
+
+
+# --------------------------------------------------------------------------- #
+# Caller-attribution banner — a one-liner emitted at the top of
+# `conductor call` / `conductor exec` to announce that Conductor is doing
+# the work, and (when detectable) name the LLM tool that invoked us.
+#
+# Goal: when Claude Code, Sentinel, etc. shell out to conductor, the user
+# watching that tool's transcript sees "▸ Claude Code is using Conductor
+# → kimi" — branding without breaking subprocess parsing (we write to
+# stderr; consumers parse stdout).
+# --------------------------------------------------------------------------- #
+
+# (env-var, display-name). Order is the precedence when multiple markers
+# are set (rare; first match wins). Status of each entry:
+#   verified   — confirmed against the actual tool's environment.
+#   convention — autumn-garage peer; we control both sides of the contract.
+#
+# Add new callers only after confirming their env footprint, so the
+# registry never claims coverage we haven't tested.
+_CALLER_REGISTRY: tuple[tuple[str, str], ...] = (
+    ("CLAUDECODE", "Claude Code"),     # verified
+    ("SENTINEL", "Sentinel"),          # convention (autumn-garage peer)
+    ("TOUCHSTONE", "Touchstone"),      # convention (autumn-garage peer)
+    # ("CURSOR_AGENT", "Cursor"),      # TODO: verify env footprint
+    # ("AIDER_AGENT", "Aider"),        # TODO: verify env footprint
+    # ("CODEX_CLI", "Codex CLI"),      # TODO: verify env footprint
+    # ("GEMINI_CLI", "Gemini CLI"),    # TODO: verify env footprint
+)
+
+
+def detect_caller() -> str | None:
+    """Return the display name of the calling LLM tool, or None.
+
+    Probes env vars set by known callers (Claude Code, trio peers) in
+    registry order; first match wins. Returns None when no marker is set
+    — caller is unknown or conductor was invoked by a plain shell.
+    """
+    for env_var, name in _CALLER_REGISTRY:
+        if os.environ.get(env_var):
+            return name
+    return None
+
+
+def print_caller_banner(
+    provider: str,
+    *,
+    stream=None,
+    silent: bool = False,
+) -> None:
+    """Emit a one-line caller-attribution banner to stderr.
+
+    Format:
+      `▸ <Caller> is using Conductor → <provider>` when a caller is detected.
+      `▸ Conductor → <provider>` when stderr is a TTY but no caller is
+      detected (a human is watching but we don't know their tool).
+
+    Stays silent when ``silent=True``, when no caller is detected AND
+    stderr is not a TTY (the line would be neither attributable nor
+    visible), or when writing fails (closed stream, broken pipe).
+    Branding must never fail a real call — every error path is swallowed.
+    """
+    if silent:
+        return
+    target = stream if stream is not None else sys.stderr
+    caller = detect_caller()
+
+    try:
+        is_tty = bool(target.isatty())
+    except (AttributeError, ValueError):
+        is_tty = False
+
+    if caller is None and not is_tty:
+        return
+
+    use_color = _color_enabled(target)
+    name = f"{_ANSI_PURPLE}Conductor{_ANSI_RESET}" if use_color else "Conductor"
+    line = (
+        f"▸ {caller} is using {name} → {provider}"
+        if caller
+        else f"▸ {name} → {provider}"
+    )
+
+    try:
+        print(line, file=target)
+    except (OSError, ValueError):
+        return

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -26,6 +26,7 @@ from dataclasses import asdict
 import click
 
 from conductor import __version__, credentials, offline_mode
+from conductor.banner import print_caller_banner
 from conductor.providers import (
     QUALITY_TIERS,
     CallResponse,
@@ -663,7 +664,8 @@ def main() -> None:
     "--silent-route",
     is_flag=True,
     default=False,
-    help="Suppress the default route-log line (useful for clean stdout piping).",
+    help="Suppress the route-log line and caller-attribution banner "
+    "(useful for clean stdout piping).",
 )
 @click.option(
     "--resume",
@@ -727,6 +729,7 @@ def call(
         except (NoConfiguredProvider, InvalidRouterRequest) as e:
             click.echo(f"conductor: {e}", err=True)
             sys.exit(2)
+        print_caller_banner(decision.provider, silent=silent_route or as_json)
         _emit_route_log(decision, verbose=verbose_route, silent=silent_route or as_json)
 
         try:
@@ -755,6 +758,7 @@ def call(
             provider = get_provider(provider_id)
         except KeyError as e:
             raise click.UsageError(str(e)) from e
+        print_caller_banner(provider_id, silent=silent_route or as_json)
         try:
             response = provider.call(
                 body,
@@ -909,6 +913,7 @@ def exec_cmd(
         except (NoConfiguredProvider, InvalidRouterRequest) as e:
             click.echo(f"conductor: {e}", err=True)
             sys.exit(2)
+        print_caller_banner(decision.provider, silent=silent_route or as_json)
         _emit_route_log(decision, verbose=verbose_route, silent=silent_route or as_json)
 
         try:
@@ -938,6 +943,7 @@ def exec_cmd(
             provider = get_provider(provider_id)
         except KeyError as e:
             raise click.UsageError(str(e)) from e
+        print_caller_banner(provider_id, silent=silent_route or as_json)
         try:
             response = provider.exec(
                 body,

--- a/tests/test_banner.py
+++ b/tests/test_banner.py
@@ -1,10 +1,28 @@
-"""Tests for conductor.banner — the ASCII hero shared with init/doctor."""
+"""Tests for conductor.banner — the ASCII hero shared with init/doctor,
+plus the caller-attribution banner emitted by `conductor call` / `exec`."""
 
 from __future__ import annotations
 
 import io
 
-from conductor.banner import print_banner, render_banner
+from conductor.banner import (
+    _CALLER_REGISTRY,
+    detect_caller,
+    print_banner,
+    print_caller_banner,
+    render_banner,
+)
+
+
+def _strip_caller_env(monkeypatch) -> None:
+    """Clear every env var the caller registry knows about.
+
+    The test process inherits whatever the calling shell has set
+    (e.g. CLAUDECODE=1 when these tests run inside Claude Code), so
+    deterministic tests must wipe the registry's footprint first.
+    """
+    for env_var, _ in _CALLER_REGISTRY:
+        monkeypatch.delenv(env_var, raising=False)
 
 
 def test_render_without_color_is_plain_ascii():
@@ -59,3 +77,95 @@ def test_print_banner_respects_no_color_env(monkeypatch):
     monkeypatch.setenv("NO_COLOR", "1")
     print_banner("x", stream=buf)
     assert "\033[" not in buf.getvalue()
+
+
+# --------------------------------------------------------------------------- #
+# Caller-attribution banner
+# --------------------------------------------------------------------------- #
+
+
+class _FakeTTY(io.StringIO):
+    """StringIO that reports as a TTY (and accepts a NO_COLOR-cleared env)."""
+
+    def isatty(self):
+        return True
+
+
+def test_detect_caller_returns_none_when_no_markers(monkeypatch):
+    _strip_caller_env(monkeypatch)
+    assert detect_caller() is None
+
+
+def test_detect_caller_returns_claude_code_when_claudecode_set(monkeypatch):
+    _strip_caller_env(monkeypatch)
+    monkeypatch.setenv("CLAUDECODE", "1")
+    assert detect_caller() == "Claude Code"
+
+
+def test_detect_caller_first_match_wins(monkeypatch):
+    """When multiple markers are set, the registry's order decides."""
+    _strip_caller_env(monkeypatch)
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setenv("SENTINEL", "1")
+    # Registry orders Claude Code before Sentinel; verify that holds.
+    assert detect_caller() == "Claude Code"
+
+
+def test_print_caller_banner_named_caller_is_attributed(monkeypatch):
+    _strip_caller_env(monkeypatch)
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setenv("NO_COLOR", "1")  # suppress ANSI for cleaner asserts
+    buf = io.StringIO()  # not a TTY, but caller-detection forces emit
+    print_caller_banner("kimi", stream=buf)
+    out = buf.getvalue()
+    assert "Claude Code is using Conductor" in out
+    assert "→ kimi" in out
+
+
+def test_print_caller_banner_generic_line_on_tty_without_caller(monkeypatch):
+    _strip_caller_env(monkeypatch)
+    monkeypatch.setenv("NO_COLOR", "1")
+    buf = _FakeTTY()
+    print_caller_banner("kimi", stream=buf)
+    out = buf.getvalue()
+    assert "Conductor" in out
+    assert "→ kimi" in out
+    assert "is using" not in out  # no caller attribution
+
+
+def test_print_caller_banner_silent_when_no_caller_and_not_tty(monkeypatch):
+    _strip_caller_env(monkeypatch)
+    buf = io.StringIO()  # not a TTY, no caller — neither attributable nor visible
+    print_caller_banner("kimi", stream=buf)
+    assert buf.getvalue() == ""
+
+
+def test_print_caller_banner_silent_flag_overrides_caller(monkeypatch):
+    _strip_caller_env(monkeypatch)
+    monkeypatch.setenv("CLAUDECODE", "1")
+    buf = io.StringIO()
+    print_caller_banner("kimi", stream=buf, silent=True)
+    assert buf.getvalue() == ""
+
+
+def test_print_caller_banner_colors_conductor_word_on_tty(monkeypatch):
+    _strip_caller_env(monkeypatch)
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("CLICOLOR", raising=False)
+    buf = _FakeTTY()
+    print_caller_banner("kimi", stream=buf)
+    out = buf.getvalue()
+    # The literal "Conductor" word is wrapped in the purple ANSI code
+    # when stderr is a TTY; surrounding text stays plain.
+    assert "\033[1;38;5;99mConductor\033[0m" in out
+
+
+def test_print_caller_banner_does_not_crash_on_closed_stream(monkeypatch):
+    """Branding must never fail a real call — closed/broken streams swallow."""
+    _strip_caller_env(monkeypatch)
+    monkeypatch.setenv("CLAUDECODE", "1")
+    buf = io.StringIO()
+    buf.close()
+    # Should not raise.
+    print_caller_banner("kimi", stream=buf)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,6 +74,8 @@ def test_call_kimi_missing_account_exits_2(monkeypatch):
 def test_call_json_output(monkeypatch):
     monkeypatch.setenv(CLOUDFLARE_API_TOKEN_ENV, "cf-test-token")
     monkeypatch.setenv(CLOUDFLARE_ACCOUNT_ID_ENV, _TEST_ACCOUNT_ID)
+    # The caller banner is silenced under --json (matches existing route-log
+    # silencing), so stdout stays clean for json.loads().
     with respx.mock() as router:
         router.post(_CF_CHAT_URL).mock(
             return_value=httpx.Response(
@@ -89,9 +91,63 @@ def test_call_json_output(monkeypatch):
             main, ["call", "--with", "kimi", "--task", "hi", "--json"]
         )
 
-    assert result.exit_code == 0, result.output
+    assert result.exit_code == 0, result.stderr
     import json
 
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["text"] == "ok"
     assert payload["provider"] == "kimi"
+
+
+def test_call_emits_caller_banner_when_claude_detected(monkeypatch):
+    """When CLAUDECODE is set, `conductor call` announces itself on stderr."""
+    monkeypatch.setenv(CLOUDFLARE_API_TOKEN_ENV, "cf-test-token")
+    monkeypatch.setenv(CLOUDFLARE_ACCOUNT_ID_ENV, _TEST_ACCOUNT_ID)
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setenv("NO_COLOR", "1")  # plain ASCII for stable assertion
+
+    with respx.mock() as router:
+        router.post(_CF_CHAT_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "model": KIMI_DEFAULT_MODEL,
+                    "choices": [{"message": {"content": "hello"}}],
+                    "usage": {},
+                },
+            )
+        )
+        result = CliRunner().invoke(
+            main, ["call", "--with", "kimi", "--task", "hi"]
+        )
+
+    assert result.exit_code == 0, result.stderr
+    # Banner on stderr — keeps stdout clean for subprocess parsing.
+    assert "Claude Code is using Conductor → kimi" in result.stderr
+    # Response on stdout, untouched.
+    assert result.stdout.strip() == "hello"
+
+
+def test_call_silent_route_suppresses_caller_banner(monkeypatch):
+    """--silent-route silences the caller banner (and the route log)."""
+    monkeypatch.setenv(CLOUDFLARE_API_TOKEN_ENV, "cf-test-token")
+    monkeypatch.setenv(CLOUDFLARE_ACCOUNT_ID_ENV, _TEST_ACCOUNT_ID)
+    monkeypatch.setenv("CLAUDECODE", "1")
+
+    with respx.mock() as router:
+        router.post(_CF_CHAT_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "model": KIMI_DEFAULT_MODEL,
+                    "choices": [{"message": {"content": "hello"}}],
+                    "usage": {},
+                },
+            )
+        )
+        result = CliRunner().invoke(
+            main, ["call", "--with", "kimi", "--task", "hi", "--silent-route"]
+        )
+
+    assert result.exit_code == 0, result.stderr
+    assert "Conductor" not in result.stderr


### PR DESCRIPTION
Emit a one-line stderr banner at the top of every conductor call/exec
that names the LLM tool driving us when one is detectable, falling back
to a generic "▸ Conductor → <provider>" line when stderr is a TTY.
Stays silent on piped non-detected invocations so subprocess parsing
of stdout is undisturbed.

Caller registry ships with verified entries (CLAUDECODE → "Claude Code")
and convention entries for autumn-garage peers (SENTINEL, TOUCHSTONE).
TODO stubs for Cursor/Aider/Codex/Gemini are left commented so the
registry never claims coverage we haven't tested.

Silenced together with the route log under --silent-route or --json.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
