### PR TITLE
fix(provider): translate --effort to model_reasoning_effort for codex 0.125.0+

### DIFF
--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -30,8 +30,11 @@ from conductor.providers.interface import (
 CODEX_DEFAULT_MODEL = "gpt-5.4"
 CODEX_REQUEST_TIMEOUT_SEC = 180.0
 
-# Map symbolic effort → codex --effort flag value.
-# Codex natively exposes minimal|low|medium|high.
+# Map symbolic effort → codex's reasoning-effort value.
+# Codex natively exposes minimal|low|medium|high. The CLI plumbs this via
+# `-c model_reasoning_effort=<value>` as of codex-cli 0.125.0 (the older
+# `--effort` flag was removed in that release). We always emit the new
+# form; users on pre-0.125.0 codex will need to upgrade.
 _EFFORT_TO_CODEX_FLAG = {
     "minimal": "minimal",
     "low": "low",
@@ -272,7 +275,7 @@ class CodexProvider:
                 sandbox,
             ]
         if codex_effort_flag:
-            args.extend(["--effort", codex_effort_flag])
+            args.extend(["-c", f"model_reasoning_effort={codex_effort_flag}"])
 
         timeout = timeout_sec_override if timeout_sec_override is not None else self._timeout_sec
         start = time.monotonic()

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -293,6 +293,31 @@ def test_codex_call_parses_ndjson_and_usage(mocker):
     assert response.session_id == "sess-codex-1"
 
 
+def test_codex_call_translates_effort_to_reasoning_effort_config(mocker):
+    """Codex CLI 0.125.0 dropped --effort in favor of `-c model_reasoning_effort=`.
+    Conductor must emit the new form. Regression test for the silent breakage
+    where conductor's call passed `--effort minimal` to a 0.125.0 codex CLI,
+    which exited 2 with `error: unexpected argument '--effort' found`."""
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    captured = mocker.patch(
+        "conductor.providers.codex.subprocess.run",
+        return_value=_fake_completed(stdout=CODEX_NDJSON),
+    )
+    CodexProvider().call("hi", effort="minimal")
+    args = captured.call_args.args[0]
+    # Old (broken) form must not appear.
+    assert "--effort" not in args, (
+        "codex CLI >= 0.125.0 removed --effort; conductor must use -c instead. "
+        f"args={args!r}"
+    )
+    # New form: -c model_reasoning_effort=minimal must be present together.
+    assert "-c" in args, f"missing -c flag, args={args!r}"
+    c_idx = args.index("-c")
+    assert args[c_idx + 1] == "model_reasoning_effort=minimal", (
+        f"expected `model_reasoning_effort=minimal`, got {args[c_idx + 1]!r}"
+    )
+
+
 def test_codex_call_with_resume_uses_resume_subcommand(mocker):
     mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
     captured = mocker.patch(


### PR DESCRIPTION
codex-cli 0.125.0 removed the `--effort` flag in favor of plumbing it
through `-c model_reasoning_effort=<value>`. Conductor was unconditionally
appending `["--effort", value]` to the codex argv, so every conductor
exec/call against a 0.125.0 codex CLI failed immediately:

    conductor: codex exited 2: error: unexpected argument '--effort' found

This blocked Touchstone's codex-coding-agent delegations (the agent
needs `conductor exec --with codex --effort ...` to work), surfaced
during today's touchstone shellcheck-py parity work.

Switch to the new form:

    args.extend(["-c", f"model_reasoning_effort={codex_effort_flag}"])

End-to-end smoke confirmed against codex-cli 0.125.0 + a real model
call — `conductor exec --with codex --effort low --task "say hi"` now
returns the agent message instead of crashing on argv validation.

Adds a regression test asserting:
1. `--effort` is no longer present in the constructed argv.
2. `-c` is present and immediately followed by the
   `model_reasoning_effort=<value>` string.

This locks the contract — a future revert or sloppy refactor that
re-introduces `--effort` will fail the test before reaching production.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
