### PR TITLE
fix(doctor): clarify wiring status and group providers

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -1373,19 +1373,34 @@ def doctor(as_json: bool) -> None:
         f"{payload['platform']}  ·  python {payload['python']}"
     )
     click.echo("")
-    click.echo("Providers:")
-    for p in payload["providers"]:
+    configured = [p for p in payload["providers"] if p["configured"]]
+    unconfigured = [p for p in payload["providers"] if not p["configured"]]
+    total = len(payload["providers"])
+
+    def _provider_line(p: dict) -> None:
         symbol = "✓" if p["configured"] else "✗"
         effort_note = "" if p["supports_effort"] else " (no thinking mode)"
         click.echo(
-            f"  {symbol} {p['provider']:<8}  "
+            f"    {symbol} {p['provider']:<8}  "
             f"tier={p['quality_tier']:<8}  "
             f"default={p['default_model']}{effort_note}"
         )
         if not p["configured"]:
-            click.echo(f"      └─ {p['reason']}")
+            click.echo(f"        └─ {p['reason']}")
         for w in p.get("warnings") or []:
-            click.echo(f"      ⚠ {w}")
+            click.echo(f"        ⚠ {w}")
+
+    click.echo(f"Providers ({len(configured)}/{total} configured):")
+    if configured:
+        click.echo("  Configured:")
+        for p in configured:
+            _provider_line(p)
+    if unconfigured:
+        if configured:
+            click.echo("")
+        click.echo("  Available (not configured):")
+        for p in unconfigured:
+            _provider_line(p)
 
     click.echo("")
     click.echo("Credentials (active source per env-var):")
@@ -1435,7 +1450,19 @@ def doctor(as_json: bool) -> None:
             version_note = f" v{entry['version']}" if entry and entry["version"] else ""
             click.echo(f"  {label}  wired — {ai[path_key]}{version_note}")
         else:
-            click.echo(f"  {label}  present but not wired — {ai[path_key]}")
+            # The file itself is loaded normally by its host agent; only
+            # Conductor's per-repo delegation block is missing. Spell that out
+            # so "present but not wired" doesn't read as "the file is broken".
+            click.echo(
+                f"  {label}  no Conductor delegation block — {ai[path_key]}"
+            )
+            click.echo(
+                "                (file still loads normally for its agent; "
+                "Conductor would add per-repo"
+            )
+            click.echo(
+                "                routing hints via `conductor init`.)"
+            )
 
     _repo_line("AGENTS.md:   ", "agents-md-import",
                "agents_md_exists", "agents_md_wired", "agents_md_path")
@@ -1456,7 +1483,10 @@ def doctor(as_json: bool) -> None:
         version_note = f" v{entry['version']}" if entry and entry["version"] else ""
         click.echo(f"  Cursor:       rule wired{version_note}")
     else:
-        click.echo("  Cursor:       .cursor/rules/ present but not wired")
+        click.echo(
+            "  Cursor:       no Conductor rule in .cursor/rules/ "
+            "(run `conductor init` to add one)"
+        )
 
     click.echo("")
     click.echo("Next steps:")

--- a/tests/test_cli_phase5.py
+++ b/tests/test_cli_phase5.py
@@ -335,7 +335,8 @@ def test_doctor_reports_agents_md_when_present(mocker, monkeypatch, tmp_path):
     result = CliRunner().invoke(main, ["doctor"])
     assert result.exit_code == 0, result.output
     assert "AGENTS.md" in result.output
-    assert "present but not wired" in result.output.lower()
+    assert "no Conductor delegation block" in result.output
+    assert "file still loads normally" in result.output
 
 
 def test_doctor_reports_gemini_md_states(mocker, monkeypatch, tmp_path):
@@ -348,10 +349,10 @@ def test_doctor_reports_gemini_md_states(mocker, monkeypatch, tmp_path):
     assert "GEMINI.md" in result.output
     assert "no GEMINI.md" in result.output
 
-    # Present but not wired.
+    # Present but no Conductor delegation block.
     (tmp_path / "repo" / "GEMINI.md").write_text("# mine\n", encoding="utf-8")
     result = CliRunner().invoke(main, ["doctor"])
-    assert "present but not wired" in result.output.lower()
+    assert "no Conductor delegation block" in result.output
 
     # Wired.
     from conductor import agent_wiring

--- a/tests/test_cli_phase5.py
+++ b/tests/test_cli_phase5.py
@@ -377,6 +377,12 @@ def test_doctor_reports_cursor_states(mocker, monkeypatch, tmp_path):
     assert "Cursor:" in result.output
     assert "no .cursor/rules/" in result.output.lower()
 
+    # Directory present but Conductor rule missing.
+    (tmp_path / "repo" / ".cursor" / "rules").mkdir(parents=True)
+    result = CliRunner().invoke(main, ["doctor"])
+    assert "Cursor:" in result.output
+    assert "no Conductor rule" in result.output
+
     # Wired.
     from conductor import agent_wiring
     agent_wiring.wire_cursor(version="0.4.2")


### PR DESCRIPTION
The "present but not wired" line for CLAUDE.md / AGENTS.md / GEMINI.md
read like the file itself was broken. Reword to name the actual missing
thing — Conductor's per-repo delegation block — and add a clarifying
line that the file still loads normally for its host agent.

Group the providers section into "Configured" and "Available (not
configured)" with a header summary so unconfigured providers don't read
as failures.

Cursor's "present but not wired" branch gets the same treatment.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
