### PR TITLE
fix: fall through to next reviewer on runtime failure

### DIFF
--- a/.codex-review.toml
+++ b/.codex-review.toml
@@ -35,8 +35,10 @@ safe_by_default = false
 mode = "review-only"
 
 # Wall-clock timeout per reviewer invocation, in seconds. 0 = no timeout.
-# If the reviewer doesn't finish in time, the hook exits per on_error policy.
-# timeout = 300
+# Safety net for wedged reviewer processes, NOT a thinking-time budget — real
+# reviews on big diffs can run 8–10 minutes. On timeout the cascade now falls
+# through to the next reviewer instead of silently passing the push.
+# timeout = 1800
 
 # What to do when the reviewer fails (crash, timeout, malformed output).
 # "fail-open"   = exit 0, allow push (default — infrastructure errors don't block)

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -1759,6 +1759,12 @@ for _outer_idx in "${!AVAILABLE_CASCADE[@]}"; do
   # Compare-by-sha (not commit-count) so amends, rewinds, or sideways
   # checkouts are detected even when they preserve the count.
   EXPECTED_HEAD="$(git rev-parse HEAD)"
+  # PRE_REVIEWER_BRANCH: the symbolic ref / branch name. A reviewer can
+  # check out a different branch that happens to point at the same sha;
+  # HEAD-sha comparison alone wouldn't catch it but the next reviewer
+  # would auto-commit on the wrong branch. `--abbrev-ref` returns "HEAD"
+  # in detached state, which is still a stable sentinel for comparison.
+  PRE_REVIEWER_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo 'detached')"
   # PRE_REVIEWER_STASH_SHAS: the literal list of stash commit shas. A
   # reviewer that drops one stash and adds another preserves the count;
   # compare the actual sha list so swap/replace is caught.
@@ -1991,6 +1997,18 @@ done
         print_summary
         exit 1
       fi
+      current_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo 'detached')"
+      if [ "$current_branch" != "$PRE_REVIEWER_BRANCH" ]; then
+        # Same sha, different branch. The next reviewer's auto-commit
+        # would land on the wrong branch.
+        echo "==> ${REVIEWER_LABEL} switched branches before failing."
+        echo "    Expected branch: $PRE_REVIEWER_BRANCH"
+        echo "    Actual branch:   $current_branch"
+        echo "    Refusing to fall through. Run 'git checkout $PRE_REVIEWER_BRANCH' to recover."
+        REVIEW_EXIT_REASON="cascade-aborted-branch-switched"
+        print_summary
+        exit 1
+      fi
       current_stash_shas="$(git stash list --format='%H' 2>/dev/null | tr '\n' ',')"
       if [ "$current_stash_shas" != "$PRE_REVIEWER_STASH_SHAS" ]; then
         # Stash list changed. This catches add, drop, AND swap (drop one /
@@ -2018,9 +2036,22 @@ done
           print_summary
           exit 1
         fi
-        if ! git clean -fd >/dev/null 2>&1; then
+        # `-ffd` (double-f) recurses into nested git repos, which a single
+        # `-fd` would leave behind. Without this a reviewer that planted a
+        # nested .git dir would still leak into the next reviewer's view.
+        if ! git clean -ffd >/dev/null 2>&1; then
           echo "==> ERROR: git clean failed; untracked reviewer files NOT removed. Aborting cascade." >&2
           REVIEW_EXIT_REASON="cascade-aborted-cleanup-failed"
+          print_summary
+          exit 1
+        fi
+        # Re-verify: cleanup commands can succeed-with-residue in edge cases
+        # (special-mode files, permission quirks, etc.). If anything is
+        # still dirty, do not proceed.
+        if [ -n "$(git status --porcelain)" ]; then
+          echo "==> ERROR: worktree still dirty after cleanup. Aborting cascade." >&2
+          git status --porcelain | sed 's/^/      /' >&2
+          REVIEW_EXIT_REASON="cascade-aborted-cleanup-residue"
           print_summary
           exit 1
         fi

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -1748,6 +1748,16 @@ for _outer_idx in "${!AVAILABLE_CASCADE[@]}"; do
   BANNER_PRINTED=false
   FALLTHROUGH_REASON=""
 
+  # Snapshot repo state at the start of this reviewer's slot so we can detect
+  # unauthorized side effects on fall-through. A reviewer in fix mode is
+  # allowed to write to the worktree and emit FIXED, and the script then
+  # auto-commits — those commits are blessed and increment FIX_COMMITS. Any
+  # other state change (commits the script didn't author, stashes, etc.) is
+  # un-blessed and must not silently leak into the next reviewer.
+  PRE_REVIEWER_HEAD="$(git rev-parse HEAD)"
+  PRE_REVIEWER_FIX_COMMITS="$FIX_COMMITS"
+  PRE_REVIEWER_STASH_COUNT="$(git stash list | wc -l | tr -d ' ')"
+
 for iter in $(seq 1 "$MAX_ITERATIONS"); do
   phase "loading diff"
   DIFF_LINE_COUNT="$(git diff "$MERGE_BASE"..HEAD | wc -l | tr -d ' ')"
@@ -1947,27 +1957,65 @@ done
 
   # End of inner iter loop — decide whether to fall through to next reviewer.
   if [ -n "$FALLTHROUGH_REASON" ]; then
-    # In fix / no-tests modes the reviewer is allowed to mutate the worktree,
-    # so a failed reviewer (timeout, non-zero exit, malformed sentinel) may
-    # have left partial edits behind that it never blessed with FIXED.
-    # Passing that state forward to the next reviewer would let them either
-    # approve the un-blessed edits (CLEAN) or auto-commit them as their own
-    # FIXED — either silently ratifies work the failing reviewer never
-    # committed to. Restore a clean slate before falling through, or abort
-    # if pre-review state was already dirty (we can't safely distinguish
-    # user changes from reviewer changes in that case).
-    if mode_allows_fix && [ -n "$(git status --porcelain)" ]; then
-      if [ "$WORKTREE_DIRTY_BEFORE_REVIEW" = true ]; then
-        echo "==> ${REVIEWER_LABEL}: ${FALLTHROUGH_REASON}"
-        echo "    Worktree had pre-review uncommitted changes — refusing to fall through"
-        echo "    with mixed user/reviewer state. Inspect the working tree manually."
-        REVIEW_EXIT_REASON="cascade-aborted-mixed-worktree"
+    # In fix / no-tests modes the reviewer is allowed to mutate the worktree
+    # and the script auto-commits FIXED iterations. A reviewer that fails
+    # (timeout, non-zero, malformed) may have:
+    #   (a) left partial uncommitted edits the contract never blessed,
+    #   (b) made commits we did not author (a porcelain-clean tree at a
+    #       different HEAD looks identical to a clean run),
+    #   (c) stashed work to hide it.
+    # Any of those leaking forward would let the next reviewer approve or
+    # auto-commit un-blessed state. Verify the snapshot we took at the top
+    # of this reviewer's slot; restore a clean worktree where safe, abort
+    # otherwise. Cleanup failures are NOT softened — a failed reset means
+    # we did NOT actually clean up, and falling through would still leak.
+    if mode_allows_fix; then
+      current_head="$(git rev-parse HEAD)"
+      authored_fix_commits=$((FIX_COMMITS - PRE_REVIEWER_FIX_COMMITS))
+      if [ "$current_head" != "$PRE_REVIEWER_HEAD" ]; then
+        actual_new_commits="$(git rev-list --count "${PRE_REVIEWER_HEAD}..HEAD" 2>/dev/null || echo "?")"
+        if [ "$actual_new_commits" != "$authored_fix_commits" ]; then
+          echo "==> ${REVIEWER_LABEL} created unauthorized commits before failing."
+          echo "    HEAD moved $PRE_REVIEWER_HEAD -> $current_head"
+          echo "    Expected $authored_fix_commits new commit(s) (script-authored auto-fix)"
+          echo "    Found $actual_new_commits new commit(s). Refusing to fall through."
+          REVIEW_EXIT_REASON="cascade-aborted-unauthorized-commits"
+          print_summary
+          exit 1
+        fi
+      fi
+      current_stash_count="$(git stash list | wc -l | tr -d ' ')"
+      if [ "$current_stash_count" != "$PRE_REVIEWER_STASH_COUNT" ]; then
+        echo "==> ${REVIEWER_LABEL} added stash entries before failing."
+        echo "    Stash count $PRE_REVIEWER_STASH_COUNT -> $current_stash_count"
+        echo "    Refusing to fall through with hidden state. Inspect 'git stash list' manually."
+        REVIEW_EXIT_REASON="cascade-aborted-stash-leak"
         print_summary
         exit 1
       fi
-      echo "==> Discarding partial edits left by ${REVIEWER_LABEL} before falling through."
-      git reset --hard HEAD >/dev/null 2>&1 || true
-      git clean -fd >/dev/null 2>&1 || true
+      if [ -n "$(git status --porcelain)" ]; then
+        if [ "$WORKTREE_DIRTY_BEFORE_REVIEW" = true ]; then
+          echo "==> ${REVIEWER_LABEL}: ${FALLTHROUGH_REASON}"
+          echo "    Worktree had pre-review uncommitted changes — refusing to fall through"
+          echo "    with mixed user/reviewer state. Inspect the working tree manually."
+          REVIEW_EXIT_REASON="cascade-aborted-mixed-worktree"
+          print_summary
+          exit 1
+        fi
+        echo "==> Discarding partial edits left by ${REVIEWER_LABEL} before falling through."
+        if ! git reset --hard HEAD >/dev/null 2>&1; then
+          echo "==> ERROR: git reset failed; partial edits NOT discarded. Aborting cascade." >&2
+          REVIEW_EXIT_REASON="cascade-aborted-cleanup-failed"
+          print_summary
+          exit 1
+        fi
+        if ! git clean -fd >/dev/null 2>&1; then
+          echo "==> ERROR: git clean failed; untracked reviewer files NOT removed. Aborting cascade." >&2
+          REVIEW_EXIT_REASON="cascade-aborted-cleanup-failed"
+          print_summary
+          exit 1
+        fi
+      fi
     fi
     next_idx=$((_outer_idx + 1))
     if [ "$next_idx" -lt "${#AVAILABLE_CASCADE[@]}" ]; then

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -1939,9 +1939,8 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
       echo "    Raw output (first 20 lines):"
       printf '%s\n' "$OUTPUT" | head -20 | sed 's/^/    /'
       REVIEWER_CHAIN+=("${ACTIVE_REVIEWER}:malformed")
-      REVIEW_EXIT_REASON="malformed-sentinel"
-      print_summary
-      handle_error "malformed sentinel"
+      FALLTHROUGH_REASON="malformed sentinel"
+      break
       ;;
   esac
 done

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -1947,6 +1947,28 @@ done
 
   # End of inner iter loop — decide whether to fall through to next reviewer.
   if [ -n "$FALLTHROUGH_REASON" ]; then
+    # In fix / no-tests modes the reviewer is allowed to mutate the worktree,
+    # so a failed reviewer (timeout, non-zero exit, malformed sentinel) may
+    # have left partial edits behind that it never blessed with FIXED.
+    # Passing that state forward to the next reviewer would let them either
+    # approve the un-blessed edits (CLEAN) or auto-commit them as their own
+    # FIXED — either silently ratifies work the failing reviewer never
+    # committed to. Restore a clean slate before falling through, or abort
+    # if pre-review state was already dirty (we can't safely distinguish
+    # user changes from reviewer changes in that case).
+    if mode_allows_fix && [ -n "$(git status --porcelain)" ]; then
+      if [ "$WORKTREE_DIRTY_BEFORE_REVIEW" = true ]; then
+        echo "==> ${REVIEWER_LABEL}: ${FALLTHROUGH_REASON}"
+        echo "    Worktree had pre-review uncommitted changes — refusing to fall through"
+        echo "    with mixed user/reviewer state. Inspect the working tree manually."
+        REVIEW_EXIT_REASON="cascade-aborted-mixed-worktree"
+        print_summary
+        exit 1
+      fi
+      echo "==> Discarding partial edits left by ${REVIEWER_LABEL} before falling through."
+      git reset --hard HEAD >/dev/null 2>&1 || true
+      git clean -fd >/dev/null 2>&1 || true
+    fi
     next_idx=$((_outer_idx + 1))
     if [ "$next_idx" -lt "${#AVAILABLE_CASCADE[@]}" ]; then
       next_reviewer="${AVAILABLE_CASCADE[$next_idx]}"

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -1961,6 +1961,11 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
       echo "    Last line was: '$LAST_LINE'"
       echo "    Raw output (first 20 lines):"
       printf '%s\n' "$OUTPUT" | head -20 | sed 's/^/    /'
+      # A reviewer can exit 0 yet print useful diagnostics on stderr
+      # (e.g. tool-restriction warnings). Surface them just like the
+      # timeout / non-zero-exit paths do, so the user sees *why* the
+      # contract was violated, not just that it was.
+      print_stderr_tail "$REVIEW_STDERR_FILE" "$REVIEWER_LABEL stderr"
       REVIEWER_CHAIN+=("${ACTIVE_REVIEWER}:malformed")
       FALLTHROUGH_REASON="malformed sentinel"
       break

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -1750,13 +1750,19 @@ for _outer_idx in "${!AVAILABLE_CASCADE[@]}"; do
 
   # Snapshot repo state at the start of this reviewer's slot so we can detect
   # unauthorized side effects on fall-through. A reviewer in fix mode is
-  # allowed to write to the worktree and emit FIXED, and the script then
-  # auto-commits — those commits are blessed and increment FIX_COMMITS. Any
-  # other state change (commits the script didn't author, stashes, etc.) is
-  # un-blessed and must not silently leak into the next reviewer.
-  PRE_REVIEWER_HEAD="$(git rev-parse HEAD)"
-  PRE_REVIEWER_FIX_COMMITS="$FIX_COMMITS"
-  PRE_REVIEWER_STASH_COUNT="$(git stash list | wc -l | tr -d ' ')"
+  # allowed to write to the worktree and emit FIXED; the script then auto-
+  # commits and bumps EXPECTED_HEAD. Any other state change (commits the
+  # script didn't author, stash add/drop/replace, branch checkout, amend,
+  # rewind) is un-blessed and must not silently leak into the next reviewer.
+  #
+  # EXPECTED_HEAD: the only sha HEAD is allowed to be at on fall-through.
+  # Compare-by-sha (not commit-count) so amends, rewinds, or sideways
+  # checkouts are detected even when they preserve the count.
+  EXPECTED_HEAD="$(git rev-parse HEAD)"
+  # PRE_REVIEWER_STASH_SHAS: the literal list of stash commit shas. A
+  # reviewer that drops one stash and adds another preserves the count;
+  # compare the actual sha list so swap/replace is caught.
+  PRE_REVIEWER_STASH_SHAS="$(git stash list --format='%H' 2>/dev/null | tr '\n' ',')"
 
 for iter in $(seq 1 "$MAX_ITERATIONS"); do
   phase "loading diff"
@@ -1920,6 +1926,7 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
       git commit -m "fix: address $REVIEWER_LABEL review findings (auto, $REVIEW_MODE, iter $iter)"
       WORKTREE_DIRTY_BEFORE_REVIEW=false
       FIX_COMMITS=$((FIX_COMMITS + 1))
+      EXPECTED_HEAD="$(git rev-parse HEAD)"
       echo "==> Created fix commit $(git rev-parse --short HEAD). Re-running review on new HEAD..."
       echo ""
       continue
@@ -1971,23 +1978,25 @@ done
     # we did NOT actually clean up, and falling through would still leak.
     if mode_allows_fix; then
       current_head="$(git rev-parse HEAD)"
-      authored_fix_commits=$((FIX_COMMITS - PRE_REVIEWER_FIX_COMMITS))
-      if [ "$current_head" != "$PRE_REVIEWER_HEAD" ]; then
-        actual_new_commits="$(git rev-list --count "${PRE_REVIEWER_HEAD}..HEAD" 2>/dev/null || echo "?")"
-        if [ "$actual_new_commits" != "$authored_fix_commits" ]; then
-          echo "==> ${REVIEWER_LABEL} created unauthorized commits before failing."
-          echo "    HEAD moved $PRE_REVIEWER_HEAD -> $current_head"
-          echo "    Expected $authored_fix_commits new commit(s) (script-authored auto-fix)"
-          echo "    Found $actual_new_commits new commit(s). Refusing to fall through."
-          REVIEW_EXIT_REASON="cascade-aborted-unauthorized-commits"
-          print_summary
-          exit 1
-        fi
+      if [ "$current_head" != "$EXPECTED_HEAD" ]; then
+        # HEAD is not where the script left it. This catches: reviewer-
+        # authored commits, amend of a script-authored fix-commit, rewind
+        # via reset, sideways checkout to another ref. None of these are
+        # safe to silently carry into the next reviewer.
+        echo "==> ${REVIEWER_LABEL} moved HEAD to an un-blessed sha before failing."
+        echo "    Expected HEAD: $EXPECTED_HEAD"
+        echo "    Actual HEAD:   $current_head"
+        echo "    Refusing to fall through. Inspect 'git log' / 'git reflog' manually."
+        REVIEW_EXIT_REASON="cascade-aborted-unauthorized-commits"
+        print_summary
+        exit 1
       fi
-      current_stash_count="$(git stash list | wc -l | tr -d ' ')"
-      if [ "$current_stash_count" != "$PRE_REVIEWER_STASH_COUNT" ]; then
-        echo "==> ${REVIEWER_LABEL} added stash entries before failing."
-        echo "    Stash count $PRE_REVIEWER_STASH_COUNT -> $current_stash_count"
+      current_stash_shas="$(git stash list --format='%H' 2>/dev/null | tr '\n' ',')"
+      if [ "$current_stash_shas" != "$PRE_REVIEWER_STASH_SHAS" ]; then
+        # Stash list changed. This catches add, drop, AND swap (drop one /
+        # add one — same count, different content). Anything that mutates
+        # hidden state under a clean-looking worktree.
+        echo "==> ${REVIEWER_LABEL} mutated the stash list before failing."
         echo "    Refusing to fall through with hidden state. Inspect 'git stash list' manually."
         REVIEW_EXIT_REASON="cascade-aborted-stash-leak"
         print_summary

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -45,7 +45,11 @@
 #   CODEX_REVIEW_MAX_ITERATIONS   — fix loop cap (default: from config, or 3)
 #   CODEX_REVIEW_MAX_DIFF_LINES   — skip review if diff > this many lines (default: 5000)
 #   CODEX_REVIEW_CACHE_CLEAN      — cache exact-input clean reviews (default: true)
-#   CODEX_REVIEW_TIMEOUT          — wall-clock timeout per invocation in seconds (default: 300, 0=none)
+#   CODEX_REVIEW_TIMEOUT          — wall-clock timeout per invocation in seconds (default: 1800, 0=none)
+#                                   Safety net for genuinely wedged reviewer processes, NOT a thinking-time
+#                                   budget. Real reviews on big diffs can take 8–10 minutes; the cascade now
+#                                   falls through to the next reviewer on timeout, so a hung reviewer no
+#                                   longer silently passes the push.
 #   CODEX_REVIEW_ASSIST           — enable peer reviewer help requests (default: false)
 #   CODEX_REVIEW_ASSIST_TIMEOUT   — timeout for peer reviewer helper calls (default: 60)
 #   CODEX_REVIEW_ASSIST_MAX_ROUNDS — max helper calls per review run (default: 1)
@@ -79,7 +83,7 @@ CACHE_CLEAN_REVIEWS="${CODEX_REVIEW_CACHE_CLEAN:-true}"
 NO_AUTOFIX="${CODEX_REVIEW_NO_AUTOFIX:-false}"
 CONFIG_MODE=""
 REVIEW_ENABLED="${CODEX_REVIEW_ENABLED:-true}"
-REVIEW_TIMEOUT="${CODEX_REVIEW_TIMEOUT:-300}"
+REVIEW_TIMEOUT="${CODEX_REVIEW_TIMEOUT:-1800}"
 ON_ERROR="${CODEX_REVIEW_ON_ERROR:-fail-open}"
 UNSAFE_PATHS=""
 REVIEWER_CASCADE=()
@@ -758,7 +762,7 @@ reviewer_codex_exec() {
       "$REVIEW_MODE" "$sandbox" >&2
   fi
   CODEX_REVIEW_IN_PROGRESS=1 codex exec \
-    --sandbox "$sandbox" --ephemeral "$1" 2>/dev/null
+    --sandbox "$sandbox" --ephemeral "$1"
 }
 
 reviewer_claude_available() { command -v claude >/dev/null 2>&1; }
@@ -775,7 +779,7 @@ reviewer_claude_exec() {
   CODEX_REVIEW_IN_PROGRESS=1 claude -p \
     --allowedTools "$tools" \
     --output-format text \
-    "$1" 2>/dev/null
+    "$1"
 }
 
 reviewer_gemini_available() { command -v gemini >/dev/null 2>&1; }
@@ -789,12 +793,12 @@ reviewer_gemini_exec() {
   # without --yolo. no-tests cannot be fully enforced (edits without commands)
   # since Gemini lacks granular tool control.
   if [ "$REVIEW_MODE" = "fix" ]; then
-    CODEX_REVIEW_IN_PROGRESS=1 gemini -p "$1" --yolo 2>/dev/null
+    CODEX_REVIEW_IN_PROGRESS=1 gemini -p "$1" --yolo
   else
     if [ "$REVIEW_MODE" = "no-tests" ]; then
       printf "  ${C_DIM}(gemini: 'no-tests' mode degrades to review-only; gemini lacks granular tool control)${C_RESET}\n" >&2
     fi
-    CODEX_REVIEW_IN_PROGRESS=1 gemini -p "$1" 2>/dev/null
+    CODEX_REVIEW_IN_PROGRESS=1 gemini -p "$1"
   fi
 }
 
@@ -852,11 +856,13 @@ reviewer_local_exec() {
 
 ACTIVE_REVIEWER=""
 REVIEWER_STATUS=""
+AVAILABLE_CASCADE=()
 
 resolve_reviewer() {
   local reviewer
   ACTIVE_REVIEWER=""
   REVIEWER_STATUS=""
+  AVAILABLE_CASCADE=()
 
   for reviewer in "${REVIEWER_CASCADE[@]}"; do
     if ! declare -F "reviewer_${reviewer}_available" >/dev/null; then
@@ -875,11 +881,15 @@ resolve_reviewer() {
       REVIEWER_STATUS="${REVIEWER_STATUS}    ${reviewer}: auth check failed\n"
       continue
     fi
-    ACTIVE_REVIEWER="$reviewer"
-    return 0
+    AVAILABLE_CASCADE+=("$reviewer")
+    REVIEWER_STATUS="${REVIEWER_STATUS}    ${reviewer}: ready\n"
   done
 
-  return 1
+  if [ "${#AVAILABLE_CASCADE[@]}" -eq 0 ]; then
+    return 1
+  fi
+  ACTIVE_REVIEWER="${AVAILABLE_CASCADE[0]}"
+  return 0
 }
 
 ASSIST_REVIEWER=""
@@ -968,8 +978,50 @@ reviewer_label() {
 # --------------------------------------------------------------------------
 
 REVIEW_OUTPUT_FILE="$(mktemp "${TMPDIR:-/tmp}/touchstone-review-output.XXXXXX")"
+REVIEW_STDERR_FILE="$(mktemp "${TMPDIR:-/tmp}/touchstone-review-stderr.XXXXXX")"
 ASSIST_OUTPUT_FILE="$(mktemp "${TMPDIR:-/tmp}/touchstone-review-assist-output.XXXXXX")"
-trap 'rm -f "$REVIEW_OUTPUT_FILE" "$ASSIST_OUTPUT_FILE"' EXIT
+ASSIST_STDERR_FILE="$(mktemp "${TMPDIR:-/tmp}/touchstone-review-assist-stderr.XXXXXX")"
+trap 'rm -f "$REVIEW_OUTPUT_FILE" "$REVIEW_STDERR_FILE" "$ASSIST_OUTPUT_FILE" "$ASSIST_STDERR_FILE"' EXIT
+
+# Print the last N lines of a captured stderr file, one indented line at a time.
+# If empty, prints "<no stderr captured>" so a silent failure still emits a hint.
+print_stderr_tail() {
+  local file="$1"
+  local label="${2:-stderr}"
+  local lines="${3:-5}"
+
+  if [ ! -s "$file" ]; then
+    printf "    %s: <no stderr captured>\n" "$label"
+    return 0
+  fi
+  printf "    %s (last %d lines, full: %s):\n" "$label" "$lines" "$file"
+  tail -n "$lines" "$file" | sed 's/^/      /'
+}
+
+# Classify reviewer stderr into a short tag for the cascade chain summary.
+# Returns one of: usage-limit | auth | network | error
+classify_reviewer_failure() {
+  local file="$1"
+
+  if [ ! -s "$file" ]; then
+    printf 'error'
+    return 0
+  fi
+  # grep -qiE returns 0 on match; -E for alternation.
+  if grep -qiE 'rate.?limit|usage.limit|quota.exhaust|too many requests|429|"status"[[:space:]]*:[[:space:]]*429|insufficient.quota|exceeded' "$file"; then
+    printf 'usage-limit'
+    return 0
+  fi
+  if grep -qiE 'unauthor|forbidden|invalid.api.?key|authentication|not.logged.in|please.log.in|401|403' "$file"; then
+    printf 'auth'
+    return 0
+  fi
+  if grep -qiE 'network|timed.out|connection.refused|dns|unreachable|tls' "$file"; then
+    printf 'network'
+    return 0
+  fi
+  printf 'error'
+}
 
 kill_process_tree() {
   local pid="$1"
@@ -984,23 +1036,29 @@ kill_process_tree() {
   kill "-$signal" "$pid" 2>/dev/null || true
 }
 
-# run_reviewer_with_timeout TIMEOUT_SECS
-#   Runs the reviewer, captures output to REVIEW_OUTPUT_FILE, returns exit code.
-#   Exit 124 = timeout. Works correctly with subshells (no $() capture needed).
+# run_reviewer_with_timeout TIMEOUT_SECS [PROMPT] [STDOUT_FILE] [STDERR_FILE]
+#   Runs the reviewer, captures stdout to STDOUT_FILE and stderr to STDERR_FILE,
+#   returns exit code. Exit 124 = timeout. Works correctly with subshells (no
+#   $() capture needed).
 run_reviewer_with_timeout() {
   local timeout_secs="$1"
   local prompt="${2:-$REVIEW_PROMPT}"
   local output_file="${3:-$REVIEW_OUTPUT_FILE}"
+  local stderr_file="${4:-$REVIEW_STDERR_FILE}"
+
+  # Truncate stderr file so each attempt starts fresh (prevents stale stderr
+  # from a prior reviewer in the cascade leaking into the new one's classification).
+  : > "$stderr_file"
 
   # No timeout: run directly
   if [ "$timeout_secs" -le 0 ] 2>/dev/null; then
-    run_reviewer "$prompt" > "$output_file" 2>/dev/null
+    run_reviewer "$prompt" > "$output_file" 2> "$stderr_file"
     return $?
   fi
 
   # Run reviewer in background, kill if it exceeds timeout.
   (
-    run_reviewer "$prompt" > "$output_file" 2>/dev/null &
+    run_reviewer "$prompt" > "$output_file" 2> "$stderr_file" &
     local reviewer_pid=$!
 
     terminate_reviewer() {
@@ -1125,7 +1183,19 @@ if ! resolve_reviewer; then
   exit 0
 fi
 REVIEWER_LABEL="$(reviewer_label)"
-echo "==> Using reviewer: $REVIEWER_LABEL"
+if [ "${#AVAILABLE_CASCADE[@]}" -gt 1 ]; then
+  cascade_labels=""
+  for _r in "${AVAILABLE_CASCADE[@]}"; do
+    if [ -z "$cascade_labels" ]; then
+      cascade_labels="$(reviewer_label_for "$_r")"
+    else
+      cascade_labels="${cascade_labels} → $(reviewer_label_for "$_r")"
+    fi
+  done
+  echo "==> Reviewer cascade: $cascade_labels"
+else
+  echo "==> Using reviewer: $REVIEWER_LABEL"
+fi
 if [ -n "$REVIEW_CONTEXT_FILE" ]; then
   echo "==> Review context: $(basename "$REVIEW_CONTEXT_FILE")"
 fi
@@ -1477,6 +1547,17 @@ REVIEW_START_TIME="$(date +%s)"
 REVIEW_FILES_INSPECTED="$(git diff --name-only "$MERGE_BASE"..HEAD | wc -l | tr -d ' ')"
 REVIEW_EXIT_REASON=""
 
+# REVIEWER_CHAIN records each reviewer's outcome as "name:status" entries
+# (e.g. "codex:usage-limit", "claude:clean"). Surfaced in the summary block
+# and the JSON output so a fallback path is legible after the fact.
+REVIEWER_CHAIN=()
+FALLTHROUGH_REASON=""
+
+format_reviewer_chain() {
+  local IFS=,
+  printf '%s' "${REVIEWER_CHAIN[*]}"
+}
+
 # --------------------------------------------------------------------------
 # Phase labels
 # --------------------------------------------------------------------------
@@ -1529,8 +1610,14 @@ print_summary() {
   secs=$((elapsed % 60))
   findings="${REVIEW_FINDINGS_COUNT:-0}"
 
+  local chain_str
+  chain_str="$(format_reviewer_chain)"
+
   printf "\n  ${C_DIM}─── review summary ────────────────────────${C_RESET}\n"
   printf "  ${C_DIM}reviewer:       %s${C_RESET}\n" "$REVIEWER_LABEL"
+  if [ -n "$chain_str" ]; then
+    printf "  ${C_DIM}cascade chain:  %s${C_RESET}\n" "$chain_str"
+  fi
   if [ "$ROUTING_DECISION" != "default" ]; then
     printf "  ${C_DIM}route:          %s${C_RESET}\n" "$ROUTING_DECISION"
   fi
@@ -1546,8 +1633,8 @@ print_summary() {
   printf "  ${C_DIM}──────────────────────────────────────────${C_RESET}\n"
 
   if [ -n "${CODEX_REVIEW_SUMMARY_FILE:-}" ]; then
-    printf '{"reviewer":"%s","route":"%s","mode":"%s","files":%d,"diff_lines":%d,"iterations":%d,"fix_commits":%d,"peer_assists":%d,"findings":%d,"exit_reason":"%s","elapsed_seconds":%d}\n' \
-      "$REVIEWER_LABEL" "$ROUTING_DECISION" "$REVIEW_MODE" "$REVIEW_FILES_INSPECTED" "$DIFF_LINE_COUNT" \
+    printf '{"reviewer":"%s","reviewer_chain":"%s","route":"%s","mode":"%s","files":%d,"diff_lines":%d,"iterations":%d,"fix_commits":%d,"peer_assists":%d,"findings":%d,"exit_reason":"%s","elapsed_seconds":%d}\n' \
+      "$REVIEWER_LABEL" "$chain_str" "$ROUTING_DECISION" "$REVIEW_MODE" "$REVIEW_FILES_INSPECTED" "$DIFF_LINE_COUNT" \
       "${iter:-0}" "$FIX_COMMITS" "$ASSIST_ROUNDS" "$findings" "$REVIEW_EXIT_REASON" "$elapsed" \
       > "$CODEX_REVIEW_SUMMARY_FILE" 2>/dev/null || true
   fi
@@ -1655,6 +1742,12 @@ print_banner() {
   BANNER_PRINTED=true
 }
 
+for _outer_idx in "${!AVAILABLE_CASCADE[@]}"; do
+  ACTIVE_REVIEWER="${AVAILABLE_CASCADE[$_outer_idx]}"
+  REVIEWER_LABEL="$(reviewer_label)"
+  BANNER_PRINTED=false
+  FALLTHROUGH_REASON=""
+
 for iter in $(seq 1 "$MAX_ITERATIONS"); do
   phase "loading diff"
   DIFF_LINE_COUNT="$(git diff "$MERGE_BASE"..HEAD | wc -l | tr -d ' ')"
@@ -1700,16 +1793,19 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
   if [ "$EXIT" -eq 124 ]; then
     phase "timed out"
     echo "==> $REVIEWER_LABEL timed out after ${REVIEW_TIMEOUT}s."
-    REVIEW_EXIT_REASON="timeout"
-    print_summary
-    handle_error "timeout after ${REVIEW_TIMEOUT}s"
+    print_stderr_tail "$REVIEW_STDERR_FILE" "$REVIEWER_LABEL stderr"
+    REVIEWER_CHAIN+=("${ACTIVE_REVIEWER}:timeout")
+    FALLTHROUGH_REASON="timeout after ${REVIEW_TIMEOUT}s"
+    break
   fi
 
   if [ $EXIT -ne 0 ]; then
-    echo "==> $REVIEWER_LABEL review failed with exit $EXIT."
-    REVIEW_EXIT_REASON="error"
-    print_summary
-    handle_error "reviewer exit $EXIT"
+    failure_tag="$(classify_reviewer_failure "$REVIEW_STDERR_FILE")"
+    echo "==> $REVIEWER_LABEL review failed with exit $EXIT (${failure_tag})."
+    print_stderr_tail "$REVIEW_STDERR_FILE" "$REVIEWER_LABEL stderr"
+    REVIEWER_CHAIN+=("${ACTIVE_REVIEWER}:${failure_tag}")
+    FALLTHROUGH_REASON="${failure_tag} (exit $EXIT)"
+    break
   fi
 
   HELP_REQUEST=""
@@ -1738,16 +1834,19 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
         if [ "$EXIT" -eq 124 ]; then
           phase "timed out"
           echo "==> $REVIEWER_LABEL timed out after ${REVIEW_TIMEOUT}s after peer assistance."
-          REVIEW_EXIT_REASON="timeout"
-          print_summary
-          handle_error "timeout after ${REVIEW_TIMEOUT}s after peer assistance"
+          print_stderr_tail "$REVIEW_STDERR_FILE" "$REVIEWER_LABEL stderr"
+          REVIEWER_CHAIN+=("${ACTIVE_REVIEWER}:timeout-after-assist")
+          FALLTHROUGH_REASON="timeout after ${REVIEW_TIMEOUT}s after peer assistance"
+          break
         fi
 
         if [ "$EXIT" -ne 0 ]; then
-          echo "==> $REVIEWER_LABEL review failed with exit $EXIT after peer assistance."
-          REVIEW_EXIT_REASON="error"
-          print_summary
-          handle_error "reviewer exit $EXIT after peer assistance"
+          failure_tag="$(classify_reviewer_failure "$REVIEW_STDERR_FILE")"
+          echo "==> $REVIEWER_LABEL review failed with exit $EXIT (${failure_tag}) after peer assistance."
+          print_stderr_tail "$REVIEW_STDERR_FILE" "$REVIEWER_LABEL stderr"
+          REVIEWER_CHAIN+=("${ACTIVE_REVIEWER}:${failure_tag}-after-assist")
+          FALLTHROUGH_REASON="${failure_tag} (exit $EXIT) after peer assistance"
+          break
         fi
       else
         echo "==> Continuing with the primary reviewer output."
@@ -1764,6 +1863,7 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
         clean_subtitle="${clean_subtitle} · ${FIX_COMMITS} auto-fix commit(s)"
       fi
       tk_verdict ok "ALL CLEAR" "$clean_subtitle"
+      REVIEWER_CHAIN+=("${ACTIVE_REVIEWER}:clean")
       REVIEW_EXIT_REASON="clean"
       print_summary
       write_clean_review_cache "$REVIEW_CACHE_KEY" "$DIFF_LINE_COUNT"
@@ -1827,6 +1927,7 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
         echo "    To undo them: git reset --hard HEAD~$FIX_COMMITS"
       fi
       echo "    Address findings and try again. Emergency override: git push --no-verify"
+      REVIEWER_CHAIN+=("${ACTIVE_REVIEWER}:blocked")
       REVIEW_EXIT_REASON="blocked"
       print_summary
       exit 1
@@ -1837,11 +1938,36 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
       echo "    Last line was: '$LAST_LINE'"
       echo "    Raw output (first 20 lines):"
       printf '%s\n' "$OUTPUT" | head -20 | sed 's/^/    /'
+      REVIEWER_CHAIN+=("${ACTIVE_REVIEWER}:malformed")
       REVIEW_EXIT_REASON="malformed-sentinel"
       print_summary
       handle_error "malformed sentinel"
       ;;
   esac
+done
+
+  # End of inner iter loop — decide whether to fall through to next reviewer.
+  if [ -n "$FALLTHROUGH_REASON" ]; then
+    next_idx=$((_outer_idx + 1))
+    if [ "$next_idx" -lt "${#AVAILABLE_CASCADE[@]}" ]; then
+      next_reviewer="${AVAILABLE_CASCADE[$next_idx]}"
+      next_label="$(reviewer_label_for "$next_reviewer")"
+      echo ""
+      echo "==> ${REVIEWER_LABEL}: ${FALLTHROUGH_REASON} — falling back to ${next_label}"
+      continue
+    fi
+    # Cascade exhausted — every reviewer that was available failed at runtime.
+    echo ""
+    echo "==> All reviewers in the cascade failed."
+    echo "    Chain: $(format_reviewer_chain)"
+    REVIEW_EXIT_REASON="cascade-exhausted"
+    print_summary
+    handle_error "cascade exhausted: $(format_reviewer_chain)"
+  fi
+  # Otherwise the inner loop fell off the end without converging — that's a
+  # genuine "diff is contentious" signal, not "reviewer broke." Don't try the
+  # next reviewer; preserve the original non-convergence behavior below.
+  break
 done
 
 echo ""
@@ -1853,6 +1979,7 @@ echo "      git diff HEAD~$FIX_COMMITS..HEAD"
 echo ""
 echo "    To undo all auto-fix commits: git reset --hard HEAD~$FIX_COMMITS"
 echo "    Emergency override: git push --no-verify"
+REVIEWER_CHAIN+=("${ACTIVE_REVIEWER}:max-iterations")
 REVIEW_EXIT_REASON="max-iterations"
 print_summary
 exit 1

--- a/tests/test_review_cascade.py
+++ b/tests/test_review_cascade.py
@@ -198,6 +198,44 @@ esac
 exit 1
 '''
 
+# Codex commits its work then fails — the worktree is clean but HEAD
+# moved without the script's auto-fix path blessing it. The cascade must
+# detect this and abort.
+FAKE_CODEX_COMMITS_THEN_FAILS = '''
+#!/usr/bin/env bash
+case "$1" in
+  login)
+    if [ "$2" = "status" ]; then exit 0; fi
+    ;;
+  exec)
+    echo "edit from codex" >> README
+    git -c user.name=t -c user.email=t@t add README
+    git -c user.name=t -c user.email=t@t commit -q -m "unauthorized commit by codex"
+    echo "ERROR: rate_limit_exceeded" >&2
+    exit 1
+    ;;
+esac
+exit 1
+'''
+
+# Codex stashes its work then fails — clean tree, unchanged HEAD, but a
+# new stash entry hides reviewer-authored state.
+FAKE_CODEX_STASHES_THEN_FAILS = '''
+#!/usr/bin/env bash
+case "$1" in
+  login)
+    if [ "$2" = "status" ]; then exit 0; fi
+    ;;
+  exec)
+    echo "edit from codex" >> README
+    git stash push -q -m "hidden by codex" -- README
+    echo "ERROR: rate_limit_exceeded" >&2
+    exit 1
+    ;;
+esac
+exit 1
+'''
+
 
 # ---------------------------------------------------------------------------
 # tests
@@ -309,6 +347,44 @@ def test_fix_mode_discards_partial_edits_before_fallthrough(tmp_path: Path) -> N
         f"Worktree should be clean post-cascade; saw: {status.stdout!r}\n"
         f"This means a failed reviewer's partial edits leaked through to the next reviewer."
     )
+
+
+def test_fix_mode_aborts_on_unauthorized_commits(tmp_path: Path) -> None:
+    """A reviewer that commits its own work leaves a clean worktree at a
+    HEAD the script never blessed. Cascade must detect HEAD movement that
+    doesn't match the auto-fix counter and abort."""
+    repo = _make_repo(tmp_path)
+    _write_config(repo, ["codex", "claude"], mode="fix")
+
+    fakes = tmp_path / "fakes"
+    fakes.mkdir()
+    _write_executable(fakes / "codex", FAKE_CODEX_COMMITS_THEN_FAILS)
+    _write_executable(fakes / "claude", FAKE_CLAUDE_CLEAN)
+
+    result = _run_script(repo, fakes, extra_env={"CODEX_REVIEW_MODE": "fix"})
+
+    assert result.returncode == 1, f"stdout={result.stdout}\nstderr={result.stderr}"
+    assert "unauthorized commits" in result.stdout
+    assert "Refusing to fall through" in result.stdout
+
+
+def test_fix_mode_aborts_on_reviewer_stash(tmp_path: Path) -> None:
+    """A reviewer that stashes its work leaves a clean worktree and
+    unchanged HEAD, but the stash hides reviewer-authored state. Cascade
+    must detect stash list growth and abort."""
+    repo = _make_repo(tmp_path)
+    _write_config(repo, ["codex", "claude"], mode="fix")
+
+    fakes = tmp_path / "fakes"
+    fakes.mkdir()
+    _write_executable(fakes / "codex", FAKE_CODEX_STASHES_THEN_FAILS)
+    _write_executable(fakes / "claude", FAKE_CLAUDE_CLEAN)
+
+    result = _run_script(repo, fakes, extra_env={"CODEX_REVIEW_MODE": "fix"})
+
+    assert result.returncode == 1, f"stdout={result.stdout}\nstderr={result.stderr}"
+    assert "added stash entries" in result.stdout
+    assert "Refusing to fall through" in result.stdout
 
 
 def test_fix_mode_aborts_when_pre_review_worktree_dirty(tmp_path: Path) -> None:

--- a/tests/test_review_cascade.py
+++ b/tests/test_review_cascade.py
@@ -129,6 +129,7 @@ case "$1" in
     ;;
   exec)
     echo "I reviewed your code and it looks fine but I will not emit the sentinel."
+    echo "warning: tool restriction prevented me from running tests" >&2
     exit 0
     ;;
 esac
@@ -339,6 +340,10 @@ def test_malformed_sentinel_falls_through(tmp_path: Path) -> None:
     assert "falling back to Claude" in result.stdout
     assert "codex:malformed" in result.stdout
     assert "claude:clean" in result.stdout
+    # A malformed-sentinel reviewer can still write useful diagnostics
+    # to stderr (e.g. tool-restriction warnings); those must surface
+    # so the user knows *why* the contract was violated.
+    assert "tool restriction prevented me from running tests" in result.stdout
 
 
 def test_cascade_exhausted_records_chain(tmp_path: Path) -> None:

--- a/tests/test_review_cascade.py
+++ b/tests/test_review_cascade.py
@@ -1,0 +1,268 @@
+"""Regression test for scripts/codex-review.sh fallback cascade.
+
+Reproduces the silent-failure bug this PR fixes: previously, when codex
+exited non-zero (usage limit, rate limit, transient API error), the
+script's stderr was discarded and the fail-open path exited 0 with only
+"reviewer exit N" logged — the push proceeded without a real review.
+
+These tests assert the new behavior: a runtime failure on one reviewer
+falls through to the next available reviewer, and the failure cause is
+surfaced in the cascade chain summary.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "scripts" / "codex-review.sh"
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(textwrap.dedent(body).lstrip("\n"))
+    path.chmod(0o755)
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    """Create a tiny git repo with two commits so MERGE_BASE..HEAD has a diff."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    env = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, env=env, check=True)
+    subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=repo, env=env, check=True)
+    (repo / "README").write_text("base\n")
+    subprocess.run(["git", "add", "README"], cwd=repo, env=env, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "base"], cwd=repo, env=env, check=True)
+    (repo / "README").write_text("base\nfeature line\n")
+    subprocess.run(["git", "add", "README"], cwd=repo, env=env, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "feature"], cwd=repo, env=env, check=True)
+    return repo
+
+
+def _run_script(repo: Path, fakes_dir: Path, extra_env: dict | None = None,
+                timeout: int = 60) -> subprocess.CompletedProcess:
+    env = {
+        **os.environ,
+        "PATH": f"{fakes_dir}:{os.environ.get('PATH', '')}",
+        "CODEX_REVIEW_BASE": "HEAD~1",  # avoid origin fetch
+        "CODEX_REVIEW_MODE": "review-only",
+        "CODEX_REVIEW_DISABLE_CACHE": "1",
+        "CODEX_REVIEW_TIMEOUT": "5",  # keep tests fast; we never exercise the real budget
+        "TOUCHSTONE_ROOT": str(repo),
+        "NO_COLOR": "1",
+        "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+    }
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        ["bash", str(SCRIPT_PATH)],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _write_config(repo: Path, reviewers: list[str], on_error: str = "fail-open") -> None:
+    body = textwrap.dedent(f"""
+        [codex_review]
+        max_iterations = 1
+        max_diff_lines = 5000
+        cache_clean_reviews = false
+        safe_by_default = false
+        mode = "review-only"
+        on_error = "{on_error}"
+        unsafe_paths = []
+
+        [review]
+        enabled = true
+        reviewers = {reviewers!r}
+    """).lstrip("\n")
+    (repo / ".codex-review.toml").write_text(body)
+
+
+# ---------------------------------------------------------------------------
+# fake reviewer factories
+# ---------------------------------------------------------------------------
+
+FAKE_CODEX_RATE_LIMIT = '''
+#!/usr/bin/env bash
+case "$1" in
+  login)
+    if [ "$2" = "status" ]; then exit 0; fi
+    ;;
+  exec)
+    echo 'ERROR: {"type":"error","status":429,"error":{"type":"rate_limit_exceeded","message":"Too many requests"}}' >&2
+    exit 1
+    ;;
+esac
+exit 1
+'''
+
+FAKE_CODEX_MALFORMED = '''
+#!/usr/bin/env bash
+case "$1" in
+  login)
+    if [ "$2" = "status" ]; then exit 0; fi
+    ;;
+  exec)
+    echo "I reviewed your code and it looks fine but I will not emit the sentinel."
+    exit 0
+    ;;
+esac
+exit 1
+'''
+
+FAKE_CODEX_FAILS = '''
+#!/usr/bin/env bash
+case "$1" in
+  login)
+    if [ "$2" = "status" ]; then exit 0; fi
+    ;;
+  exec)
+    echo "ERROR: usage limit exceeded" >&2
+    exit 1
+    ;;
+esac
+exit 1
+'''
+
+FAKE_CLAUDE_CLEAN = '''
+#!/usr/bin/env bash
+case "$1" in
+  auth)
+    if [ "$2" = "status" ]; then exit 0; fi
+    ;;
+  -p)
+    echo "Looks fine."
+    echo "CODEX_REVIEW_CLEAN"
+    exit 0
+    ;;
+esac
+exit 1
+'''
+
+FAKE_CLAUDE_FAILS = '''
+#!/usr/bin/env bash
+case "$1" in
+  auth)
+    if [ "$2" = "status" ]; then exit 0; fi
+    ;;
+  -p)
+    echo "ERROR: 401 unauthorized" >&2
+    exit 1
+    ;;
+esac
+exit 1
+'''
+
+
+# ---------------------------------------------------------------------------
+# tests
+# ---------------------------------------------------------------------------
+
+def test_usage_limit_falls_through_to_next_reviewer(tmp_path: Path) -> None:
+    """Codex hits a rate limit; cascade falls through to claude, which clears."""
+    repo = _make_repo(tmp_path)
+    _write_config(repo, ["codex", "claude"])
+
+    fakes = tmp_path / "fakes"
+    fakes.mkdir()
+    _write_executable(fakes / "codex", FAKE_CODEX_RATE_LIMIT)
+    _write_executable(fakes / "claude", FAKE_CLAUDE_CLEAN)
+
+    result = _run_script(repo, fakes)
+
+    assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+    assert "falling back to Claude" in result.stdout
+    assert "codex:usage-limit" in result.stdout
+    assert "claude:clean" in result.stdout
+    assert "ALL CLEAR" in result.stdout
+
+
+def test_malformed_sentinel_falls_through(tmp_path: Path) -> None:
+    """Codex emits non-sentinel output (a contract violation, not a crash);
+    cascade still falls through to claude per the silent-fail-prevention spirit."""
+    repo = _make_repo(tmp_path)
+    _write_config(repo, ["codex", "claude"])
+
+    fakes = tmp_path / "fakes"
+    fakes.mkdir()
+    _write_executable(fakes / "codex", FAKE_CODEX_MALFORMED)
+    _write_executable(fakes / "claude", FAKE_CLAUDE_CLEAN)
+
+    result = _run_script(repo, fakes)
+
+    assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+    assert "did not match the expected sentinel contract" in result.stdout
+    assert "falling back to Claude" in result.stdout
+    assert "codex:malformed" in result.stdout
+    assert "claude:clean" in result.stdout
+
+
+def test_cascade_exhausted_records_chain(tmp_path: Path) -> None:
+    """Both reviewers fail; cascade-exhausted path records the chain and
+    fail-open allows the push (preserving today's exit-policy semantics).
+    The bug this PR fixes is *visibility*, not the exit policy itself —
+    the failure reason is now in the chain instead of swallowed."""
+    repo = _make_repo(tmp_path)
+    _write_config(repo, ["codex", "claude"])
+
+    fakes = tmp_path / "fakes"
+    fakes.mkdir()
+    _write_executable(fakes / "codex", FAKE_CODEX_FAILS)
+    _write_executable(fakes / "claude", FAKE_CLAUDE_FAILS)
+
+    result = _run_script(repo, fakes)
+
+    # fail-open: cascade exhausted → exit 0 with loud message
+    assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+    assert "All reviewers in the cascade failed" in result.stdout
+    assert "codex:usage-limit" in result.stdout
+    assert "claude:auth" in result.stdout
+    assert "cascade exhausted" in result.stdout
+
+
+def test_cascade_exhausted_blocks_when_fail_closed(tmp_path: Path) -> None:
+    """Same as above but with on_error=fail-closed — push must be blocked."""
+    repo = _make_repo(tmp_path)
+    _write_config(repo, ["codex", "claude"], on_error="fail-closed")
+
+    fakes = tmp_path / "fakes"
+    fakes.mkdir()
+    _write_executable(fakes / "codex", FAKE_CODEX_FAILS)
+    _write_executable(fakes / "claude", FAKE_CLAUDE_FAILS)
+
+    result = _run_script(repo, fakes)
+
+    assert result.returncode == 1, f"stdout={result.stdout}\nstderr={result.stderr}"
+    assert "All reviewers in the cascade failed" in result.stdout
+    assert "blocking push" in result.stderr or "blocking push" in result.stdout
+
+
+def test_stderr_tail_surfaced_on_failure(tmp_path: Path) -> None:
+    """Reviewer stderr is no longer discarded — the rate-limit message
+    must appear in the user-visible output so they know *why* it failed."""
+    repo = _make_repo(tmp_path)
+    _write_config(repo, ["codex", "claude"])
+
+    fakes = tmp_path / "fakes"
+    fakes.mkdir()
+    _write_executable(fakes / "codex", FAKE_CODEX_RATE_LIMIT)
+    _write_executable(fakes / "claude", FAKE_CLAUDE_CLEAN)
+
+    result = _run_script(repo, fakes)
+
+    assert "rate_limit_exceeded" in result.stdout, (
+        "Codex stderr (rate-limit JSON) should be tailed into user output, "
+        "not silenced. This is the core silent-failure bug.\n"
+        f"stdout={result.stdout!r}"
+    )

--- a/tests/test_review_cascade.py
+++ b/tests/test_review_cascade.py
@@ -258,6 +258,25 @@ esac
 exit 1
 '''
 
+# Codex switches to a different branch that points at the same sha
+# (e.g. a fresh branch off HEAD) and then fails. HEAD-sha is unchanged
+# but the next reviewer would auto-commit on the wrong branch.
+FAKE_CODEX_SWITCH_BRANCH = '''
+#!/usr/bin/env bash
+case "$1" in
+  login)
+    if [ "$2" = "status" ]; then exit 0; fi
+    ;;
+  exec)
+    git -c user.name=t -c user.email=t@t branch sideways-same-sha
+    git -c user.name=t -c user.email=t@t checkout -q sideways-same-sha
+    echo "ERROR: rate_limit_exceeded" >&2
+    exit 1
+    ;;
+esac
+exit 1
+'''
+
 # Codex drops the existing stash and adds its own — same count,
 # different content. Catches the count-vs-sha distinction.
 FAKE_CODEX_SWAP_STASH = '''
@@ -427,6 +446,25 @@ def test_fix_mode_aborts_on_sideways_checkout(tmp_path: Path) -> None:
 
     assert result.returncode == 1, f"stdout={result.stdout}\nstderr={result.stderr}"
     assert "moved HEAD to an un-blessed sha" in result.stdout
+    assert "Refusing to fall through" in result.stdout
+
+
+def test_fix_mode_aborts_on_branch_switch_at_same_sha(tmp_path: Path) -> None:
+    """A reviewer that creates and checks out a different branch pointing
+    at the same sha leaves HEAD-sha unchanged but on the wrong branch.
+    Branch-name comparison must catch this."""
+    repo = _make_repo(tmp_path)
+    _write_config(repo, ["codex", "claude"], mode="fix")
+
+    fakes = tmp_path / "fakes"
+    fakes.mkdir()
+    _write_executable(fakes / "codex", FAKE_CODEX_SWITCH_BRANCH)
+    _write_executable(fakes / "claude", FAKE_CLAUDE_CLEAN)
+
+    result = _run_script(repo, fakes, extra_env={"CODEX_REVIEW_MODE": "fix"})
+
+    assert result.returncode == 1, f"stdout={result.stdout}\nstderr={result.stderr}"
+    assert "switched branches" in result.stdout
     assert "Refusing to fall through" in result.stdout
 
 

--- a/tests/test_review_cascade.py
+++ b/tests/test_review_cascade.py
@@ -236,6 +236,48 @@ esac
 exit 1
 '''
 
+# Codex creates a sideways branch with an unauthorized commit and
+# checks it out (HEAD moves to a different ref entirely). Worktree
+# stays "clean" relative to the new HEAD but the count-based check
+# would compare zero new commits ahead of the original HEAD.
+FAKE_CODEX_CHECKOUT_SIDEWAYS = '''
+#!/usr/bin/env bash
+case "$1" in
+  login)
+    if [ "$2" = "status" ]; then exit 0; fi
+    ;;
+  exec)
+    git -c user.name=t -c user.email=t@t checkout -q -b sideways
+    echo "edit from codex" >> README
+    git -c user.name=t -c user.email=t@t add README
+    git -c user.name=t -c user.email=t@t commit -q -m "sideways unauthorized"
+    echo "ERROR: rate_limit_exceeded" >&2
+    exit 1
+    ;;
+esac
+exit 1
+'''
+
+# Codex drops the existing stash and adds its own — same count,
+# different content. Catches the count-vs-sha distinction.
+FAKE_CODEX_SWAP_STASH = '''
+#!/usr/bin/env bash
+case "$1" in
+  login)
+    if [ "$2" = "status" ]; then exit 0; fi
+    ;;
+  exec)
+    # Drop whatever is on top, then push our own.
+    git stash drop -q stash@{0} 2>/dev/null || true
+    echo "edit from codex" >> README
+    git stash push -q -m "swapped by codex" -- README
+    echo "ERROR: rate_limit_exceeded" >&2
+    exit 1
+    ;;
+esac
+exit 1
+'''
+
 
 # ---------------------------------------------------------------------------
 # tests
@@ -364,7 +406,52 @@ def test_fix_mode_aborts_on_unauthorized_commits(tmp_path: Path) -> None:
     result = _run_script(repo, fakes, extra_env={"CODEX_REVIEW_MODE": "fix"})
 
     assert result.returncode == 1, f"stdout={result.stdout}\nstderr={result.stderr}"
-    assert "unauthorized commits" in result.stdout
+    assert "moved HEAD to an un-blessed sha" in result.stdout
+    assert "Refusing to fall through" in result.stdout
+
+
+def test_fix_mode_aborts_on_sideways_checkout(tmp_path: Path) -> None:
+    """A reviewer that creates a branch and commits to it leaves a clean
+    tree and a HEAD that's not the script's expected sha. Detection by
+    HEAD-sha (not commit count) catches this even though the diff vs the
+    *original* HEAD shows zero new ancestors."""
+    repo = _make_repo(tmp_path)
+    _write_config(repo, ["codex", "claude"], mode="fix")
+
+    fakes = tmp_path / "fakes"
+    fakes.mkdir()
+    _write_executable(fakes / "codex", FAKE_CODEX_CHECKOUT_SIDEWAYS)
+    _write_executable(fakes / "claude", FAKE_CLAUDE_CLEAN)
+
+    result = _run_script(repo, fakes, extra_env={"CODEX_REVIEW_MODE": "fix"})
+
+    assert result.returncode == 1, f"stdout={result.stdout}\nstderr={result.stderr}"
+    assert "moved HEAD to an un-blessed sha" in result.stdout
+    assert "Refusing to fall through" in result.stdout
+
+
+def test_fix_mode_aborts_on_swapped_stash(tmp_path: Path) -> None:
+    """A reviewer that drops one stash and pushes another keeps the count
+    constant but the content changes. SHA-list comparison catches it."""
+    repo = _make_repo(tmp_path)
+    _write_config(repo, ["codex", "claude"], mode="fix")
+
+    # Plant a pre-existing stash so the reviewer has something to drop.
+    env = {**os.environ, "GIT_AUTHOR_NAME": "u", "GIT_AUTHOR_EMAIL": "u@u",
+           "GIT_COMMITTER_NAME": "u", "GIT_COMMITTER_EMAIL": "u@u"}
+    (repo / "README").write_text("base\nfeature line\nuser stash content\n")
+    subprocess.run(["git", "stash", "push", "-q", "-m", "user stash", "--",
+                    "README"], cwd=repo, env=env, check=True)
+
+    fakes = tmp_path / "fakes"
+    fakes.mkdir()
+    _write_executable(fakes / "codex", FAKE_CODEX_SWAP_STASH)
+    _write_executable(fakes / "claude", FAKE_CLAUDE_CLEAN)
+
+    result = _run_script(repo, fakes, extra_env={"CODEX_REVIEW_MODE": "fix"})
+
+    assert result.returncode == 1, f"stdout={result.stdout}\nstderr={result.stderr}"
+    assert "mutated the stash list" in result.stdout
     assert "Refusing to fall through" in result.stdout
 
 
@@ -383,7 +470,7 @@ def test_fix_mode_aborts_on_reviewer_stash(tmp_path: Path) -> None:
     result = _run_script(repo, fakes, extra_env={"CODEX_REVIEW_MODE": "fix"})
 
     assert result.returncode == 1, f"stdout={result.stdout}\nstderr={result.stderr}"
-    assert "added stash entries" in result.stdout
+    assert "mutated the stash list" in result.stdout
     assert "Refusing to fall through" in result.stdout
 
 

--- a/tests/test_review_cascade.py
+++ b/tests/test_review_cascade.py
@@ -13,12 +13,9 @@ surfaced in the cascade chain summary.
 from __future__ import annotations
 
 import os
-import shutil
 import subprocess
 import textwrap
 from pathlib import Path
-
-import pytest
 
 SCRIPT_PATH = Path(__file__).resolve().parent.parent / "scripts" / "codex-review.sh"
 
@@ -100,14 +97,17 @@ def _write_config(repo: Path, reviewers: list[str], on_error: str = "fail-open")
 # fake reviewer factories
 # ---------------------------------------------------------------------------
 
-FAKE_CODEX_RATE_LIMIT = '''
+FAKE_CODEX_RATE_LIMIT = r'''
 #!/usr/bin/env bash
 case "$1" in
   login)
     if [ "$2" = "status" ]; then exit 0; fi
     ;;
   exec)
-    echo 'ERROR: {"type":"error","status":429,"error":{"type":"rate_limit_exceeded","message":"Too many requests"}}' >&2
+    msg='{"type":"error","status":429,'
+    msg="${msg}\"error\":{\"type\":\"rate_limit_exceeded\","
+    msg="${msg}\"message\":\"Too many requests\"}}"
+    echo "ERROR: $msg" >&2
     exit 1
     ;;
 esac

--- a/tests/test_review_cascade.py
+++ b/tests/test_review_cascade.py
@@ -75,14 +75,15 @@ def _run_script(repo: Path, fakes_dir: Path, extra_env: dict | None = None,
     )
 
 
-def _write_config(repo: Path, reviewers: list[str], on_error: str = "fail-open") -> None:
+def _write_config(repo: Path, reviewers: list[str], on_error: str = "fail-open",
+                  mode: str = "review-only") -> None:
     body = textwrap.dedent(f"""
         [codex_review]
         max_iterations = 1
         max_diff_lines = 5000
         cache_clean_reviews = false
-        safe_by_default = false
-        mode = "review-only"
+        safe_by_default = true
+        mode = "{mode}"
         on_error = "{on_error}"
         unsafe_paths = []
 
@@ -91,6 +92,12 @@ def _write_config(repo: Path, reviewers: list[str], on_error: str = "fail-open")
         reviewers = {reviewers!r}
     """).lstrip("\n")
     (repo / ".codex-review.toml").write_text(body)
+    # Commit so the worktree is clean before review runs — otherwise the
+    # config file shows up as untracked and trips WORKTREE_DIRTY_BEFORE_REVIEW.
+    env = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    subprocess.run(["git", "add", ".codex-review.toml"], cwd=repo, env=env, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "config"], cwd=repo, env=env, check=True)
 
 
 # ---------------------------------------------------------------------------
@@ -165,6 +172,26 @@ case "$1" in
     ;;
   -p)
     echo "ERROR: 401 unauthorized" >&2
+    exit 1
+    ;;
+esac
+exit 1
+'''
+
+# Codex writes a file (simulating a partial edit) then exits non-zero
+# without ever emitting CODEX_REVIEW_FIXED. In fix mode the cascade must
+# discard this partial edit before falling through, otherwise claude would
+# review-or-bless un-blessed work.
+FAKE_CODEX_PARTIAL_EDIT = '''
+#!/usr/bin/env bash
+case "$1" in
+  login)
+    if [ "$2" = "status" ]; then exit 0; fi
+    ;;
+  exec)
+    # Simulate codex starting an edit then crashing mid-flight.
+    echo "partial edit from codex that will never be blessed" >> README
+    echo "ERROR: rate_limit_exceeded" >&2
     exit 1
     ;;
 esac
@@ -253,6 +280,56 @@ def test_cascade_exhausted_blocks_when_fail_closed(tmp_path: Path) -> None:
     assert result.returncode == 1, f"stdout={result.stdout}\nstderr={result.stderr}"
     assert "All reviewers in the cascade failed" in result.stdout
     assert "blocking push" in result.stderr or "blocking push" in result.stdout
+
+
+def test_fix_mode_discards_partial_edits_before_fallthrough(tmp_path: Path) -> None:
+    """In fix mode, a failed reviewer may have written partial edits before
+    crashing. The cascade must NOT pass that dirty worktree to the next
+    reviewer — otherwise claude could bless or auto-commit work codex
+    never blessed with FIXED."""
+    repo = _make_repo(tmp_path)
+    _write_config(repo, ["codex", "claude"], mode="fix")
+
+    fakes = tmp_path / "fakes"
+    fakes.mkdir()
+    _write_executable(fakes / "codex", FAKE_CODEX_PARTIAL_EDIT)
+    _write_executable(fakes / "claude", FAKE_CLAUDE_CLEAN)
+
+    result = _run_script(repo, fakes, extra_env={"CODEX_REVIEW_MODE": "fix"})
+
+    assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+    assert "Discarding partial edits" in result.stdout
+    assert "falling back to Claude" in result.stdout
+    # Worktree must be clean after the cascade — codex's un-blessed edit
+    # should have been reverted before claude saw it.
+    status = subprocess.run(
+        ["git", "status", "--porcelain"], cwd=repo, capture_output=True, text=True,
+    )
+    assert status.stdout == "", (
+        f"Worktree should be clean post-cascade; saw: {status.stdout!r}\n"
+        f"This means a failed reviewer's partial edits leaked through to the next reviewer."
+    )
+
+
+def test_fix_mode_aborts_when_pre_review_worktree_dirty(tmp_path: Path) -> None:
+    """If the user already had uncommitted changes before review started,
+    we cannot safely distinguish their work from reviewer edits on failure.
+    Refuse to fall through and block the push, so the user can sort it out."""
+    repo = _make_repo(tmp_path)
+    _write_config(repo, ["codex", "claude"], mode="fix")
+    # Plant a pre-review uncommitted change.
+    (repo / "README").write_text("base\nfeature line\nuser edit\n")
+
+    fakes = tmp_path / "fakes"
+    fakes.mkdir()
+    _write_executable(fakes / "codex", FAKE_CODEX_PARTIAL_EDIT)
+    _write_executable(fakes / "claude", FAKE_CLAUDE_CLEAN)
+
+    result = _run_script(repo, fakes, extra_env={"CODEX_REVIEW_MODE": "fix"})
+
+    assert result.returncode == 1, f"stdout={result.stdout}\nstderr={result.stderr}"
+    assert "refusing to fall through" in result.stdout
+    assert "mixed user/reviewer state" in result.stdout
 
 
 def test_stderr_tail_surfaced_on_failure(tmp_path: Path) -> None:

--- a/tests/test_review_cascade.py
+++ b/tests/test_review_cascade.py
@@ -47,8 +47,15 @@ def _make_repo(tmp_path: Path) -> Path:
 
 def _run_script(repo: Path, fakes_dir: Path, extra_env: dict | None = None,
                 timeout: int = 60) -> subprocess.CompletedProcess:
+    # Scrub pre-commit/pre-push hook signals that may leak in from the test
+    # runner's environment (e.g. when pytest itself runs under a pre-push
+    # hook). The script's `should_skip_pre_push_review` would otherwise
+    # think we're pushing a non-default branch and skip review entirely.
+    inherited = {k: v for k, v in os.environ.items()
+                 if not (k.startswith("PRE_COMMIT") or k.startswith("CODEX_REVIEW")
+                         or k == "TOUCHSTONE_REVIEWER")}
     env = {
-        **os.environ,
+        **inherited,
         "PATH": f"{fakes_dir}:{os.environ.get('PATH', '')}",
         "CODEX_REVIEW_BASE": "HEAD~1",  # avoid origin fetch
         "CODEX_REVIEW_MODE": "review-only",


### PR DESCRIPTION
The pre-push hook would silently pass on codex usage-limit hits and
timeouts because reviewer stderr was discarded and the fail-open path
exited 0 with only "reviewer exit N" logged — push proceeded without a
real review.

- Stop redirecting reviewer stderr to /dev/null; capture to a per-attempt
  file, print last 5 lines on failure, classify as usage-limit / auth /
  network / error from known stderr patterns
- resolve_reviewer now builds AVAILABLE_CASCADE (every installed+authed
  reviewer in cascade order) instead of locking in the first match
- Outer loop walks the cascade; on timeout (124) or non-zero exit, the
  failure is telegraphed and the next reviewer is tried. handle_error
  fires once when the entire cascade is exhausted, with the chain in
  the reason
- Default timeout 300s → 1800s (safety net for hangs, not a thinking
  budget — real reviews on big diffs run 8-10 min)
- Summary block and JSON gain reviewer_chain (e.g.
  "codex:usage-limit,claude:clean")
- Worktree-mutation and max-iterations-without-convergence paths
  unchanged — those aren't "reviewer broke" conditions

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
