### PR TITLE
feat: auth-aware configured() for claude/codex/gemini adapters

### DIFF
--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -53,6 +53,12 @@ class ClaudeProvider:
     # Claude Sonnet 4.6 ships 1M context via the CLI's long-context mode.
     max_context_tokens = 1_000_000
 
+    # User-facing login command surfaced in error messages and the init
+    # wizard. Note: top-level `claude --help` doesn't list `auth` as a
+    # subcommand, but `claude auth login` is the actual non-interactive
+    # entry point (the slash variant `/login` only works inside the REPL).
+    auth_login_command = "claude auth login"
+
     def __init__(
         self,
         *,
@@ -62,13 +68,69 @@ class ClaudeProvider:
         self._cli = cli_command
         self._timeout_sec = timeout_sec
 
-    def configured(self) -> tuple[bool, str | None]:
+    def _check_cli_path(self) -> tuple[bool, str | None]:
+        """Cheap PATH-only check (no subprocess). Used by call()/exec()
+        for the defensive guard so the hot path doesn't take an auth-probe
+        round-trip on every invocation."""
         if not shutil.which(self._cli):
             return False, (
                 f"`{self._cli}` CLI not found on PATH. "
-                "Install with `brew install claude` and auth with `claude login`."
+                "Install with `brew install claude` and auth with "
+                f"`{self.auth_login_command}` "
+                "(or set `ANTHROPIC_API_KEY` for non-interactive use)."
             )
         return True, None
+
+    def _auth_probe(self) -> tuple[bool, str | None]:
+        """Verify the user is authenticated.
+
+        Calls ``claude auth status --json``, which exits 0 in BOTH the
+        authed and unauthed cases — the JSON body's ``loggedIn`` field
+        is the canonical signal. Returns a structured failure reason for
+        every error mode (timeout, non-JSON, missing field, loggedIn=false)
+        so doctor/wizard can render a useful next step.
+        """
+        try:
+            result = subprocess.run(
+                [self._cli, "auth", "status", "--json"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+            return False, (
+                f"could not verify `{self._cli}` auth status: {e}. "
+                "Update the CLI (`brew upgrade claude`) and re-run, "
+                "or set `ANTHROPIC_API_KEY` for non-interactive use."
+            )
+        if result.returncode != 0:
+            return False, (
+                f"`{self._cli} auth status` exited {result.returncode}: "
+                f"{(result.stderr or result.stdout).strip()[:200]}. "
+                "Older CLIs may lack the `auth` subcommand; "
+                "`brew upgrade claude` and retry."
+            )
+        try:
+            data = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            return False, (
+                f"`{self._cli} auth status --json` output was not JSON: "
+                f"{result.stdout[:200]!r}"
+            )
+        if data.get("loggedIn"):
+            return True, None
+        return False, (
+            "not authenticated. "
+            f"Run `{self.auth_login_command}` to log in via browser, "
+            "`claude setup-token` for a long-lived token (subscription req'd), "
+            "or set `ANTHROPIC_API_KEY` for non-interactive use."
+        )
+
+    def configured(self) -> tuple[bool, str | None]:
+        ok, reason = self._check_cli_path()
+        if not ok:
+            return False, reason
+        return self._auth_probe()
 
     def smoke(self) -> tuple[bool, str | None]:
         ok, reason = self.configured()
@@ -154,7 +216,11 @@ class ClaudeProvider:
         timeout_sec_override: float | None = None,
         resume_session_id: str | None = None,
     ) -> CallResponse:
-        ok, reason = self.configured()
+        # Cheap PATH check only on the hot path — auth state surfaces as a
+        # CLI exit failure below if the user installed but didn't log in.
+        # `configured()` (with the auth probe) is the entry point that
+        # `doctor`/`list`/wizard call.
+        ok, reason = self._check_cli_path()
         if not ok:
             raise ProviderConfigError(reason or "claude not configured")
 

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -65,6 +65,9 @@ class CodexProvider:
     # GPT-5-codex ships 400K context via the `codex` CLI.
     max_context_tokens = 400_000
 
+    # User-facing login command surfaced in error messages and the wizard.
+    auth_login_command = "codex login"
+
     def __init__(
         self,
         *,
@@ -74,13 +77,47 @@ class CodexProvider:
         self._cli = cli_command
         self._timeout_sec = timeout_sec
 
-    def configured(self) -> tuple[bool, str | None]:
+    def _check_cli_path(self) -> tuple[bool, str | None]:
+        """Cheap PATH-only check (no subprocess) for the call/exec hot path."""
         if not shutil.which(self._cli):
             return False, (
                 f"`{self._cli}` CLI not found on PATH. "
-                "Install with `npm install -g @openai/codex` and auth with `codex login`."
+                "Install with `npm install -g @openai/codex` "
+                f"and auth with `{self.auth_login_command}` "
+                "(or set `OPENAI_API_KEY` for non-interactive use)."
             )
         return True, None
+
+    def _auth_probe(self) -> tuple[bool, str | None]:
+        """Verify auth via `codex login status` (exit 0 = logged in)."""
+        try:
+            result = subprocess.run(
+                [self._cli, "login", "status"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+            return False, (
+                f"could not verify `{self._cli}` auth status: {e}. "
+                "Update the CLI and retry, or set `OPENAI_API_KEY` "
+                "for non-interactive use."
+            )
+        if result.returncode == 0:
+            return True, None
+        return False, (
+            "not authenticated. "
+            f"Run `{self.auth_login_command}` to log in via browser, "
+            f"`{self._cli} login --device-auth` for headless flow, "
+            f"or `printenv OPENAI_API_KEY | {self._cli} login --with-api-key` "
+            "for non-interactive use."
+        )
+
+    def configured(self) -> tuple[bool, str | None]:
+        ok, reason = self._check_cli_path()
+        if not ok:
+            return False, reason
+        return self._auth_probe()
 
     def smoke(self) -> tuple[bool, str | None]:
         ok, reason = self.configured()
@@ -198,7 +235,10 @@ class CodexProvider:
         timeout_sec_override: float | None = None,
         resume_session_id: str | None = None,
     ) -> CallResponse:
-        ok, reason = self.configured()
+        # Cheap PATH check on the hot path; auth state surfaces as a CLI
+        # exit failure below if needed. configured() (with auth probe) is
+        # the entry point that doctor/list/wizard call.
+        ok, reason = self._check_cli_path()
         if not ok:
             raise ProviderConfigError(reason or "codex not configured")
 

--- a/src/conductor/providers/gemini.py
+++ b/src/conductor/providers/gemini.py
@@ -13,9 +13,11 @@ multiple model hops.
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import time
+from pathlib import Path
 
 from conductor.providers.interface import (
     CallResponse,
@@ -27,6 +29,17 @@ from conductor.providers.interface import (
 
 GEMINI_DEFAULT_MODEL = "gemini-2.5-pro"
 GEMINI_REQUEST_TIMEOUT_SEC = 180.0
+
+# Env vars Gemini CLI accepts as auth credentials. Any one of these being
+# set is sufficient — the CLI prefers them over the OAuth file.
+GEMINI_AUTH_ENV_VARS = (
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+)
+# Default OAuth credentials file written by the CLI's first-run browser
+# flow. Override per-instance via the constructor for tests.
+GEMINI_DEFAULT_OAUTH_CREDS_PATH = Path.home() / ".gemini" / "oauth_creds.json"
 
 
 class GeminiProvider:
@@ -53,23 +66,93 @@ class GeminiProvider:
     # Gemini 2.5 Pro ships a 2M context window.
     max_context_tokens = 2_000_000
 
+    # No `gemini login` subcommand exists as of 0.38.x — the first
+    # interactive run of `gemini` itself triggers browser OAuth. None
+    # signals to the wizard that there's no non-interactive login command;
+    # the recommended fallback is `GEMINI_API_KEY`.
+    auth_login_command: str | None = None
+
     def __init__(
         self,
         *,
         cli_command: str = "gemini",
         timeout_sec: float = GEMINI_REQUEST_TIMEOUT_SEC,
+        oauth_creds_path: Path | None = None,
     ) -> None:
         self._cli = cli_command
         self._timeout_sec = timeout_sec
+        self._oauth_creds_path = (
+            oauth_creds_path
+            if oauth_creds_path is not None
+            else GEMINI_DEFAULT_OAUTH_CREDS_PATH
+        )
 
-    def configured(self) -> tuple[bool, str | None]:
+    def _check_cli_path(self) -> tuple[bool, str | None]:
+        """Cheap PATH-only check (no subprocess) for the call/exec hot path."""
         if not shutil.which(self._cli):
             return False, (
                 f"`{self._cli}` CLI not found on PATH. "
                 "Install with `npm install -g @google/gemini-cli`; "
-                "first run will prompt a browser auth."
+                "first run will prompt a browser auth, "
+                "or set `GEMINI_API_KEY` for non-interactive use."
             )
         return True, None
+
+    def _auth_probe(self) -> tuple[bool, str | None]:
+        """Verify auth state via env vars or the OAuth credentials file.
+
+        Gemini CLI doesn't ship `auth status` or `login` subcommands as of
+        0.38.x — they're interpreted as prompts and silently start an
+        agent loop. The probe runs:
+
+          1. Any of GEMINI_API_KEY / GOOGLE_API_KEY /
+             GOOGLE_APPLICATION_CREDENTIALS set → authed (the CLI uses
+             these directly without OAuth).
+          2. ``~/.gemini/oauth_creds.json`` exists, JSON-parses, and
+             carries an access_token or refresh_token → authed. We
+             deliberately don't check ``expiry_date``: the CLI uses the
+             refresh_token to mint new access tokens silently, so an
+             expired access_token isn't a real failure.
+          3. Otherwise → not authed.
+
+        Revisit when Gemini ships a real auth subcommand.
+        """
+        if any(os.environ.get(v) for v in GEMINI_AUTH_ENV_VARS):
+            return True, None
+
+        creds = self._oauth_creds_path
+        if not creds.exists():
+            return False, (
+                "not authenticated. "
+                f"Run `{self._cli}` interactively to trigger browser OAuth, "
+                "or set `GEMINI_API_KEY` (or GOOGLE_API_KEY / "
+                "GOOGLE_APPLICATION_CREDENTIALS) for non-interactive use."
+            )
+
+        try:
+            data = json.loads(creds.read_text())
+        except (OSError, json.JSONDecodeError) as e:
+            return False, (
+                f"could not parse {creds}: {e}. "
+                f"Re-run `{self._cli}` to refresh the OAuth credentials, "
+                "or set `GEMINI_API_KEY` for non-interactive use."
+            )
+
+        if not isinstance(data, dict) or not (
+            data.get("access_token") or data.get("refresh_token")
+        ):
+            return False, (
+                f"{creds} exists but has no usable tokens. "
+                f"Re-run `{self._cli}` to refresh."
+            )
+
+        return True, None
+
+    def configured(self) -> tuple[bool, str | None]:
+        ok, reason = self._check_cli_path()
+        if not ok:
+            return False, reason
+        return self._auth_probe()
 
     def smoke(self) -> tuple[bool, str | None]:
         ok, reason = self.configured()
@@ -147,7 +230,10 @@ class GeminiProvider:
         timeout_sec_override: float | None = None,
         resume_session_id: str | None = None,
     ) -> CallResponse:
-        ok, reason = self.configured()
+        # Cheap PATH check on the hot path; auth state surfaces as a CLI
+        # exit failure below if needed. configured() (with auth probe) is
+        # the entry point that doctor/list/wizard call.
+        ok, reason = self._check_cli_path()
         if not ok:
             raise ProviderConfigError(reason or "gemini not configured")
 
@@ -173,11 +259,10 @@ class GeminiProvider:
             args.extend(["--resume", resume_session_id])
         # Gemini CLI thinking budget support is evolving; pass via env var as
         # a forward-compatible hook. Ignored by versions that don't read it.
-        import os as _os
         env_overrides: dict[str, str] = {}
         if thinking_budget:
             env_overrides["GEMINI_THINKING_BUDGET"] = str(thinking_budget)
-        proc_env = {**_os.environ, **env_overrides} if env_overrides else None
+        proc_env = {**os.environ, **env_overrides} if env_overrides else None
 
         timeout = timeout_sec_override if timeout_sec_override is not None else self._timeout_sec
         start = time.monotonic()

--- a/src/conductor/wizard.py
+++ b/src/conductor/wizard.py
@@ -70,11 +70,15 @@ _INFO: dict[str, _ProviderInfo] = {
             "npm install -g @anthropic-ai/claude-code    # any platform",
         ],
         auth_cmds=[
-            "claude /login    # opens a browser for subscription OAuth",
+            "claude auth login         # opens a browser for subscription OAuth",
+            "# OR for headless / non-interactive use:",
+            "claude setup-token        # long-lived token (subscription req'd)",
+            "export ANTHROPIC_API_KEY=sk-ant-...    # API-key billing",
         ],
         troubleshoot_tips=[
-            "`claude /login` opens a browser — won't work in a headless env.",
-            "Verify with `claude --version` (need >= 1.0); then `claude -p 'hi'`.",
+            "`claude auth login` opens a browser — won't work in a headless env; "
+            "use `claude setup-token` or set `ANTHROPIC_API_KEY` instead.",
+            "Verify with `claude auth status --json` — `loggedIn: true` means authed.",
             "Subscription status: https://claude.ai/plans — Pro or Team required.",
             "Behind a proxy? auth uses auth0; check $HTTP_PROXY / firewall rules.",
         ],

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -14,13 +14,23 @@ import pytest
 
 from conductor.providers.claude import ClaudeProvider
 from conductor.providers.codex import CodexProvider
-from conductor.providers.gemini import GeminiProvider
+from conductor.providers.gemini import GEMINI_AUTH_ENV_VARS, GeminiProvider
 from conductor.providers.interface import (
     CallResponse,
     ProviderConfigError,
     ProviderError,
     ProviderHTTPError,
 )
+
+
+def _strip_gemini_auth_env(monkeypatch) -> None:
+    """Clear any GEMINI/GOOGLE auth env vars inherited from the host shell.
+
+    Without this, tests that exercise the OAuth-file path silently
+    succeed via the env-var fast path on developer machines.
+    """
+    for var in GEMINI_AUTH_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
 
 
 def _fake_completed(stdout: str = "", stderr: str = "", returncode: int = 0):
@@ -42,8 +52,12 @@ CLAUDE_JSON = """{
 }"""
 
 
-def test_claude_configured_when_cli_present(mocker):
+def test_claude_configured_when_cli_present_and_authed(mocker):
     mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
+    mocker.patch(
+        "conductor.providers.claude.subprocess.run",
+        return_value=_fake_completed(stdout='{"loggedIn": true}'),
+    )
     ok, reason = ClaudeProvider().configured()
     assert ok is True and reason is None
 
@@ -51,7 +65,62 @@ def test_claude_configured_when_cli_present(mocker):
 def test_claude_configured_false_when_cli_missing(mocker):
     mocker.patch("conductor.providers.claude.shutil.which", return_value=None)
     ok, reason = ClaudeProvider().configured()
-    assert ok is False and "claude" in reason
+    assert ok is False
+    assert "not found on PATH" in reason
+    # Reason names the actionable login command + env-var fallback.
+    assert "claude auth login" in reason
+    assert "ANTHROPIC_API_KEY" in reason
+
+
+def test_claude_configured_false_when_not_authed(mocker):
+    mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
+    mocker.patch(
+        "conductor.providers.claude.subprocess.run",
+        return_value=_fake_completed(stdout='{"loggedIn": false}'),
+    )
+    ok, reason = ClaudeProvider().configured()
+    assert ok is False
+    assert "not authenticated" in reason
+    assert "claude auth login" in reason
+    assert "ANTHROPIC_API_KEY" in reason
+
+
+def test_claude_configured_false_when_auth_probe_exits_nonzero(mocker):
+    """Older CLI versions without `auth status` exit non-zero — surface,
+    don't silently treat as authed."""
+    mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
+    mocker.patch(
+        "conductor.providers.claude.subprocess.run",
+        return_value=_fake_completed(
+            stderr="error: unknown command 'auth'", returncode=2
+        ),
+    )
+    ok, reason = ClaudeProvider().configured()
+    assert ok is False
+    assert "exited 2" in reason
+    assert "upgrade" in reason.lower()
+
+
+def test_claude_configured_false_when_auth_probe_times_out(mocker):
+    mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
+    mocker.patch(
+        "conductor.providers.claude.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="claude", timeout=5),
+    )
+    ok, reason = ClaudeProvider().configured()
+    assert ok is False
+    assert "could not verify" in reason
+
+
+def test_claude_configured_false_when_auth_probe_returns_non_json(mocker):
+    mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
+    mocker.patch(
+        "conductor.providers.claude.subprocess.run",
+        return_value=_fake_completed(stdout="hello not json"),
+    )
+    ok, reason = ClaudeProvider().configured()
+    assert ok is False
+    assert "not JSON" in reason
 
 
 def test_claude_call_returns_normalized_response(mocker):
@@ -163,10 +232,49 @@ CODEX_NDJSON = (
 )
 
 
-def test_codex_configured_when_cli_present(mocker):
+def test_codex_configured_when_cli_present_and_authed(mocker):
     mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
-    ok, _ = CodexProvider().configured()
-    assert ok is True
+    mocker.patch(
+        "conductor.providers.codex.subprocess.run",
+        return_value=_fake_completed(stdout="Logged in using ChatGPT"),
+    )
+    ok, reason = CodexProvider().configured()
+    assert ok is True and reason is None
+
+
+def test_codex_configured_false_when_cli_missing(mocker):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value=None)
+    ok, reason = CodexProvider().configured()
+    assert ok is False
+    assert "not found on PATH" in reason
+    assert "codex login" in reason
+    assert "OPENAI_API_KEY" in reason
+
+
+def test_codex_configured_false_when_not_authed(mocker):
+    """`codex login status` exits non-zero when the user isn't authed."""
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    mocker.patch(
+        "conductor.providers.codex.subprocess.run",
+        return_value=_fake_completed(stderr="not logged in", returncode=1),
+    )
+    ok, reason = CodexProvider().configured()
+    assert ok is False
+    assert "not authenticated" in reason
+    assert "codex login" in reason
+    assert "OPENAI_API_KEY" in reason
+    assert "--with-api-key" in reason
+
+
+def test_codex_configured_false_when_auth_probe_times_out(mocker):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    mocker.patch(
+        "conductor.providers.codex.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="codex", timeout=5),
+    )
+    ok, reason = CodexProvider().configured()
+    assert ok is False
+    assert "could not verify" in reason
 
 
 def test_codex_call_parses_ndjson_and_usage(mocker):
@@ -240,10 +348,86 @@ GEMINI_JSON = """{
 }"""
 
 
-def test_gemini_configured_when_cli_present(mocker):
+def test_gemini_configured_when_cli_present_and_env_authed(mocker, monkeypatch):
     mocker.patch("conductor.providers.gemini.shutil.which", return_value="/usr/bin/gemini")
-    ok, _ = GeminiProvider().configured()
-    assert ok is True
+    _strip_gemini_auth_env(monkeypatch)
+    monkeypatch.setenv("GEMINI_API_KEY", "fake-key")
+    ok, reason = GeminiProvider().configured()
+    assert ok is True and reason is None
+
+
+def test_gemini_configured_when_oauth_creds_have_tokens(
+    mocker, monkeypatch, tmp_path
+):
+    """Filesystem-only auth path — env vars unset, OAuth file present."""
+    mocker.patch("conductor.providers.gemini.shutil.which", return_value="/usr/bin/gemini")
+    _strip_gemini_auth_env(monkeypatch)
+    creds = tmp_path / "oauth_creds.json"
+    creds.write_text(
+        '{"access_token": "ya29.fake", "refresh_token": "1//fake", '
+        '"expiry_date": 0}'
+    )
+    # Expiry deliberately stale — we trust the CLI to refresh, so an
+    # expired access_token alongside a refresh_token is still authed.
+    ok, reason = GeminiProvider(oauth_creds_path=creds).configured()
+    assert ok is True and reason is None
+
+
+def test_gemini_configured_false_when_cli_missing(mocker):
+    mocker.patch("conductor.providers.gemini.shutil.which", return_value=None)
+    ok, reason = GeminiProvider().configured()
+    assert ok is False
+    assert "not found on PATH" in reason
+    assert "GEMINI_API_KEY" in reason
+
+
+def test_gemini_configured_false_when_no_env_and_no_oauth_file(
+    mocker, monkeypatch, tmp_path
+):
+    mocker.patch("conductor.providers.gemini.shutil.which", return_value="/usr/bin/gemini")
+    _strip_gemini_auth_env(monkeypatch)
+    missing = tmp_path / "does_not_exist.json"
+    ok, reason = GeminiProvider(oauth_creds_path=missing).configured()
+    assert ok is False
+    assert "not authenticated" in reason
+    assert "GEMINI_API_KEY" in reason
+    assert "GOOGLE_API_KEY" in reason
+
+
+def test_gemini_configured_false_when_oauth_file_corrupt(
+    mocker, monkeypatch, tmp_path
+):
+    mocker.patch("conductor.providers.gemini.shutil.which", return_value="/usr/bin/gemini")
+    _strip_gemini_auth_env(monkeypatch)
+    creds = tmp_path / "oauth_creds.json"
+    creds.write_text("not valid json {{")
+    ok, reason = GeminiProvider(oauth_creds_path=creds).configured()
+    assert ok is False
+    assert "could not parse" in reason
+
+
+def test_gemini_configured_false_when_oauth_file_has_no_tokens(
+    mocker, monkeypatch, tmp_path
+):
+    mocker.patch("conductor.providers.gemini.shutil.which", return_value="/usr/bin/gemini")
+    _strip_gemini_auth_env(monkeypatch)
+    creds = tmp_path / "oauth_creds.json"
+    creds.write_text('{"unrelated_field": "value"}')
+    ok, reason = GeminiProvider(oauth_creds_path=creds).configured()
+    assert ok is False
+    assert "no usable tokens" in reason
+
+
+def test_gemini_configured_when_only_google_application_credentials_set(
+    mocker, monkeypatch, tmp_path
+):
+    """Vertex AI ADC path — GOOGLE_APPLICATION_CREDENTIALS is sufficient."""
+    mocker.patch("conductor.providers.gemini.shutil.which", return_value="/usr/bin/gemini")
+    _strip_gemini_auth_env(monkeypatch)
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "/tmp/sa.json")
+    missing = tmp_path / "does_not_exist.json"  # unreachable; env wins
+    ok, reason = GeminiProvider(oauth_creds_path=missing).configured()
+    assert ok is True and reason is None
 
 
 def test_gemini_call_parses_json_and_usage(mocker):


### PR DESCRIPTION
Splits each subprocess adapter's `configured()` into a fast PATH check
plus an auth probe so `doctor`, `list`, and the init wizard stop
reporting "✓" for users who installed the CLI but never logged in.

Probes (verified empirically against installed CLIs):
- claude: `claude auth status --json` → JSON `loggedIn: true|false`
- codex:  `codex login status` → exit 0 when authed
- gemini: GEMINI_API_KEY / GOOGLE_API_KEY / GOOGLE_APPLICATION_CREDENTIALS
          env-var fast path, then `~/.gemini/oauth_creds.json` token check
          (no auth subcommand exists as of 0.38.x)

Each adapter exposes `auth_login_command` so error messages and the
wizard surface the exact next-step incantation. `_run()` uses only the
cheap PATH check on the hot path — auth state surfaces as a CLI exit
failure if the probe was skipped.

Incidental fixes:
- Wrong install hint at claude.py:69 said `claude login`; the actual
  command is `claude auth login` (the slash variant only works inside
  the REPL).
- wizard.py auth_cmds for claude updated to match, plus mentions
  `claude setup-token` (headless) and `ANTHROPIC_API_KEY` (non-interactive).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
