### PR TITLE
feat: register deepseek-chat and deepseek-reasoner providers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Both modes return the same `CallResponse` shape on stdout (text or JSON via `--j
 
 ### Two physical adapter shapes
 
-- **HTTP adapters** (e.g. `kimi`, `ollama`) talk to an OpenAI-compatible endpoint via `httpx`. These are the only adapters that touch API keys directly.
+- **HTTP adapters** (e.g. `kimi`, `deepseek-chat`, `deepseek-reasoner`, `ollama`) talk to an OpenAI-compatible endpoint via `httpx`. These are the only adapters that touch API keys directly. DeepSeek is registered as two providers backed by one HTTP base class — `deepseek-chat` (V3.x: cheap, code-review, tool-use) and `deepseek-reasoner` (R1: strong-reasoning, thinking) — so the auto-mode router can pick the right model per task tag while sharing one `DEEPSEEK_API_KEY`.
 - **Subprocess adapters** (e.g. `claude`, `codex`, `gemini`) shell out to a CLI that owns its own auth. These never touch API keys.
 
 Both shapes implement the same `Provider` Protocol (`configured()`, `smoke()`, `call()`) so the rest of Conductor doesn't care which physical shape it's calling.

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -607,8 +607,11 @@ def main() -> None:
     "--with",
     "provider_id",
     default=None,
-    help="Provider identifier (kimi, claude, codex, gemini, ollama). "
-    "Mutually exclusive with --auto.",
+    help=(
+        "Provider identifier "
+        "(kimi, claude, codex, deepseek-chat, deepseek-reasoner, gemini, ollama). "
+        "Mutually exclusive with --auto."
+    ),
 )
 @click.option(
     "--auto",
@@ -1244,6 +1247,7 @@ def smoke(provider_id: str | None, run_all: bool, as_json: bool) -> None:
 _DIAGNOSTIC_ENV_VARS = (
     "CLOUDFLARE_API_TOKEN",
     "CLOUDFLARE_ACCOUNT_ID",
+    "DEEPSEEK_API_KEY",
     "OLLAMA_BASE_URL",
 )
 
@@ -1687,7 +1691,15 @@ def providers_add(
     # Guard against shadowing built-ins — the loader does the same check
     # when reading the file, but catching it here gives a friendlier error
     # before the file is touched.
-    if name in {"kimi", "claude", "codex", "gemini", "ollama"}:
+    if name in {
+        "kimi",
+        "claude",
+        "codex",
+        "deepseek-chat",
+        "deepseek-reasoner",
+        "gemini",
+        "ollama",
+    }:
         raise click.UsageError(
             f"`{name}` is a built-in provider identifier. Pick a different name."
         )

--- a/src/conductor/custom_providers.py
+++ b/src/conductor/custom_providers.py
@@ -217,4 +217,14 @@ def _escape(s: str) -> str:
 # Built-in names that custom entries MUST NOT shadow. Kept here (and not
 # derived from providers/__init__._REGISTRY) to avoid a circular import —
 # the values change only when a new first-party provider ships.
-_BUILTIN_NAMES = frozenset({"kimi", "claude", "codex", "gemini", "ollama"})
+_BUILTIN_NAMES = frozenset(
+    {
+        "kimi",
+        "claude",
+        "codex",
+        "deepseek-chat",
+        "deepseek-reasoner",
+        "gemini",
+        "ollama",
+    }
+)

--- a/src/conductor/providers/__init__.py
+++ b/src/conductor/providers/__init__.py
@@ -1,5 +1,6 @@
 from conductor.providers.claude import ClaudeProvider
 from conductor.providers.codex import CodexProvider
+from conductor.providers.deepseek import DeepSeekChatProvider, DeepSeekReasonerProvider
 from conductor.providers.gemini import GeminiProvider
 from conductor.providers.interface import (
     EFFORT_LEVELS,
@@ -28,6 +29,8 @@ __all__ = [
     "CallResponse",
     "ClaudeProvider",
     "CodexProvider",
+    "DeepSeekChatProvider",
+    "DeepSeekReasonerProvider",
     "GeminiProvider",
     "KimiProvider",
     "OllamaProvider",
@@ -47,6 +50,8 @@ _BUILTIN_REGISTRY: dict[str, type[Provider]] = {
     "kimi": KimiProvider,
     "claude": ClaudeProvider,
     "codex": CodexProvider,
+    "deepseek-chat": DeepSeekChatProvider,
+    "deepseek-reasoner": DeepSeekReasonerProvider,
     "gemini": GeminiProvider,
     "ollama": OllamaProvider,
 }

--- a/src/conductor/providers/deepseek.py
+++ b/src/conductor/providers/deepseek.py
@@ -1,0 +1,281 @@
+"""DeepSeek provider — direct DeepSeek API (OpenAI-compatible).
+
+DeepSeek ships two distinct models that map to different conductor use cases,
+so they are registered as two providers (``deepseek-chat`` and
+``deepseek-reasoner``) backed by one HTTP base class:
+
+  - ``deepseek-chat``     — V3.x: cheap, fast, general/code-review.
+  - ``deepseek-reasoner`` — R1: strong-reasoning with built-in chain-of-thought.
+
+Both share one credential (``DEEPSEEK_API_KEY``) and one endpoint
+(``https://api.deepseek.com/v1``). The router picks between them via the
+provider-level tags.
+
+A future Cloudflare-hosted backend (parity with how Kimi reaches CF) would
+land as a backend option on this same provider, not a new identifier — same
+rule documented in ``kimi.py``.
+
+v1 scope: single-turn ``call()`` only. ``exec()`` without tools delegates
+to ``call()``; with tools, raises ``UnsupportedCapability``. Tool-use
+loop can be added later mirroring the kimi/ollama pattern; not in scope
+for this adapter's first cut.
+"""
+
+from __future__ import annotations
+
+import time
+
+import httpx
+
+from conductor import credentials
+from conductor.providers.interface import (
+    CallResponse,
+    ProviderConfigError,
+    ProviderHTTPError,
+    UnsupportedCapability,
+    resolve_effort_tokens,
+)
+
+DEEPSEEK_API_KEY_ENV = "DEEPSEEK_API_KEY"
+DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1"
+DEEPSEEK_REQUEST_TIMEOUT_SEC = 120.0
+
+DEEPSEEK_CHAT_MODEL = "deepseek-chat"
+DEEPSEEK_REASONER_MODEL = "deepseek-reasoner"
+
+
+class _DeepSeekBase:
+    """Shared HTTP plumbing for DeepSeek's OpenAI-compatible endpoint.
+
+    Subclasses set ``name``, ``default_model``, ``tags``, and the capability
+    fields the router scores against.
+    """
+
+    # --- subclasses must override --- #
+    name: str = ""
+    default_model: str = ""
+    tags: list[str] = []
+
+    # --- capability declarations (subclasses may override) --- #
+    quality_tier = "strong"
+    supported_tools: frozenset[str] = frozenset()
+    supported_sandboxes: frozenset[str] = frozenset({"none"})
+    supports_effort = False
+    effort_to_thinking: dict[str, int] = {}
+    cost_per_1k_in = 0.0
+    cost_per_1k_out = 0.0
+    cost_per_1k_thinking = 0.0
+    typical_p50_ms = 3000
+    max_context_tokens = 128_000
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str = DEEPSEEK_BASE_URL,
+        timeout_sec: float = DEEPSEEK_REQUEST_TIMEOUT_SEC,
+    ) -> None:
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._timeout_sec = timeout_sec
+
+    def _resolve_key(self) -> str:
+        key = self._api_key or credentials.get(DEEPSEEK_API_KEY_ENV)
+        if not key:
+            raise ProviderConfigError(
+                f"{DEEPSEEK_API_KEY_ENV} is not set. "
+                "Create an API key at https://platform.deepseek.com/api_keys "
+                "and set it via `conductor init` or "
+                f"`export {DEEPSEEK_API_KEY_ENV}=...`."
+            )
+        return key
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._resolve_key()}",
+            "Content-Type": "application/json",
+        }
+
+    def configured(self) -> tuple[bool, str | None]:
+        if self._api_key or credentials.get(DEEPSEEK_API_KEY_ENV):
+            return True, None
+        return False, (
+            f"missing credential: {DEEPSEEK_API_KEY_ENV}. "
+            "Set via `conductor init` or export as an env var."
+        )
+
+    def smoke(self) -> tuple[bool, str | None]:
+        # Cheapest round-trip that proves auth + endpoint + model are reachable.
+        try:
+            response = self._post_chat(
+                {
+                    "model": self.default_model,
+                    "messages": [{"role": "user", "content": "ping"}],
+                    "max_tokens": 1,
+                }
+            )
+        except ProviderConfigError as e:
+            return False, str(e)
+        except ProviderHTTPError as e:
+            return False, str(e)
+        if "choices" not in response:
+            return False, f"unexpected response shape: {sorted(response)[:5]}"
+        return True, None
+
+    def _post_chat(self, payload: dict) -> dict:
+        try:
+            with httpx.Client(timeout=self._timeout_sec) as client:
+                resp = client.post(
+                    f"{self._base_url}/chat/completions",
+                    headers=self._headers(),
+                    json=payload,
+                )
+        except httpx.HTTPError as e:
+            raise ProviderHTTPError(f"network error calling DeepSeek: {e}") from e
+
+        if resp.status_code != 200:
+            raise ProviderHTTPError(
+                f"DeepSeek returned HTTP {resp.status_code}: {resp.text[:500]}"
+            )
+        try:
+            return resp.json()
+        except ValueError as e:
+            raise ProviderHTTPError(f"DeepSeek response was not JSON: {e}") from e
+
+    def call(
+        self,
+        task: str,
+        model: str | None = None,
+        *,
+        effort: str | int = "medium",
+        resume_session_id: str | None = None,
+    ) -> CallResponse:
+        if resume_session_id:
+            raise UnsupportedCapability(
+                f"{self.name} has no session model — each DeepSeek API call is "
+                "stateless. To replay context, prepend the prior turns to `task`."
+            )
+        model = model or self.default_model
+        thinking_budget = resolve_effort_tokens(effort, self.effort_to_thinking)
+
+        payload: dict = {
+            "model": model,
+            "messages": [{"role": "user", "content": task}],
+        }
+
+        start = time.monotonic()
+        body = self._post_chat(payload)
+        duration_ms = int((time.monotonic() - start) * 1000)
+
+        try:
+            text = body["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError) as e:
+            raise ProviderHTTPError(
+                f"DeepSeek response missing choices[0].message.content: {body!r:.500}"
+            ) from e
+
+        # deepseek-reasoner returns its chain-of-thought in
+        # ``choices[0].message.reasoning_content``; surface its length in usage
+        # for observability without forcing it into ``text``.
+        reasoning_content = (
+            (body.get("choices") or [{}])[0].get("message", {}).get("reasoning_content")
+        )
+        usage = body.get("usage") or {}
+        return CallResponse(
+            text=text,
+            provider=self.name,
+            model=body.get("model", model),
+            duration_ms=duration_ms,
+            usage={
+                "input_tokens": usage.get("prompt_tokens"),
+                "output_tokens": usage.get("completion_tokens"),
+                "cached_tokens": (usage.get("prompt_tokens_details") or {}).get(
+                    "cached_tokens"
+                ),
+                "thinking_tokens": (usage.get("completion_tokens_details") or {}).get(
+                    "reasoning_tokens"
+                ),
+                "reasoning_chars": len(reasoning_content) if reasoning_content else 0,
+                "effort": effort if isinstance(effort, str) else None,
+                "thinking_budget": thinking_budget,
+            },
+            raw=body,
+        )
+
+    def exec(
+        self,
+        task: str,
+        model: str | None = None,
+        *,
+        effort: str | int = "medium",
+        tools: frozenset[str] = frozenset(),
+        sandbox: str = "none",
+        cwd: str | None = None,
+        timeout_sec: int = 300,
+        resume_session_id: str | None = None,
+    ) -> CallResponse:
+        if resume_session_id:
+            raise UnsupportedCapability(
+                f"{self.name} has no session model — each DeepSeek API call is "
+                "stateless. To replay context, prepend the prior turns to `task`."
+            )
+        if sandbox == "":
+            sandbox = "none"
+
+        if tools:
+            raise UnsupportedCapability(
+                f"{self.name} does not yet drive a tool-use loop in conductor "
+                f"(supported tools: {sorted(self.supported_tools) or 'none'}). "
+                "Use a provider with tool support (claude, codex, gemini, "
+                "kimi, ollama) or run this task without --tools."
+            )
+        if sandbox != "none":
+            raise UnsupportedCapability(
+                f"{self.name}.exec() sandbox={sandbox!r} is not meaningful "
+                "without tools. Use sandbox='none' for a text-only exec."
+            )
+        return self.call(task, model=model, effort=effort)
+
+
+class DeepSeekChatProvider(_DeepSeekBase):
+    """DeepSeek V3.x chat model — cheap, fast, general code-review tier."""
+
+    name = "deepseek-chat"
+    default_model = DEEPSEEK_CHAT_MODEL
+    tags = ["cheap", "code-review", "tool-use"]
+
+    quality_tier = "strong"
+    supports_effort = False
+    effort_to_thinking: dict[str, int] = {}
+    # Cache-miss prices; cache hits are cheaper but unpredictable for budgeting.
+    cost_per_1k_in = 0.00027
+    cost_per_1k_out = 0.0011
+    cost_per_1k_thinking = 0.0
+    typical_p50_ms = 2500
+    max_context_tokens = 128_000
+
+
+class DeepSeekReasonerProvider(_DeepSeekBase):
+    """DeepSeek R1 reasoning model — strong-reasoning with built-in CoT."""
+
+    name = "deepseek-reasoner"
+    default_model = DEEPSEEK_REASONER_MODEL
+    tags = ["strong-reasoning", "thinking", "code-review"]
+
+    quality_tier = "strong"
+    # R1 always emits reasoning_content; the dial is informational (DeepSeek's
+    # API has no per-call thinking-budget knob today). The mapping lets
+    # downstream callers reason about effort consistently across providers.
+    supports_effort = True
+    effort_to_thinking = {
+        "minimal": 0,
+        "low": 2_000,
+        "medium": 4_000,
+        "high": 8_000,
+        "max": 16_000,
+    }
+    cost_per_1k_in = 0.00055
+    cost_per_1k_out = 0.00219
+    cost_per_1k_thinking = 0.00055
+    typical_p50_ms = 12_000  # reasoning models are slow
+    max_context_tokens = 128_000

--- a/src/conductor/wizard.py
+++ b/src/conductor/wizard.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
 
 from conductor import credentials
 from conductor.providers import get_provider, known_providers
+from conductor.providers.deepseek import DEEPSEEK_API_KEY_ENV
 from conductor.providers.kimi import (
     CLOUDFLARE_ACCOUNT_ID_ENV,
     CLOUDFLARE_API_TOKEN_ENV,
@@ -154,6 +155,56 @@ _INFO: dict[str, _ProviderInfo] = {
             "Quick check: curl -H 'Authorization: Bearer $TOKEN' "
             "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/ai/models/search",
             "Free tier = 10k tokens/day; 429 errors mean you've hit the cap.",
+        ],
+    ),
+    "deepseek-chat": _ProviderInfo(
+        tagline="DeepSeek V3.x chat — cheap, fast general-purpose model.",
+        description=(
+            "Cheap and fast; strong tier; good default for code-review "
+            "and general chat when latency and cost matter more than "
+            "deep reasoning. Requires a DeepSeek API key."
+        ),
+        install_cmds=[
+            "# No install step — Conductor talks directly to DeepSeek's",
+            "# OpenAI-compatible HTTP endpoint via httpx.",
+        ],
+        auth_cmds=[
+            "# Wizard will prompt for DEEPSEEK_API_KEY and store it",
+            "# in Keychain / direnv. The same key serves deepseek-reasoner.",
+        ],
+        credential_source_url="https://platform.deepseek.com/api_keys",
+        troubleshoot_tips=[
+            "DEEPSEEK_API_KEY must be in the current shell — restart your "
+            "terminal after adding it to ~/.zshrc.",
+            "Validate the key: https://platform.deepseek.com/api_keys "
+            "(regenerate if unsure).",
+            "401 means the key is wrong; 402 means the account is out of credit.",
+        ],
+    ),
+    "deepseek-reasoner": _ProviderInfo(
+        tagline="DeepSeek R1 reasoning — strong reasoning with built-in CoT.",
+        description=(
+            "Picks up tasks tagged 'strong-reasoning' or 'thinking'. "
+            "Slower (12s p50) and more expensive than deepseek-chat, but "
+            "emits a chain-of-thought before the answer. Reuses the same "
+            "DEEPSEEK_API_KEY as deepseek-chat — set up once."
+        ),
+        install_cmds=[
+            "# No install step — Conductor talks directly to DeepSeek's",
+            "# OpenAI-compatible HTTP endpoint via httpx.",
+        ],
+        auth_cmds=[
+            "# Wizard will prompt for DEEPSEEK_API_KEY and store it",
+            "# in Keychain / direnv. Same key as deepseek-chat.",
+        ],
+        credential_source_url="https://platform.deepseek.com/api_keys",
+        troubleshoot_tips=[
+            "Same DEEPSEEK_API_KEY as deepseek-chat — if chat works and "
+            "reasoner doesn't, the key is fine; check the model id.",
+            "Reasoner is slow (12s p50 typical); long timeouts are normal, "
+            "not a hang.",
+            "402 means the account is out of credit; reasoner uses ~2× the "
+            "tokens-per-call as chat because of the reasoning trace.",
         ],
     ),
     "ollama": _ProviderInfo(
@@ -582,8 +633,110 @@ def _kimi_flow(*, can_back: bool = False) -> WizardOutcome:
     return WizardOutcome("kimi", "failed", f"stored via {storage}, smoke failed: {reason}")
 
 
+def _deepseek_flow(name: str) -> Callable[..., WizardOutcome]:
+    """API-key flow for either deepseek-chat or deepseek-reasoner.
+
+    Both providers share one credential (``DEEPSEEK_API_KEY``); once one
+    flow stores it, the other detects it as already-configured and skips
+    the prompt.
+    """
+
+    def flow(*, can_back: bool = False) -> WizardOutcome:
+        info = _INFO[name]
+        if can_back:
+            options = [
+                ("c", "continue — enter credentials now"),
+                ("s", "skip this provider"),
+                ("b", "back — redo the previous provider"),
+                ("q", "quit setup"),
+            ]
+            entry = _prompt_menu(options=options, default="c")
+            if entry == "s":
+                return WizardOutcome(name, "skipped", "user skipped")
+            if entry == "q":
+                raise _AbortSetup()
+            if entry == "b":
+                raise _GoBack()
+            click.echo("")
+        click.echo(f"  Get a key: {info.credential_source_url}")
+        click.echo("")
+
+        if credentials.get(DEEPSEEK_API_KEY_ENV) is not None:
+            provider = get_provider(name)
+            ok, reason = provider.smoke()
+            if ok:
+                return WizardOutcome(
+                    name, "ok", "credentials already present, smoke passed"
+                )
+            return WizardOutcome(
+                name, "failed", f"credentials present but smoke failed: {reason}"
+            )
+
+        try:
+            value = click.prompt(
+                f"  DeepSeek API key ({DEEPSEEK_API_KEY_ENV})",
+                hide_input=True,
+                default="",
+                show_default=False,
+            )
+        except click.Abort:
+            value = ""
+        if not value:
+            click.echo(f"  {DEEPSEEK_API_KEY_ENV} not provided — skipping {name}.")
+            return WizardOutcome(name, "skipped", f"{DEEPSEEK_API_KEY_ENV} not provided")
+
+        storage = _prompt_menu(
+            options=[
+                ("keychain", "keychain — macOS Keychain (recommended, no shell-env leakage)"),
+                ("envrc", "envrc — write export to .envrc via direnv"),
+                ("print", "print — show export statement, I'll store it myself"),
+                ("skip", f"skip — skip {name} entirely"),
+            ],
+        )
+        if storage == "skip":
+            return WizardOutcome(name, "skipped", "user skipped during storage choice")
+
+        values = {DEEPSEEK_API_KEY_ENV: value}
+
+        if storage == "keychain":
+            try:
+                credentials.set_in_keychain(DEEPSEEK_API_KEY_ENV, value)
+                click.echo("  ✓ stored in macOS Keychain (service: conductor).")
+            except RuntimeError as e:
+                click.echo(f"  ✗ keychain storage failed: {e}")
+                click.echo("  falling back to print-only.")
+                storage = "print"
+
+        if storage == "envrc":
+            envrc_path = os.path.join(os.getcwd(), ".envrc")
+            _append_envrc(envrc_path, values)
+            click.echo(f"  ✓ wrote export line to {envrc_path}")
+            click.echo("    run `direnv allow` in that directory to activate.")
+
+        if storage == "print":
+            click.echo("  add this to your shell rc or .envrc:")
+            click.echo(f"    export {DEEPSEEK_API_KEY_ENV}={value!r}")
+
+        os.environ[DEEPSEEK_API_KEY_ENV] = value
+
+        provider = get_provider(name)
+        ok, reason = provider.smoke()
+        if ok:
+            click.echo("  ✓ smoke test passed")
+            return WizardOutcome(name, "ok", f"stored via {storage}, smoke passed")
+        click.echo(f"  ✗ smoke test failed: {reason}")
+        click.echo("  credential stored but the endpoint is not responding as expected.")
+        return WizardOutcome(
+            name, "failed", f"stored via {storage}, smoke failed: {reason}"
+        )
+
+    return flow
+
+
 _FLOWS: dict[str, Callable[..., WizardOutcome]] = {
     "kimi": _kimi_flow,
+    "deepseek-chat": _deepseek_flow("deepseek-chat"),
+    "deepseek-reasoner": _deepseek_flow("deepseek-reasoner"),
 }
 
 

--- a/tests/test_cli_phase5.py
+++ b/tests/test_cli_phase5.py
@@ -27,6 +27,8 @@ def _stub_all_unconfigured(mocker):
     from conductor.providers import (
         ClaudeProvider,
         CodexProvider,
+        DeepSeekChatProvider,
+        DeepSeekReasonerProvider,
         GeminiProvider,
         KimiProvider,
         OllamaProvider,
@@ -35,6 +37,8 @@ def _stub_all_unconfigured(mocker):
     for cls in (
         ClaudeProvider,
         CodexProvider,
+        DeepSeekChatProvider,
+        DeepSeekReasonerProvider,
         GeminiProvider,
         KimiProvider,
         OllamaProvider,
@@ -52,11 +56,19 @@ def _stub_all_unconfigured(mocker):
 # ---------------------------------------------------------------------------
 
 
-def test_list_text_output_shows_all_five_providers(mocker):
+def test_list_text_output_shows_all_builtin_providers(mocker):
     _stub_all_unconfigured(mocker)
     result = CliRunner().invoke(main, ["list"])
     assert result.exit_code == 0, result.output
-    for name in ("kimi", "claude", "codex", "gemini", "ollama"):
+    for name in (
+        "kimi",
+        "claude",
+        "codex",
+        "deepseek-chat",
+        "deepseek-reasoner",
+        "gemini",
+        "ollama",
+    ):
         assert name in result.output
 
 
@@ -65,14 +77,17 @@ def test_list_json_output_returns_structured_rows(mocker):
     result = CliRunner().invoke(main, ["list", "--json"])
     assert result.exit_code == 0
     rows = json.loads(result.output)
-    assert len(rows) == 5
-    assert {r["provider"] for r in rows} == {
+    expected = {
         "kimi",
         "claude",
         "codex",
+        "deepseek-chat",
+        "deepseek-reasoner",
         "gemini",
         "ollama",
     }
+    assert len(rows) == len(expected)
+    assert {r["provider"] for r in rows} == expected
     assert all(r["configured"] is False for r in rows)
     assert all(r["default_model"] for r in rows)
 
@@ -158,21 +173,37 @@ def test_smoke_json_output_shape(mocker):
 
 def test_doctor_text_output_covers_every_provider(mocker, monkeypatch):
     _stub_all_unconfigured(mocker)
-    for var in ("CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "OLLAMA_BASE_URL"):
+    for var in (
+        "CLOUDFLARE_API_TOKEN",
+        "CLOUDFLARE_ACCOUNT_ID",
+        "DEEPSEEK_API_KEY",
+        "OLLAMA_BASE_URL",
+    ):
         monkeypatch.delenv(var, raising=False)
 
     result = CliRunner().invoke(main, ["doctor"])
     assert result.exit_code == 0, result.output
-    for name in ("kimi", "claude", "codex", "gemini", "ollama"):
+    for name in (
+        "kimi",
+        "claude",
+        "codex",
+        "deepseek-chat",
+        "deepseek-reasoner",
+        "gemini",
+        "ollama",
+    ):
         assert name in result.output
     assert "Credentials" in result.output or "credentials" in result.output.lower()
     assert "conductor init" in result.output
 
 
 def test_doctor_json_shape(mocker, monkeypatch):
+    from conductor.providers import known_providers
+
     _stub_all_unconfigured(mocker)
     monkeypatch.setenv("CLOUDFLARE_API_TOKEN", "x")
     monkeypatch.delenv("CLOUDFLARE_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
     monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
     mocker.patch("conductor.cli.credentials.keychain_has", return_value=False)
 
@@ -182,7 +213,7 @@ def test_doctor_json_shape(mocker, monkeypatch):
     assert set(payload.keys()) >= {
         "version", "platform", "python", "providers", "credentials", "warnings"
     }
-    assert len(payload["providers"]) == 5
+    assert len(payload["providers"]) == len(known_providers())
     cred_map = {c["name"]: c for c in payload["credentials"]}
     assert cred_map["CLOUDFLARE_API_TOKEN"]["in_env"] is True
     assert cred_map["CLOUDFLARE_ACCOUNT_ID"]["in_env"] is False

--- a/tests/test_deepseek.py
+++ b/tests/test_deepseek.py
@@ -1,0 +1,244 @@
+"""Unit tests for the DeepSeek providers — mocked httpx, no live calls."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from conductor.providers.deepseek import (
+    DEEPSEEK_API_KEY_ENV,
+    DEEPSEEK_BASE_URL,
+    DEEPSEEK_CHAT_MODEL,
+    DEEPSEEK_REASONER_MODEL,
+    DeepSeekChatProvider,
+    DeepSeekReasonerProvider,
+)
+from conductor.providers.interface import (
+    CallResponse,
+    ProviderConfigError,
+    ProviderHTTPError,
+    UnsupportedCapability,
+)
+
+CHAT_URL = f"{DEEPSEEK_BASE_URL}/chat/completions"
+
+
+@pytest.fixture
+def configured(monkeypatch):
+    monkeypatch.setenv(DEEPSEEK_API_KEY_ENV, "ds-test-key")
+
+
+@pytest.fixture
+def no_key(monkeypatch):
+    monkeypatch.delenv(DEEPSEEK_API_KEY_ENV, raising=False)
+
+
+def test_chat_configured_true_when_env_set(configured):
+    ok, reason = DeepSeekChatProvider().configured()
+    assert ok is True
+    assert reason is None
+
+
+def test_reasoner_configured_true_when_env_set(configured):
+    ok, reason = DeepSeekReasonerProvider().configured()
+    assert ok is True
+    assert reason is None
+
+
+def test_chat_configured_false_when_key_missing(no_key):
+    ok, reason = DeepSeekChatProvider().configured()
+    assert ok is False
+    assert DEEPSEEK_API_KEY_ENV in reason
+
+
+def test_reasoner_configured_false_when_key_missing(no_key):
+    ok, reason = DeepSeekReasonerProvider().configured()
+    assert ok is False
+    assert DEEPSEEK_API_KEY_ENV in reason
+
+
+def test_chat_call_returns_normalized_response(configured):
+    body = {
+        "id": "chatcmpl-abc",
+        "model": DEEPSEEK_CHAT_MODEL,
+        "choices": [
+            {"message": {"role": "assistant", "content": "4"}, "finish_reason": "stop"},
+        ],
+        "usage": {
+            "prompt_tokens": 7,
+            "completion_tokens": 1,
+            "prompt_tokens_details": {"cached_tokens": 0},
+        },
+    }
+    with respx.mock() as router:
+        router.post(CHAT_URL).mock(return_value=httpx.Response(200, json=body))
+        response = DeepSeekChatProvider().call("What is 2+2?")
+
+    assert isinstance(response, CallResponse)
+    assert response.text == "4"
+    assert response.provider == "deepseek-chat"
+    assert response.model == DEEPSEEK_CHAT_MODEL
+    assert response.usage["input_tokens"] == 7
+    assert response.usage["output_tokens"] == 1
+    assert response.usage["cached_tokens"] == 0
+    # chat doesn't support effort, so the dial resolves to 0.
+    assert response.usage["thinking_budget"] == 0
+    assert response.duration_ms >= 0
+    assert response.raw == body
+
+
+def test_reasoner_call_surfaces_reasoning_chars(configured):
+    reasoning = "Let me think step by step..."
+    body = {
+        "model": DEEPSEEK_REASONER_MODEL,
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "42",
+                    "reasoning_content": reasoning,
+                },
+            },
+        ],
+        "usage": {
+            "prompt_tokens": 20,
+            "completion_tokens": 5,
+            "completion_tokens_details": {"reasoning_tokens": 13},
+        },
+    }
+    with respx.mock() as router:
+        router.post(CHAT_URL).mock(return_value=httpx.Response(200, json=body))
+        response = DeepSeekReasonerProvider().call("hard question")
+
+    assert response.text == "42"
+    assert response.provider == "deepseek-reasoner"
+    assert response.usage["thinking_tokens"] == 13
+    assert response.usage["reasoning_chars"] == len(reasoning)
+    # reasoner declares supports_effort, so the medium dial maps to a budget.
+    assert response.usage["thinking_budget"] == 4_000
+
+
+def test_call_uses_default_model_when_none_passed(configured):
+    captured: dict[str, bytes] = {}
+
+    def _record(request):
+        captured["payload"] = request.read()
+        return httpx.Response(
+            200,
+            json={
+                "model": DEEPSEEK_CHAT_MODEL,
+                "choices": [{"message": {"content": "ok"}}],
+                "usage": {},
+            },
+        )
+
+    with respx.mock() as router:
+        router.post(CHAT_URL).mock(side_effect=_record)
+        DeepSeekChatProvider().call("hi")
+
+    payload = json.loads(captured["payload"])
+    assert payload["model"] == DEEPSEEK_CHAT_MODEL
+
+
+def test_call_raises_config_error_when_unconfigured(no_key):
+    with pytest.raises(ProviderConfigError):
+        DeepSeekChatProvider().call("hello")
+
+
+def test_call_raises_http_error_on_non_200(configured):
+    with respx.mock() as router:
+        router.post(CHAT_URL).mock(return_value=httpx.Response(401, text="bad key"))
+        with pytest.raises(ProviderHTTPError) as exc:
+            DeepSeekChatProvider().call("hi")
+    assert "401" in str(exc.value)
+
+
+def test_call_raises_http_error_on_network_failure(configured):
+    with respx.mock() as router:
+        router.post(CHAT_URL).mock(side_effect=httpx.ConnectError("dns failure"))
+        with pytest.raises(ProviderHTTPError) as exc:
+            DeepSeekChatProvider().call("hi")
+    assert "network error" in str(exc.value).lower()
+
+
+def test_smoke_returns_true_on_well_formed_response(configured):
+    body = {
+        "model": DEEPSEEK_CHAT_MODEL,
+        "choices": [{"message": {"content": "pong"}}],
+        "usage": {},
+    }
+    with respx.mock() as router:
+        router.post(CHAT_URL).mock(return_value=httpx.Response(200, json=body))
+        ok, reason = DeepSeekChatProvider().smoke()
+    assert ok is True
+    assert reason is None
+
+
+def test_smoke_returns_false_when_unconfigured(no_key):
+    ok, reason = DeepSeekChatProvider().smoke()
+    assert ok is False
+    assert DEEPSEEK_API_KEY_ENV in reason
+
+
+def test_resume_session_id_unsupported(configured):
+    with pytest.raises(UnsupportedCapability):
+        DeepSeekChatProvider().call("hi", resume_session_id="abc")
+
+
+def test_exec_without_tools_delegates_to_call(configured):
+    body = {
+        "model": DEEPSEEK_CHAT_MODEL,
+        "choices": [{"message": {"content": "ok"}}],
+        "usage": {},
+    }
+    with respx.mock() as router:
+        router.post(CHAT_URL).mock(return_value=httpx.Response(200, json=body))
+        response = DeepSeekChatProvider().exec("hi")
+    assert response.text == "ok"
+
+
+def test_exec_with_tools_raises_unsupported(configured):
+    with pytest.raises(UnsupportedCapability):
+        DeepSeekChatProvider().exec("hi", tools=frozenset({"Read"}))
+
+
+def test_exec_with_sandbox_but_no_tools_raises(configured):
+    with pytest.raises(UnsupportedCapability):
+        DeepSeekChatProvider().exec("hi", sandbox="read-only")
+
+
+def test_chat_and_reasoner_have_distinct_use_case_tags():
+    """deepseek-chat targets cheap/general; deepseek-reasoner targets reasoning.
+    The router uses these tags to pick the right model per task."""
+    chat_tags = set(DeepSeekChatProvider().tags)
+    reasoner_tags = set(DeepSeekReasonerProvider().tags)
+    assert "cheap" in chat_tags
+    assert "strong-reasoning" in reasoner_tags
+    assert "thinking" in reasoner_tags
+    # The two should not be identical — they exist to serve different routes.
+    assert chat_tags != reasoner_tags
+
+
+def test_authorization_header_uses_bearer_token(configured):
+    captured: dict[str, str] = {}
+
+    def _record(request):
+        captured["auth"] = request.headers.get("authorization", "")
+        return httpx.Response(
+            200,
+            json={
+                "model": DEEPSEEK_CHAT_MODEL,
+                "choices": [{"message": {"content": "ok"}}],
+                "usage": {},
+            },
+        )
+
+    with respx.mock() as router:
+        router.post(CHAT_URL).mock(side_effect=_record)
+        DeepSeekChatProvider().call("hi")
+
+    assert captured["auth"].startswith("Bearer ")
+    assert "ds-test-key" in captured["auth"]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -7,6 +7,8 @@ import pytest
 from conductor.providers import (
     ClaudeProvider,
     CodexProvider,
+    DeepSeekChatProvider,
+    DeepSeekReasonerProvider,
     GeminiProvider,
     KimiProvider,
     OllamaProvider,
@@ -15,14 +17,24 @@ from conductor.providers import (
 )
 
 
-def test_known_providers_returns_all_five():
-    assert known_providers() == ["claude", "codex", "gemini", "kimi", "ollama"]
+def test_known_providers_returns_all_builtins():
+    assert known_providers() == [
+        "claude",
+        "codex",
+        "deepseek-chat",
+        "deepseek-reasoner",
+        "gemini",
+        "kimi",
+        "ollama",
+    ]
 
 
 def test_get_provider_returns_correct_class():
     assert isinstance(get_provider("kimi"), KimiProvider)
     assert isinstance(get_provider("claude"), ClaudeProvider)
     assert isinstance(get_provider("codex"), CodexProvider)
+    assert isinstance(get_provider("deepseek-chat"), DeepSeekChatProvider)
+    assert isinstance(get_provider("deepseek-reasoner"), DeepSeekReasonerProvider)
     assert isinstance(get_provider("gemini"), GeminiProvider)
     assert isinstance(get_provider("ollama"), OllamaProvider)
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,6 +1,6 @@
 """Tests for the auto-mode router.
 
-All five providers expose their own ``configured()`` (env-var or CLI check);
+All built-in providers expose their own ``configured()`` (env-var or CLI check);
 we stub those directly so tests run without real CLIs/env vars.
 """
 
@@ -36,6 +36,8 @@ def _stub_configured(mocker, results: dict[str, bool]):
     from conductor.providers import (
         ClaudeProvider,
         CodexProvider,
+        DeepSeekChatProvider,
+        DeepSeekReasonerProvider,
         GeminiProvider,
         KimiProvider,
         OllamaProvider,
@@ -45,6 +47,8 @@ def _stub_configured(mocker, results: dict[str, bool]):
         "kimi": KimiProvider,
         "claude": ClaudeProvider,
         "codex": CodexProvider,
+        "deepseek-chat": DeepSeekChatProvider,
+        "deepseek-reasoner": DeepSeekReasonerProvider,
         "gemini": GeminiProvider,
         "ollama": OllamaProvider,
     }
@@ -118,7 +122,14 @@ def test_route_decision_surfaces_skipped_with_reasons(mocker):
     _stub_configured(mocker, {"kimi": True})
     _, decision = pick(["cheap"])
     skipped_names = {name for name, _ in decision.candidates_skipped}
-    assert skipped_names == {"claude", "codex", "gemini", "ollama"}
+    assert skipped_names == {
+        "claude",
+        "codex",
+        "deepseek-chat",
+        "deepseek-reasoner",
+        "gemini",
+        "ollama",
+    }
 
 
 def test_priority_order_is_stable():

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -278,53 +278,36 @@ def test_init_help_not_shown_before_any_failure(mocker):
 
 def test_init_first_provider_has_no_back_option(mocker):
     """[b]ack doesn't appear on the first provider's menu (nothing to go back to)."""
-    from conductor.providers import (
-        ClaudeProvider,
-        CodexProvider,
-        GeminiProvider,
-        KimiProvider,
-        OllamaProvider,
-    )
+    from conductor.providers import known_providers
 
     mocker.patch("conductor.wizard._is_tty", return_value=True)
-    for cls in (
-        ClaudeProvider, CodexProvider, GeminiProvider, KimiProvider, OllamaProvider
-    ):
-        mocker.patch.object(cls, "configured", lambda self: (False, "nope"))
+    _stub_all_providers_unconfigured(mocker)
 
-    # Skip claude immediately → wizard continues to codex where [b] should appear.
+    # Skip claude immediately → wizard continues to the second provider where
+    # [b] should appear.
     result = CliRunner().invoke(main, ["init"], input="s\nq\n")
-    # The claude section should not have offered [b]ack.
-    claude_section, _, rest = result.output.partition("[2/5]")
+    second_header = f"[2/{len(known_providers())}]"
+    claude_section, _, rest = result.output.partition(second_header)
     assert "[b]" not in claude_section
-    # The codex section (rest) should offer [b]ack.
     assert "[b]" in rest
 
 
 def test_init_back_rewinds_previous_provider(mocker):
     """Pressing [b]ack from provider 2 rewalks provider 1 and drops its outcome."""
-    from conductor.providers import (
-        ClaudeProvider,
-        CodexProvider,
-        GeminiProvider,
-        KimiProvider,
-        OllamaProvider,
-    )
+    from conductor.providers import known_providers
 
     mocker.patch("conductor.wizard._is_tty", return_value=True)
-    for cls in (
-        ClaudeProvider, CodexProvider, GeminiProvider, KimiProvider, OllamaProvider
-    ):
-        mocker.patch.object(cls, "configured", lambda self: (False, "nope"))
+    _stub_all_providers_unconfigured(mocker)
 
-    # Input: claude→skip, codex→back, claude(rewalk)→skip, codex→skip,
-    # gemini→skip, kimi prompt→empty (skip), ollama→skip.
-    result = CliRunner().invoke(
-        main, ["init"], input="s\nb\ns\ns\ns\n\ns\n"
-    )
+    total = len(known_providers())
+    # Input: claude→skip, codex→back, claude(rewalk)→skip, then skip the
+    # remaining providers (codex through ollama). Empty line covers the
+    # one API-key flow that prompts for credentials before the menu.
+    inputs = ["s", "b", "s"] + ["s"] * (total - 1) + [""] + ["s"] * 2
+    result = CliRunner().invoke(main, ["init"], input="\n".join(inputs) + "\n")
     assert result.exit_code == 0
     # The claude section header should appear twice (original + rewalk).
-    assert result.output.count("[1/5]  claude") == 2
+    assert result.output.count(f"[1/{total}]  claude") == 2
 
 
 # ---------------------------------------------------------------------------
@@ -332,17 +315,22 @@ def test_init_back_rewinds_previous_provider(mocker):
 # ---------------------------------------------------------------------------
 
 
+_ALL_PROVIDER_CLASSES = (
+    "ClaudeProvider",
+    "CodexProvider",
+    "DeepSeekChatProvider",
+    "DeepSeekReasonerProvider",
+    "GeminiProvider",
+    "KimiProvider",
+    "OllamaProvider",
+)
+
+
 def _stub_all_providers_unconfigured(mocker):
-    from conductor.providers import (
-        ClaudeProvider,
-        CodexProvider,
-        GeminiProvider,
-        KimiProvider,
-        OllamaProvider,
-    )
-    for cls in (
-        ClaudeProvider, CodexProvider, GeminiProvider, KimiProvider, OllamaProvider
-    ):
+    import conductor.providers as providers_pkg
+
+    for class_name in _ALL_PROVIDER_CLASSES:
+        cls = getattr(providers_pkg, class_name)
         mocker.patch.object(cls, "configured", lambda self: (False, "stubbed"))
 
 
@@ -428,10 +416,11 @@ def test_init_interactive_claude_detected_prompts(mocker, tmp_path):
     (tmp_path / ".claude").mkdir()
 
     # For each provider's concierge flow: [s]kip. Then at the agent prompt: [n]o.
-    # 5 providers × "s" (skip) + agent-wiring "n" (decline).
-    result = CliRunner().invoke(
-        main, ["init"], input="s\ns\ns\ns\ns\nn\n"
-    )
+    # One "s" per built-in provider + agent-wiring "n" (decline).
+    from conductor.providers import known_providers
+
+    skips = "s\n" * len(known_providers())
+    result = CliRunner().invoke(main, ["init"], input=f"{skips}n\n")
     assert result.exit_code == 0
     assert "Agent integration — Claude Code" in result.output
     # User declined — no files written.


### PR DESCRIPTION
Adds the DeepSeek API as two built-in providers backed by one HTTP base
class so the auto-mode router can pick the right model per task tag
while sharing a single DEEPSEEK_API_KEY:

- deepseek-chat (V3.x): cheap, code-review, tool-use
- deepseek-reasoner (R1): strong-reasoning, thinking, code-review

Wires the new identifiers into the registry, doctor diagnostics, custom-
provider shadow-guard, and the init wizard (shared API-key flow that
detects the second provider as already-configured once the first stores
the key). v1 supports single-turn call() only; exec() with tools raises
UnsupportedCapability — tool-use loop deferred to a follow-up.

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
