### PR TITLE
--title

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=v[0-9]*)$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst


### PR DESCRIPTION
GitHub tarballs don't contain .git, so hatch-vcs/setuptools_scm can't
derive the version. The two files (matching sentinel's setup) tell
`git archive` to bake the resolved tag into the tarball at archive
time, so `brew install` from the GitHub source tarball works.

Surfaced by today's brew install of v0.4.0 failing with the
setuptools_scm 'no version metadata' error.

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
