### PR TITLE
fix(release): gh pre-check + atomic tag creation

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -44,11 +44,14 @@ new_tag="v${major}.${minor}.${patch}"
 echo "==> Current: $current_tag"
 echo "==> New:     $new_tag"
 
-# Atomic: gh release create with --target builds the tag server-side as
-# part of the release, so a failed release leaves no orphan tag for the
-# next run to skip past.
-gh release create "$new_tag" --target main --generate-notes
-git fetch --tags origin >/dev/null
+# Pin the release target to the verified-in-sync HEAD SHA, not the branch
+# name — otherwise a commit that lands on origin/main between the sync
+# check above and the gh call below would be released instead. The tag
+# is created server-side as part of the release, so a failed release
+# leaves no orphan tag for the next run to skip past.
+target_sha="$(git rev-parse HEAD)"
+gh release create "$new_tag" --target "$target_sha" --generate-notes
+git fetch --tags origin >/dev/null || true
 
 echo
 echo "  ✓ Released $new_tag"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -44,9 +44,11 @@ new_tag="v${major}.${minor}.${patch}"
 echo "==> Current: $current_tag"
 echo "==> New:     $new_tag"
 
-git tag "$new_tag"
-git push origin "$new_tag"
-gh release create "$new_tag" --generate-notes
+# Atomic: gh release create with --target builds the tag server-side as
+# part of the release, so a failed release leaves no orphan tag for the
+# next run to skip past.
+gh release create "$new_tag" --target main --generate-notes
+git fetch --tags origin >/dev/null
 
 echo
 echo "  ✓ Released $new_tag"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -22,6 +22,9 @@ case "$bump" in
   *) echo "ERROR: unknown bump arg: $bump (use --major, --minor, --patch)" >&2; exit 1 ;;
 esac
 
+command -v gh >/dev/null 2>&1 || { echo "ERROR: gh CLI not installed (need it for gh release create)" >&2; exit 1; }
+gh auth status >/dev/null 2>&1 || { echo "ERROR: gh not authenticated (run: gh auth login)" >&2; exit 1; }
+
 branch="$(git rev-parse --abbrev-ref HEAD)"
 [ "$branch" = "main" ] || { echo "ERROR: must be on main (currently $branch)" >&2; exit 1; }
 [ -z "$(git status --porcelain)" ] || { echo "ERROR: working tree dirty" >&2; exit 1; }


### PR DESCRIPTION
Builds on the gh-precheck — even with auth verified, gh release create
can still fail (network, perm, rate limit). If it fails after the local
tag is pushed, the orphan remote tag means a rerun bumps past the
intended version. Letting gh create the tag server-side as part of the
release makes the operation atomic.

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
