### PR TITLE
fix(exec): drop default --timeout, recover codex session_id on timeout

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -375,7 +375,7 @@ def _invoke_with_fallback(
     tools: frozenset[str],
     sandbox: str,
     cwd: str | None,
-    timeout_sec: int,
+    timeout_sec: int | None,
     silent: bool,
     resume_session_id: str | None = None,
 ) -> tuple[CallResponse, list[str]]:
@@ -745,7 +745,7 @@ def call(
                 tools=frozenset(),
                 sandbox="none",
                 cwd=None,
-                timeout_sec=300,
+                timeout_sec=None,
                 silent=silent_route or as_json,
             )
         except ProviderConfigError as e:
@@ -837,9 +837,13 @@ def call(
 @click.option(
     "--timeout",
     "timeout_sec",
-    default=300,
+    default=None,
     type=int,
-    help="Wall-clock timeout in seconds (default: 300).",
+    help=(
+        "Wall-clock timeout in seconds. Default: no timeout — agent sessions "
+        "can run as long as they need. Set explicitly (e.g. --timeout 600) "
+        "for CI or unattended runs that must bound runtime."
+    ),
 )
 @click.option("--task", default=None, help="The task / prompt. Reads stdin if omitted.")
 @click.option("--model", default=None, help="Override the provider's default model.")
@@ -875,7 +879,7 @@ def exec_cmd(
     sandbox: str | None,
     exclude: str | None,
     cwd: str | None,
-    timeout_sec: int,
+    timeout_sec: int | None,
     task: str | None,
     model: str | None,
     as_json: bool,

--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -27,6 +27,10 @@ from conductor.providers.interface import (
 CLAUDE_DEFAULT_MODEL = "sonnet"
 CLAUDE_REQUEST_TIMEOUT_SEC = 180.0
 
+# Sentinel: "caller didn't specify a timeout" vs "caller explicitly passed
+# None". The constructor default applies only in the first case.
+_USE_DEFAULT: object = object()
+
 
 class ClaudeProvider:
     name = "claude"
@@ -178,7 +182,7 @@ class ClaudeProvider:
         tools: frozenset[str] = frozenset(),
         sandbox: str = "none",
         cwd: str | None = None,
-        timeout_sec: int = 300,
+        timeout_sec: int | None = None,
         resume_session_id: str | None = None,
     ) -> CallResponse:
         # Claude's `--allowedTools` is fine-grained; passing an empty set
@@ -213,7 +217,7 @@ class ClaudeProvider:
         allowed_tools: str | None,
         permission_mode: str | None,
         cwd: str | None = None,
-        timeout_sec_override: float | None = None,
+        timeout_sec_override: float | None | object = _USE_DEFAULT,
         resume_session_id: str | None = None,
     ) -> CallResponse:
         # Cheap PATH check only on the hot path — auth state surfaces as a
@@ -250,7 +254,10 @@ class ClaudeProvider:
         # by older CLI versions). Wire to a proper CLI flag when stable.
         env_overrides = {"MAX_THINKING_TOKENS": str(thinking_budget)} if thinking_budget else {}
 
-        timeout = timeout_sec_override if timeout_sec_override is not None else self._timeout_sec
+        if timeout_sec_override is _USE_DEFAULT:
+            timeout = self._timeout_sec
+        else:
+            timeout = timeout_sec_override  # type: ignore[assignment]
         start = time.monotonic()
         try:
             import os as _os
@@ -264,8 +271,9 @@ class ClaudeProvider:
                 env=proc_env,
             )
         except subprocess.TimeoutExpired as e:
+            elapsed = time.monotonic() - start
             raise ProviderError(
-                f"claude CLI timed out after {timeout:.0f}s"
+                f"claude CLI timed out after {elapsed:.0f}s"
             ) from e
         duration_ms = int((time.monotonic() - start) * 1000)
 

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -30,6 +30,11 @@ from conductor.providers.interface import (
 CODEX_DEFAULT_MODEL = "gpt-5.4"
 CODEX_REQUEST_TIMEOUT_SEC = 180.0
 
+# Sentinel distinguishing "caller didn't specify a timeout" from "caller
+# explicitly asked for no timeout (None)". The constructor default applies
+# only in the first case; explicit None means run unbounded.
+_USE_DEFAULT: object = object()
+
 # Map symbolic effort → codex's reasoning-effort value.
 # Codex natively exposes minimal|low|medium|high. The CLI plumbs this via
 # `-c model_reasoning_effort=<value>` as of codex-cli 0.125.0 (the older
@@ -204,19 +209,14 @@ class CodexProvider:
         tools: frozenset[str] = frozenset(),
         sandbox: str = "none",
         cwd: str | None = None,
-        timeout_sec: int = 300,
+        timeout_sec: int | None = None,
         resume_session_id: str | None = None,
     ) -> CallResponse:
-        # Codex has two sandboxes: read-only (no fs writes), workspace-write
-        # (edits allowed). "none" is ambiguous in codex; we treat it as
-        # read-only since there's no meaningful "no sandbox" in codex exec.
         codex_sandbox = {
             "read-only": "read-only",
             "workspace-write": "workspace-write",
             "none": "read-only",
         }.get(sandbox, "read-only")
-        # Tool filtering in codex is sandbox-based, not fine-grained.
-        # `tools` is advisory for logging; sandbox does the enforcing.
         return self._run(
             task,
             model=model,
@@ -235,7 +235,7 @@ class CodexProvider:
         effort: str | int,
         sandbox: str,
         cwd: str | None = None,
-        timeout_sec_override: float | None = None,
+        timeout_sec_override: float | None | object = _USE_DEFAULT,
         resume_session_id: str | None = None,
     ) -> CallResponse:
         # Cheap PATH check on the hot path; auth state surfaces as a CLI
@@ -277,7 +277,11 @@ class CodexProvider:
         if codex_effort_flag:
             args.extend(["-c", f"model_reasoning_effort={codex_effort_flag}"])
 
-        timeout = timeout_sec_override if timeout_sec_override is not None else self._timeout_sec
+        if timeout_sec_override is _USE_DEFAULT:
+            timeout = self._timeout_sec
+        else:
+            # `None` means "run unbounded" (subprocess.run accepts timeout=None).
+            timeout = timeout_sec_override  # type: ignore[assignment]
         start = time.monotonic()
         try:
             result = subprocess.run(
@@ -288,9 +292,22 @@ class CodexProvider:
                 cwd=cwd,
             )
         except subprocess.TimeoutExpired as e:
-            raise ProviderError(
-                f"codex CLI timed out after {timeout:.0f}s"
-            ) from e
+            # Recover the session_id (if any) from whatever NDJSON the codex
+            # CLI managed to emit before we killed it. Without this the user
+            # has nothing to `--resume` from after a timeout.
+            partial_stdout = e.stdout or ""
+            if isinstance(partial_stdout, bytes):
+                partial_stdout = partial_stdout.decode("utf-8", errors="replace")
+            _, _, _, partial_session_id = self._parse_ndjson(partial_stdout)
+            elapsed = time.monotonic() - start
+            msg = f"codex CLI timed out after {elapsed:.0f}s"
+            if partial_session_id:
+                msg += (
+                    f" (partial session_id={partial_session_id} — "
+                    f"resume with `conductor exec --with codex "
+                    f"--resume {partial_session_id} ...`)"
+                )
+            raise ProviderError(msg) from e
         duration_ms = int((time.monotonic() - start) * 1000)
 
         if result.returncode != 0:

--- a/src/conductor/providers/deepseek.py
+++ b/src/conductor/providers/deepseek.py
@@ -211,7 +211,7 @@ class _DeepSeekBase:
         tools: frozenset[str] = frozenset(),
         sandbox: str = "none",
         cwd: str | None = None,
-        timeout_sec: int = 300,
+        timeout_sec: int | None = None,
         resume_session_id: str | None = None,
     ) -> CallResponse:
         if resume_session_id:

--- a/src/conductor/providers/gemini.py
+++ b/src/conductor/providers/gemini.py
@@ -30,6 +30,10 @@ from conductor.providers.interface import (
 GEMINI_DEFAULT_MODEL = "gemini-2.5-pro"
 GEMINI_REQUEST_TIMEOUT_SEC = 180.0
 
+# Sentinel: "caller didn't specify a timeout" vs "caller explicitly passed
+# None". The constructor default applies only in the first case.
+_USE_DEFAULT: object = object()
+
 # Env vars Gemini CLI accepts as auth credentials. Any one of these being
 # set is sufficient — the CLI prefers them over the OAuth file.
 GEMINI_AUTH_ENV_VARS = (
@@ -199,7 +203,7 @@ class GeminiProvider:
         tools: frozenset[str] = frozenset(),
         sandbox: str = "none",
         cwd: str | None = None,
-        timeout_sec: int = 300,
+        timeout_sec: int | None = None,
         resume_session_id: str | None = None,
     ) -> CallResponse:
         # Gemini's --approval-mode: "plan" (read-only) vs "yolo" (all writes
@@ -227,7 +231,7 @@ class GeminiProvider:
         effort: str | int,
         approval_mode: str,
         cwd: str | None = None,
-        timeout_sec_override: float | None = None,
+        timeout_sec_override: float | None | object = _USE_DEFAULT,
         resume_session_id: str | None = None,
     ) -> CallResponse:
         # Cheap PATH check on the hot path; auth state surfaces as a CLI
@@ -264,7 +268,10 @@ class GeminiProvider:
             env_overrides["GEMINI_THINKING_BUDGET"] = str(thinking_budget)
         proc_env = {**os.environ, **env_overrides} if env_overrides else None
 
-        timeout = timeout_sec_override if timeout_sec_override is not None else self._timeout_sec
+        if timeout_sec_override is _USE_DEFAULT:
+            timeout = self._timeout_sec
+        else:
+            timeout = timeout_sec_override  # type: ignore[assignment]
         start = time.monotonic()
         try:
             result = subprocess.run(
@@ -276,8 +283,9 @@ class GeminiProvider:
                 env=proc_env,
             )
         except subprocess.TimeoutExpired as e:
+            elapsed = time.monotonic() - start
             raise ProviderError(
-                f"gemini CLI timed out after {timeout:.0f}s"
+                f"gemini CLI timed out after {elapsed:.0f}s"
             ) from e
         duration_ms = int((time.monotonic() - start) * 1000)
 

--- a/src/conductor/providers/kimi.py
+++ b/src/conductor/providers/kimi.py
@@ -267,7 +267,7 @@ class KimiProvider:
         tools: frozenset[str] = frozenset(),
         sandbox: str = "none",
         cwd: str | None = None,
-        timeout_sec: int = 300,
+        timeout_sec: int | None = None,
         resume_session_id: str | None = None,
     ) -> CallResponse:
         if resume_session_id:

--- a/src/conductor/providers/ollama.py
+++ b/src/conductor/providers/ollama.py
@@ -295,7 +295,7 @@ class OllamaProvider:
         tools: frozenset[str] = frozenset(),
         sandbox: str = "none",
         cwd: str | None = None,
-        timeout_sec: int = 300,
+        timeout_sec: int | None = None,
         resume_session_id: str | None = None,
     ) -> CallResponse:
         if resume_session_id:

--- a/src/conductor/providers/shell.py
+++ b/src/conductor/providers/shell.py
@@ -49,6 +49,10 @@ from conductor.providers.interface import (
 
 SHELL_PROVIDER_TIMEOUT_SEC = 180.0
 
+# Sentinel: distinguishes "caller didn't specify a timeout" from "caller
+# explicitly passed None" (no timeout, run unbounded).
+_USE_DEFAULT: object = object()
+
 AcceptsMode = Literal["stdin", "argv"]
 
 
@@ -183,7 +187,7 @@ class ShellProvider:
         tools: frozenset[str] = frozenset(),
         sandbox: str = "none",
         cwd: str | None = None,
-        timeout_sec: int = 300,
+        timeout_sec: int | None = None,
         resume_session_id: str | None = None,
     ) -> CallResponse:
         if tools:
@@ -212,7 +216,7 @@ class ShellProvider:
         task: str,
         *,
         effort: str | int,
-        timeout_override: float | None = None,
+        timeout_override: float | None | object = _USE_DEFAULT,
         cwd: str | None = None,
     ) -> CallResponse:
         argv = shlex.split(self._spec.shell)
@@ -222,7 +226,11 @@ class ShellProvider:
         else:  # argv
             argv = [*argv, task]
 
-        timeout = timeout_override if timeout_override is not None else self._timeout_sec
+        timeout = (
+            self._timeout_sec
+            if timeout_override is _USE_DEFAULT
+            else timeout_override  # type: ignore[assignment]
+        )
         start = time.monotonic()
         try:
             result = subprocess.run(
@@ -233,8 +241,9 @@ class ShellProvider:
                 cwd=cwd,
             )
         except subprocess.TimeoutExpired as e:
+            elapsed = time.monotonic() - start
             raise ProviderError(
-                f"custom provider `{self._spec.name}` timed out after {timeout:.0f}s"
+                f"custom provider `{self._spec.name}` timed out after {elapsed:.0f}s"
             ) from e
         except FileNotFoundError as e:
             raise ProviderConfigError(

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -358,6 +358,111 @@ def test_codex_call_raises_on_non_zero_exit(mocker):
     assert "login required" in str(exc.value)
 
 
+def test_codex_exec_default_timeout_is_unbounded(mocker):
+    """Regression: `conductor exec --with codex` (no --timeout) used to default
+    to 300s, which silently killed long agent sessions and lost the session_id.
+    The default is now no-timeout — subprocess.run must be invoked with
+    timeout=None when the caller does not specify."""
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    captured = mocker.patch(
+        "conductor.providers.codex.subprocess.run",
+        return_value=_fake_completed(stdout=CODEX_NDJSON),
+    )
+    CodexProvider().exec("hi")
+    assert captured.call_args.kwargs["timeout"] is None, (
+        "exec() with no explicit timeout must run unbounded. "
+        f"Got timeout={captured.call_args.kwargs['timeout']!r}"
+    )
+
+
+def test_codex_exec_explicit_timeout_is_honored(mocker):
+    """Caller-supplied --timeout still works — sentinel pattern must not
+    swallow an explicitly-passed integer."""
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    captured = mocker.patch(
+        "conductor.providers.codex.subprocess.run",
+        return_value=_fake_completed(stdout=CODEX_NDJSON),
+    )
+    CodexProvider().exec("hi", timeout_sec=42)
+    assert captured.call_args.kwargs["timeout"] == 42
+
+
+def test_codex_call_keeps_constructor_default_timeout(mocker):
+    """Single-turn call() retains the constructor-default HTTP-style timeout
+    (180s) — the no-timeout change is scoped to exec(), where long agent
+    sessions are normal."""
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    captured = mocker.patch(
+        "conductor.providers.codex.subprocess.run",
+        return_value=_fake_completed(stdout=CODEX_NDJSON),
+    )
+    CodexProvider().call("hi")
+    # Default constructor timeout is 180s — see CODEX_REQUEST_TIMEOUT_SEC.
+    assert captured.call_args.kwargs["timeout"] == 180.0
+
+
+def test_codex_timeout_recovers_session_id_from_partial_ndjson(mocker):
+    """When codex emits a session.created event but then runs past the wall
+    clock, the user must be able to --resume from the partial session_id.
+    Pre-fix, the TimeoutExpired path threw away the captured stdout entirely,
+    leaving the user with 22 minutes of churn and no recovery handle."""
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    partial = (
+        '{"type":"session.created","session_id":"sess-partial-7"}\n'
+        '{"type":"item.started","item":{"type":"agent_message"}}\n'
+    )
+    mocker.patch(
+        "conductor.providers.codex.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(
+            cmd="codex", timeout=5, output=partial, stderr=""
+        ),
+    )
+    with pytest.raises(ProviderError) as exc:
+        CodexProvider().exec("hi", timeout_sec=5)
+    msg = str(exc.value)
+    assert "timed out" in msg
+    assert "sess-partial-7" in msg, (
+        "Timeout error must surface the partial session_id so --resume "
+        f"is actionable. Got: {msg!r}"
+    )
+    assert "--resume sess-partial-7" in msg
+
+
+def test_codex_timeout_without_partial_session_id_still_raises_clean(mocker):
+    """If codex died before emitting session.created, the timeout error
+    should still raise cleanly without crashing on the missing ID."""
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    mocker.patch(
+        "conductor.providers.codex.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(
+            cmd="codex", timeout=5, output="", stderr=""
+        ),
+    )
+    with pytest.raises(ProviderError) as exc:
+        CodexProvider().exec("hi", timeout_sec=5)
+    msg = str(exc.value)
+    assert "timed out" in msg
+    assert "session_id" not in msg  # Nothing to surface
+
+
+def test_codex_timeout_handles_bytes_stdout_from_subprocess(mocker):
+    """subprocess.TimeoutExpired.output can be bytes when text=False is used
+    elsewhere in the call chain. Recovery must decode defensively."""
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    partial_bytes = (
+        b'{"type":"session.created","session_id":"sess-bytes-9"}\n'
+    )
+    mocker.patch(
+        "conductor.providers.codex.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(
+            cmd="codex", timeout=5, output=partial_bytes, stderr=b""
+        ),
+    )
+    with pytest.raises(ProviderError) as exc:
+        CodexProvider().exec("hi", timeout_sec=5)
+    assert "sess-bytes-9" in str(exc.value)
+
+
 # ---------------------------------------------------------------------------
 # Gemini
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -279,6 +279,46 @@ def test_exec_unknown_sandbox_errors_with_hint():
     assert "read-only" in result.output
 
 
+def test_exec_cli_default_passes_no_timeout_to_provider(mocker):
+    """`conductor exec --with codex --task ...` (no --timeout) must hand
+    the provider `timeout_sec=None` so subprocess.run runs unbounded.
+    Regression for the 22-minute lost-work bug where the CLI silently
+    capped exec at 300s and the partial session_id was never recoverable."""
+    _stub_all_configured(mocker, {"codex"})
+    exec_mock = mocker.patch.object(
+        CodexProvider, "exec", return_value=_fake_response("codex")
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["exec", "--with", "codex", "--task", "do the thing"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert exec_mock.called
+    assert exec_mock.call_args.kwargs["timeout_sec"] is None, (
+        "exec without --timeout must pass None (unbounded). "
+        f"Got timeout_sec={exec_mock.call_args.kwargs['timeout_sec']!r}"
+    )
+
+
+def test_exec_cli_explicit_timeout_passes_through(mocker):
+    """`--timeout 600` must be honored — the no-default change must not
+    block users who deliberately want to bound a CI run."""
+    _stub_all_configured(mocker, {"codex"})
+    exec_mock = mocker.patch.object(
+        CodexProvider, "exec", return_value=_fake_response("codex")
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["exec", "--with", "codex", "--timeout", "600", "--task", "do it"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert exec_mock.call_args.kwargs["timeout_sec"] == 600
+
+
 def test_exec_with_kimi_tools_raises_unsupported(mocker, monkeypatch):
     # Pin kimi to its pre-v0.3.0 capability set so --tools Edit is
     # guaranteed to land in the UnsupportedCapability branch. Post-v0.3.1


### PR DESCRIPTION
`conductor exec` defaulted to a 300s wall-clock timeout, which silently
killed long agent sessions and lost the partial work. The TimeoutExpired
path also discarded the captured stdout, so the user had no session_id
to --resume from after a timeout — 22 minutes of work, no recovery.

Two fixes, scoped to exec():
  - exec() now defaults to no timeout (subprocess.run runs unbounded).
    Pass --timeout N for CI/unattended runs that must bound runtime.
    Single-turn call() keeps its 180s constructor-default — that's a
    protective HTTP-style timeout for hung connections.
  - On codex TimeoutExpired, parse the partial NDJSON we captured before
    killing the child and surface any session_id in the error message
    so `conductor exec --with codex --resume <id> ...` is actionable.

Sentinel pattern (_USE_DEFAULT) in subprocess providers (codex, claude,
gemini, shell) distinguishes "caller didn't specify" (use constructor
default) from "caller explicitly passed None" (run unbounded). HTTP
providers (deepseek, kimi, ollama) get the matching exec() signature
change for uniformity; their tool-use loops keep using the constructor-
default httpx timeout per request, which is unchanged.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
