### PR TITLE
feat(exec): stall watchdog, liveness signal, verification reflex guidance

### DIFF
--- a/src/conductor/_agent_templates.py
+++ b/src/conductor/_agent_templates.py
@@ -168,6 +168,14 @@ Kimi is strongest for: summarization, broad-reading across many files,
 structural extraction from long transcripts, and cheap second-opinion
 reviews.
 
+Verification reflex: If you diagnose a conductor-config-level cause for an
+error (e.g. "the Kimi provider config at ~/.conductor/providers/kimi.toml
+is wrong"), verify the named paths and flags exist before acting on the
+diagnosis. Run `ls`, `grep`, `conductor doctor`, or read the source. A
+confidently-stated wrong cause leads downstream agents to act on a
+hallucinated premise. If you cannot verify, say "I see symptom X but
+cannot verify the cause" rather than naming a cause you haven't confirmed.
+
 If conductor errors:
 - `no provider...` → kimi isn't configured. Tell the user to run
   `conductor init`.
@@ -205,6 +213,14 @@ If the user's question doesn't actually need the web (it's a coding
 task, a reasoning task, a summary of material they already provided),
 tell the parent agent to handle it directly instead of calling you —
 you exist specifically for the web-search path.
+
+Verification reflex: If you diagnose a conductor-config-level cause for an
+error (e.g. "the Gemini provider config at ~/.conductor/providers/gemini.toml
+is wrong"), verify the named paths and flags exist before acting on the
+diagnosis. Run `ls`, `grep`, `conductor doctor`, or read the source. A
+confidently-stated wrong cause leads downstream agents to act on a
+hallucinated premise. If you cannot verify, say "I see symptom X but
+cannot verify the cause" rather than naming a cause you haven't confirmed.
 
 If conductor errors:
 - `no provider...` → gemini isn't configured. Tell the user to run
@@ -245,6 +261,14 @@ When invoked:
 If the task is a quick one-shot question (no file tools needed), route
 it to a single-turn provider instead — `exec` mode carries more setup
 cost than is warranted for single-turn prompts.
+
+Verification reflex: If you diagnose a conductor-config-level cause for an
+error (e.g. "the codex provider config at ~/.conductor/providers/codex.toml
+is wrong"), verify the named paths and flags exist before acting on the
+diagnosis. Run `ls`, `grep`, `conductor doctor`, or read the source. A
+confidently-stated wrong cause leads downstream agents to act on a
+hallucinated premise. If you cannot verify, say "I see symptom X but
+cannot verify the cause" rather than naming a cause you haven't confirmed.
 
 If conductor errors:
 - `no provider...` → codex CLI isn't installed or authed. Tell the user
@@ -288,6 +312,14 @@ When invoked:
 
 3. Parse the JSON, extract `text`, and return it prefixed with
    "From Ollama (local):".
+
+Verification reflex: If you diagnose a conductor-config-level cause for an
+error (e.g. "the Ollama provider config at ~/.conductor/providers/ollama.toml
+is wrong"), verify the named paths and flags exist before acting on the
+diagnosis. Run `ls`, `grep`, `conductor doctor`, or read the source. A
+confidently-stated wrong cause leads downstream agents to act on a
+hallucinated premise. If you cannot verify, say "I see symptom X but
+cannot verify the cause" rather than naming a cause you haven't confirmed.
 
 If conductor errors:
 - Connection refused / daemon not running → tell the user to

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -376,6 +376,7 @@ def _invoke_with_fallback(
     sandbox: str,
     cwd: str | None,
     timeout_sec: int | None,
+    max_stall_sec: int | None,
     silent: bool,
     resume_session_id: str | None = None,
 ) -> tuple[CallResponse, list[str]]:
@@ -436,6 +437,7 @@ def _invoke_with_fallback(
                     sandbox=sandbox,
                     cwd=cwd,
                     timeout_sec=timeout_sec,
+                    max_stall_sec=max_stall_sec,
                     resume_session_id=resume_session_id,
                 )
             else:
@@ -746,6 +748,7 @@ def call(
                 sandbox="none",
                 cwd=None,
                 timeout_sec=None,
+                max_stall_sec=None,
                 silent=silent_route or as_json,
             )
         except ProviderConfigError as e:
@@ -845,6 +848,17 @@ def call(
         "for CI or unattended runs that must bound runtime."
     ),
 )
+@click.option(
+    "--max-stall-seconds",
+    "max_stall_sec",
+    default=None,
+    type=int,
+    help=(
+        "Kill the underlying provider if it produces no output for this many "
+        "seconds. Default: off (let it run). Recommended for unattended runs: "
+        "--max-stall-seconds 600 (10 minutes of silence = stalled)."
+    ),
+)
 @click.option("--task", default=None, help="The task / prompt. Reads stdin if omitted.")
 @click.option("--model", default=None, help="Override the provider's default model.")
 @click.option(
@@ -880,6 +894,7 @@ def exec_cmd(
     exclude: str | None,
     cwd: str | None,
     timeout_sec: int | None,
+    max_stall_sec: int | None,
     task: str | None,
     model: str | None,
     as_json: bool,
@@ -934,6 +949,7 @@ def exec_cmd(
                 sandbox=sandbox_value,
                 cwd=cwd,
                 timeout_sec=timeout_sec,
+                max_stall_sec=max_stall_sec,
                 silent=silent_route or as_json,
             )
         except UnsupportedCapability as e:
@@ -960,6 +976,7 @@ def exec_cmd(
                 sandbox=sandbox_value,
                 cwd=cwd,
                 timeout_sec=timeout_sec,
+                max_stall_sec=max_stall_sec,
                 resume_session_id=resume_session_id,
             )
         except UnsupportedCapability as e:

--- a/src/conductor/providers/__init__.py
+++ b/src/conductor/providers/__init__.py
@@ -13,6 +13,7 @@ from conductor.providers.interface import (
     ProviderConfigError,
     ProviderError,
     ProviderHTTPError,
+    ProviderStalledError,
     UnsupportedCapability,
     resolve_effort_tokens,
 )
@@ -38,6 +39,7 @@ __all__ = [
     "ProviderConfigError",
     "ProviderError",
     "ProviderHTTPError",
+    "ProviderStalledError",
     "ShellProvider",
     "ShellProviderSpec",
     "UnsupportedCapability",

--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -183,8 +183,10 @@ class ClaudeProvider:
         sandbox: str = "none",
         cwd: str | None = None,
         timeout_sec: int | None = None,
+        max_stall_sec: int | None = None,
         resume_session_id: str | None = None,
     ) -> CallResponse:
+        # accepted for API parity; only codex implements stall-watchdog today
         # Claude's `--allowedTools` is fine-grained; passing an empty set
         # is effectively "no tools permitted" (single-turn).
         allowed = ",".join(sorted(tools)) if tools else None

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -15,8 +15,11 @@ autumn-garage `plans/sentinel-conductor-migration.md`, future).
 from __future__ import annotations
 
 import json
+import queue
 import shutil
 import subprocess
+import sys
+import threading
 import time
 
 from conductor.providers.interface import (
@@ -24,6 +27,7 @@ from conductor.providers.interface import (
     ProviderConfigError,
     ProviderError,
     ProviderHTTPError,
+    ProviderStalledError,
     resolve_effort_tokens,
 )
 
@@ -210,6 +214,8 @@ class CodexProvider:
         sandbox: str = "none",
         cwd: str | None = None,
         timeout_sec: int | None = None,
+        max_stall_sec: int | None = None,
+        liveness_interval_sec: float = 30.0,
         resume_session_id: str | None = None,
     ) -> CallResponse:
         codex_sandbox = {
@@ -224,6 +230,9 @@ class CodexProvider:
             sandbox=codex_sandbox,
             cwd=cwd,
             timeout_sec_override=timeout_sec,
+            max_stall_sec=max_stall_sec,
+            liveness_interval_sec=liveness_interval_sec,
+            stream=True,
             resume_session_id=resume_session_id,
         )
 
@@ -236,6 +245,9 @@ class CodexProvider:
         sandbox: str,
         cwd: str | None = None,
         timeout_sec_override: float | None | object = _USE_DEFAULT,
+        max_stall_sec: int | None = None,
+        liveness_interval_sec: float = 30.0,
+        stream: bool = False,
         resume_session_id: str | None = None,
     ) -> CallResponse:
         # Cheap PATH check on the hot path; auth state surfaces as a CLI
@@ -282,6 +294,19 @@ class CodexProvider:
         else:
             # `None` means "run unbounded" (subprocess.run accepts timeout=None).
             timeout = timeout_sec_override  # type: ignore[assignment]
+
+        if stream:
+            return self._run_streaming(
+                args,
+                model=model,
+                effort=effort,
+                thinking_budget=thinking_budget,
+                cwd=cwd,
+                timeout=timeout,
+                max_stall_sec=max_stall_sec,
+                liveness_interval_sec=liveness_interval_sec,
+            )
+
         start = time.monotonic()
         try:
             result = subprocess.run(
@@ -298,16 +323,13 @@ class CodexProvider:
             partial_stdout = e.stdout or ""
             if isinstance(partial_stdout, bytes):
                 partial_stdout = partial_stdout.decode("utf-8", errors="replace")
-            _, _, _, partial_session_id = self._parse_ndjson(partial_stdout)
             elapsed = time.monotonic() - start
-            msg = f"codex CLI timed out after {elapsed:.0f}s"
-            if partial_session_id:
-                msg += (
-                    f" (partial session_id={partial_session_id} — "
-                    f"resume with `conductor exec --with codex "
-                    f"--resume {partial_session_id} ...`)"
+            raise ProviderError(
+                self._message_with_partial_session_id(
+                    f"codex CLI timed out after {elapsed:.0f}s",
+                    partial_stdout,
                 )
-            raise ProviderError(msg) from e
+            ) from e
         duration_ms = int((time.monotonic() - start) * 1000)
 
         if result.returncode != 0:
@@ -338,4 +360,190 @@ class CodexProvider:
             },
             session_id=session_id,
             raw={"stdout": result.stdout},
+        )
+
+    def _run_streaming(
+        self,
+        args: list[str],
+        *,
+        model: str,
+        effort: str | int,
+        thinking_budget: int,
+        cwd: str | None,
+        timeout: float | None,
+        max_stall_sec: int | None,
+        liveness_interval_sec: float,
+    ) -> CallResponse:
+        start = time.monotonic()
+        process = subprocess.Popen(
+            args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=cwd,
+        )
+
+        stdout_q: queue.Queue[str | None] = queue.Queue()
+        stdout_parts: list[str] = []
+        stderr_parts: list[str] = []
+
+        def read_stdout() -> None:
+            assert process.stdout is not None
+            try:
+                while True:
+                    line = process.stdout.readline()
+                    if line == "":
+                        break
+                    stdout_q.put(line)
+            finally:
+                stdout_q.put(None)
+
+        def read_stderr() -> None:
+            assert process.stderr is not None
+            while True:
+                chunk = process.stderr.readline()
+                if chunk == "":
+                    break
+                stderr_parts.append(chunk)
+
+        stdout_thread = threading.Thread(target=read_stdout, daemon=True)
+        stderr_thread = threading.Thread(target=read_stderr, daemon=True)
+        stdout_thread.start()
+        stderr_thread.start()
+
+        stdout_done = False
+        last_output = start
+        last_liveness = start
+        while True:
+            now = time.monotonic()
+            if timeout is not None and now - start > timeout:
+                self._terminate_process(process)
+                self._join_reader_threads(stdout_thread, stderr_thread)
+                self._drain_stdout_queue(stdout_q, stdout_parts)
+                stdout = "".join(stdout_parts)
+                elapsed = time.monotonic() - start
+                raise ProviderError(
+                    self._message_with_partial_session_id(
+                        f"codex CLI timed out after {elapsed:.0f}s",
+                        stdout,
+                    )
+                )
+
+            if max_stall_sec is not None and now - last_output > max_stall_sec:
+                self._terminate_process(process)
+                self._join_reader_threads(stdout_thread, stderr_thread)
+                self._drain_stdout_queue(stdout_q, stdout_parts)
+                stdout = "".join(stdout_parts)
+                elapsed = time.monotonic() - last_output
+                raise ProviderStalledError(
+                    self._message_with_partial_session_id(
+                        f"codex CLI stalled after {elapsed:.0f}s with no output",
+                        stdout,
+                    )
+                )
+
+            if (
+                liveness_interval_sec > 0
+                and now - last_output >= liveness_interval_sec
+                and now - last_liveness >= liveness_interval_sec
+            ):
+                sys.stderr.write(
+                    f"[conductor] no output from codex for {now - last_output:.0f}s...\n"
+                )
+                sys.stderr.flush()
+                last_liveness = now
+
+            try:
+                item = stdout_q.get(timeout=0.05)
+            except queue.Empty:
+                if stdout_done and process.poll() is not None:
+                    break
+                continue
+
+            if item is None:
+                stdout_done = True
+                if process.poll() is not None:
+                    break
+                continue
+
+            stdout_parts.append(item)
+            last_output = time.monotonic()
+            last_liveness = last_output
+
+        returncode = process.wait()
+        self._join_reader_threads(stdout_thread, stderr_thread)
+        self._drain_stdout_queue(stdout_q, stdout_parts)
+        duration_ms = int((time.monotonic() - start) * 1000)
+        stdout = "".join(stdout_parts)
+        stderr = "".join(stderr_parts)
+
+        if returncode != 0:
+            raise ProviderHTTPError(
+                f"codex exited {returncode}: "
+                f"{(stderr or stdout).strip()[:500]}"
+            )
+
+        content, input_tokens, output_tokens, session_id = self._parse_ndjson(stdout)
+        if not content:
+            raise ProviderHTTPError(
+                f"codex NDJSON stream had no agent_message: {stdout[:500]!r}"
+            )
+        return CallResponse(
+            text=content,
+            provider=self.name,
+            model=model,
+            duration_ms=duration_ms,
+            usage={
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "cached_tokens": None,
+                "thinking_tokens": None,
+                "effort": effort if isinstance(effort, str) else None,
+                "thinking_budget": thinking_budget,
+            },
+            session_id=session_id,
+            raw={"stdout": stdout},
+        )
+
+    def _terminate_process(self, process: subprocess.Popen[str]) -> None:
+        if process.poll() is not None:
+            return
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+            return
+        except subprocess.TimeoutExpired:
+            if process.poll() is None:
+                process.kill()
+                process.wait()
+
+    def _join_reader_threads(
+        self,
+        stdout_thread: threading.Thread,
+        stderr_thread: threading.Thread,
+    ) -> None:
+        stdout_thread.join(timeout=1)
+        stderr_thread.join(timeout=1)
+
+    def _drain_stdout_queue(
+        self,
+        stdout_q: queue.Queue[str | None],
+        stdout_parts: list[str],
+    ) -> None:
+        while True:
+            try:
+                item = stdout_q.get_nowait()
+            except queue.Empty:
+                return
+            if item is not None:
+                stdout_parts.append(item)
+
+    def _message_with_partial_session_id(self, prefix: str, stdout: str) -> str:
+        _, _, _, partial_session_id = self._parse_ndjson(stdout)
+        if not partial_session_id:
+            return prefix
+        return (
+            f"{prefix} (partial session_id={partial_session_id} — "
+            f"resume with `conductor exec --with codex "
+            f"--resume {partial_session_id} ...`)"
         )

--- a/src/conductor/providers/deepseek.py
+++ b/src/conductor/providers/deepseek.py
@@ -212,8 +212,10 @@ class _DeepSeekBase:
         sandbox: str = "none",
         cwd: str | None = None,
         timeout_sec: int | None = None,
+        max_stall_sec: int | None = None,
         resume_session_id: str | None = None,
     ) -> CallResponse:
+        # accepted for API parity; only codex implements stall-watchdog today
         if resume_session_id:
             raise UnsupportedCapability(
                 f"{self.name} has no session model — each DeepSeek API call is "

--- a/src/conductor/providers/gemini.py
+++ b/src/conductor/providers/gemini.py
@@ -204,8 +204,10 @@ class GeminiProvider:
         sandbox: str = "none",
         cwd: str | None = None,
         timeout_sec: int | None = None,
+        max_stall_sec: int | None = None,
         resume_session_id: str | None = None,
     ) -> CallResponse:
+        # accepted for API parity; only codex implements stall-watchdog today
         # Gemini's --approval-mode: "plan" (read-only) vs "yolo" (all writes
         # auto-approved). No finer granularity; tools set is advisory.
         approval_mode = {

--- a/src/conductor/providers/interface.py
+++ b/src/conductor/providers/interface.py
@@ -71,6 +71,12 @@ class ProviderHTTPError(ProviderError):
     (non-2xx, malformed JSON, timeout)."""
 
 
+class ProviderStalledError(ProviderError):
+    """Raised when a provider produced no output for longer than the
+    configured max_stall_sec watchdog. Distinct from wall-clock timeout —
+    a stall means the subprocess is alive but not making progress."""
+
+
 class UnsupportedCapability(ProviderError):  # noqa: N818  — public API name; renaming to -Error breaks callers
     """Raised when a provider cannot satisfy the requested capability —
     e.g., tool-use requested but the provider only supports single-turn
@@ -163,11 +169,14 @@ class Provider(Protocol):
         sandbox: str = "none",
         cwd: str | None = None,
         timeout_sec: int = 300,
+        max_stall_sec: int | None = None,
         resume_session_id: str | None = None,
     ) -> CallResponse:
         """Multi-turn agent session with tool access.
 
         ``resume_session_id`` semantics match ``call()``.
+        ``max_stall_sec`` is an optional no-output watchdog; providers that
+        do not implement it accept and ignore the value for API parity.
 
         Raises UnsupportedCapability if the provider cannot drive the
         requested tools or sandbox, or cannot resume sessions when one

--- a/src/conductor/providers/kimi.py
+++ b/src/conductor/providers/kimi.py
@@ -268,8 +268,10 @@ class KimiProvider:
         sandbox: str = "none",
         cwd: str | None = None,
         timeout_sec: int | None = None,
+        max_stall_sec: int | None = None,
         resume_session_id: str | None = None,
     ) -> CallResponse:
+        # accepted for API parity; only codex implements stall-watchdog today
         if resume_session_id:
             raise UnsupportedCapability(
                 "kimi has no session model — each Cloudflare Workers AI call is "

--- a/src/conductor/providers/ollama.py
+++ b/src/conductor/providers/ollama.py
@@ -296,8 +296,10 @@ class OllamaProvider:
         sandbox: str = "none",
         cwd: str | None = None,
         timeout_sec: int | None = None,
+        max_stall_sec: int | None = None,
         resume_session_id: str | None = None,
     ) -> CallResponse:
+        # accepted for API parity; only codex implements stall-watchdog today
         if resume_session_id:
             raise UnsupportedCapability(
                 "ollama has no session model — each /api/chat call is stateless. "

--- a/src/conductor/providers/shell.py
+++ b/src/conductor/providers/shell.py
@@ -188,8 +188,10 @@ class ShellProvider:
         sandbox: str = "none",
         cwd: str | None = None,
         timeout_sec: int | None = None,
+        max_stall_sec: int | None = None,
         resume_session_id: str | None = None,
     ) -> CallResponse:
+        # accepted for API parity; only codex implements stall-watchdog today
         if tools:
             raise UnsupportedCapability(
                 f"custom provider `{self._spec.name}` (shell-command) does not support "

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import threading
 
 import pytest
 
@@ -20,6 +21,7 @@ from conductor.providers.interface import (
     ProviderConfigError,
     ProviderError,
     ProviderHTTPError,
+    ProviderStalledError,
 )
 
 
@@ -232,6 +234,98 @@ CODEX_NDJSON = (
 )
 
 
+class _FakeScheduledPipe:
+    def __init__(
+        self,
+        schedule: list[tuple[float, str]],
+        *,
+        hang_after_schedule: bool,
+        terminated: threading.Event,
+        on_eof,
+    ) -> None:
+        self._schedule = schedule
+        self._hang_after_schedule = hang_after_schedule
+        self._terminated = terminated
+        self._on_eof = on_eof
+        self._idx = 0
+
+    def readline(self) -> str:
+        if self._idx < len(self._schedule):
+            delay, line = self._schedule[self._idx]
+            self._idx += 1
+            if self._terminated.wait(delay):
+                return ""
+            return line
+        if self._hang_after_schedule:
+            self._terminated.wait()
+        if self._on_eof is not None:
+            self._on_eof()
+        return ""
+
+
+class _FakePopen:
+    def __init__(
+        self,
+        *,
+        stdout_schedule: list[tuple[float, str]],
+        stderr_schedule: list[tuple[float, str]] | None = None,
+        hang_after_stdout: bool = False,
+        returncode: int = 0,
+    ) -> None:
+        self.args = None
+        self.returncode = None
+        self.terminated = False
+        self.killed = False
+        self._configured_returncode = returncode
+        self._terminated_event = threading.Event()
+        self._finished_event = threading.Event()
+        self.stdout = _FakeScheduledPipe(
+            stdout_schedule,
+            hang_after_schedule=hang_after_stdout,
+            terminated=self._terminated_event,
+            on_eof=self._finish_success,
+        )
+        self.stderr = _FakeScheduledPipe(
+            stderr_schedule or [],
+            hang_after_schedule=False,
+            terminated=self._terminated_event,
+            on_eof=None,
+        )
+
+    def _finish_success(self) -> None:
+        if self.returncode is None:
+            self.returncode = self._configured_returncode
+            self._finished_event.set()
+
+    def poll(self):
+        return self.returncode
+
+    def wait(self, timeout=None):
+        if not self._finished_event.wait(timeout):
+            raise subprocess.TimeoutExpired(cmd=self.args or "codex", timeout=timeout)
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+        self.returncode = -15
+        self._terminated_event.set()
+        self._finished_event.set()
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+        self._terminated_event.set()
+        self._finished_event.set()
+
+
+def _patch_codex_popen(mocker, fake: _FakePopen):
+    def factory(args, **kwargs):
+        fake.args = args
+        return fake
+
+    return mocker.patch("conductor.providers.codex.subprocess.Popen", side_effect=factory)
+
+
 def test_codex_configured_when_cli_present_and_authed(mocker):
     mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
     mocker.patch(
@@ -361,30 +455,31 @@ def test_codex_call_raises_on_non_zero_exit(mocker):
 def test_codex_exec_default_timeout_is_unbounded(mocker):
     """Regression: `conductor exec --with codex` (no --timeout) used to default
     to 300s, which silently killed long agent sessions and lost the session_id.
-    The default is now no-timeout — subprocess.run must be invoked with
-    timeout=None when the caller does not specify."""
+    The default is now no-timeout; exec uses the streaming Popen path and
+    must complete without imposing a wall-clock cap when the caller omits it."""
     mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
-    captured = mocker.patch(
-        "conductor.providers.codex.subprocess.run",
-        return_value=_fake_completed(stdout=CODEX_NDJSON),
+    fake = _FakePopen(
+        stdout_schedule=[(0, line) for line in CODEX_NDJSON.splitlines(keepends=True)]
     )
+    captured = _patch_codex_popen(mocker, fake)
     CodexProvider().exec("hi")
-    assert captured.call_args.kwargs["timeout"] is None, (
-        "exec() with no explicit timeout must run unbounded. "
-        f"Got timeout={captured.call_args.kwargs['timeout']!r}"
-    )
+    assert captured.called
+    assert fake.terminated is False
 
 
 def test_codex_exec_explicit_timeout_is_honored(mocker):
     """Caller-supplied --timeout still works — sentinel pattern must not
     swallow an explicitly-passed integer."""
     mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
-    captured = mocker.patch(
-        "conductor.providers.codex.subprocess.run",
-        return_value=_fake_completed(stdout=CODEX_NDJSON),
+    fake = _FakePopen(
+        stdout_schedule=[(0, '{"type":"session.created","session_id":"sess-slow"}\n')],
+        hang_after_stdout=True,
     )
-    CodexProvider().exec("hi", timeout_sec=42)
-    assert captured.call_args.kwargs["timeout"] == 42
+    _patch_codex_popen(mocker, fake)
+    with pytest.raises(ProviderError) as exc:
+        CodexProvider().exec("hi", timeout_sec=0.05, max_stall_sec=None)
+    assert "timed out" in str(exc.value)
+    assert fake.terminated is True
 
 
 def test_codex_call_keeps_constructor_default_timeout(mocker):
@@ -411,14 +506,13 @@ def test_codex_timeout_recovers_session_id_from_partial_ndjson(mocker):
         '{"type":"session.created","session_id":"sess-partial-7"}\n'
         '{"type":"item.started","item":{"type":"agent_message"}}\n'
     )
-    mocker.patch(
-        "conductor.providers.codex.subprocess.run",
-        side_effect=subprocess.TimeoutExpired(
-            cmd="codex", timeout=5, output=partial, stderr=""
-        ),
+    fake = _FakePopen(
+        stdout_schedule=[(0, line) for line in partial.splitlines(keepends=True)],
+        hang_after_stdout=True,
     )
+    _patch_codex_popen(mocker, fake)
     with pytest.raises(ProviderError) as exc:
-        CodexProvider().exec("hi", timeout_sec=5)
+        CodexProvider().exec("hi", timeout_sec=0.05)
     msg = str(exc.value)
     assert "timed out" in msg
     assert "sess-partial-7" in msg, (
@@ -432,22 +526,18 @@ def test_codex_timeout_without_partial_session_id_still_raises_clean(mocker):
     """If codex died before emitting session.created, the timeout error
     should still raise cleanly without crashing on the missing ID."""
     mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
-    mocker.patch(
-        "conductor.providers.codex.subprocess.run",
-        side_effect=subprocess.TimeoutExpired(
-            cmd="codex", timeout=5, output="", stderr=""
-        ),
-    )
+    fake = _FakePopen(stdout_schedule=[], hang_after_stdout=True)
+    _patch_codex_popen(mocker, fake)
     with pytest.raises(ProviderError) as exc:
-        CodexProvider().exec("hi", timeout_sec=5)
+        CodexProvider().exec("hi", timeout_sec=0.05)
     msg = str(exc.value)
     assert "timed out" in msg
     assert "session_id" not in msg  # Nothing to surface
 
 
-def test_codex_timeout_handles_bytes_stdout_from_subprocess(mocker):
+def test_codex_call_timeout_handles_bytes_stdout_from_subprocess(mocker):
     """subprocess.TimeoutExpired.output can be bytes when text=False is used
-    elsewhere in the call chain. Recovery must decode defensively."""
+    elsewhere in the call path. Recovery must decode defensively."""
     mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
     partial_bytes = (
         b'{"type":"session.created","session_id":"sess-bytes-9"}\n'
@@ -459,8 +549,92 @@ def test_codex_timeout_handles_bytes_stdout_from_subprocess(mocker):
         ),
     )
     with pytest.raises(ProviderError) as exc:
-        CodexProvider().exec("hi", timeout_sec=5)
+        CodexProvider().call("hi")
     assert "sess-bytes-9" in str(exc.value)
+
+
+def test_codex_exec_stall_watchdog_kills_silent_provider(mocker):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    partial = '{"type":"session.created","session_id":"sess-stalled-1"}\n'
+    fake = _FakePopen(
+        stdout_schedule=[(0, partial)],
+        hang_after_stdout=True,
+    )
+    _patch_codex_popen(mocker, fake)
+
+    with pytest.raises(ProviderStalledError) as exc:
+        CodexProvider().exec("hi", max_stall_sec=0.05, liveness_interval_sec=0)
+
+    msg = str(exc.value)
+    assert "stalled" in msg
+    assert "sess-stalled-1" in msg
+    assert "--resume sess-stalled-1" in msg
+    assert fake.terminated is True
+
+
+def test_codex_exec_streams_output_resets_stall_clock(mocker):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    lines = [
+        '{"type":"session.created","session_id":"sess-streaming-1"}\n',
+        '{"type":"item.started","item":{"type":"agent_message"}}\n',
+        '{"type":"item.completed","item":{"type":"agent_message","text":"done"}}\n',
+        '{"type":"turn.completed","usage":{"input_tokens":5,"output_tokens":2}}\n',
+    ]
+    fake = _FakePopen(stdout_schedule=[(0.1, line) for line in lines])
+    _patch_codex_popen(mocker, fake)
+
+    response = CodexProvider().exec("hi", max_stall_sec=2, liveness_interval_sec=0)
+
+    assert response.text == "done"
+    assert response.session_id == "sess-streaming-1"
+    assert fake.terminated is False
+
+
+def test_codex_exec_no_stall_watchdog_by_default(mocker):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    partial = '{"type":"session.created","session_id":"sess-no-watchdog"}\n'
+    fake = _FakePopen(
+        stdout_schedule=[(0, partial)],
+        hang_after_stdout=True,
+    )
+    _patch_codex_popen(mocker, fake)
+
+    with pytest.raises(ProviderError) as exc:
+        CodexProvider().exec("hi", timeout_sec=0.05)
+
+    assert "timed out" in str(exc.value)
+    assert not isinstance(exc.value, ProviderStalledError)
+    assert fake.terminated is True
+
+
+def test_codex_exec_emits_liveness_signal_to_stderr(mocker, capsys):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    partial = '{"type":"session.created","session_id":"sess-liveness"}\n'
+    fake = _FakePopen(
+        stdout_schedule=[(0, partial)],
+        hang_after_stdout=True,
+    )
+    _patch_codex_popen(mocker, fake)
+
+    with pytest.raises(ProviderStalledError):
+        CodexProvider().exec("hi", max_stall_sec=0.25, liveness_interval_sec=0.1)
+
+    assert "[conductor] no output from codex for " in capsys.readouterr().err
+
+
+def test_codex_call_unaffected_by_streaming_changes(mocker):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    popen_mock = mocker.patch("conductor.providers.codex.subprocess.Popen")
+    run_mock = mocker.patch(
+        "conductor.providers.codex.subprocess.run",
+        return_value=_fake_completed(stdout=CODEX_NDJSON),
+    )
+
+    response = CodexProvider().call("hi")
+
+    assert response.text == "hello from codex"
+    assert run_mock.called
+    assert not popen_mock.called
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -319,6 +319,40 @@ def test_exec_cli_explicit_timeout_passes_through(mocker):
     assert exec_mock.call_args.kwargs["timeout_sec"] == 600
 
 
+def test_exec_cli_max_stall_seconds_flag_propagates(mocker):
+    _stub_all_configured(mocker, {"codex"})
+    exec_mock = mocker.patch.object(
+        CodexProvider, "exec", return_value=_fake_response("codex")
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec", "--with", "codex",
+            "--max-stall-seconds", "60",
+            "--task", "do it",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert exec_mock.call_args.kwargs["max_stall_sec"] == 60
+
+
+def test_exec_cli_no_max_stall_seconds_defaults_none(mocker):
+    _stub_all_configured(mocker, {"codex"})
+    exec_mock = mocker.patch.object(
+        CodexProvider, "exec", return_value=_fake_response("codex")
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["exec", "--with", "codex", "--task", "do it"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert exec_mock.call_args.kwargs["max_stall_sec"] is None
+
+
 def test_exec_with_kimi_tools_raises_unsupported(mocker, monkeypatch):
     # Pin kimi to its pre-v0.3.0 capability set so --tools Edit is
     # guaranteed to land in the UnsupportedCapability branch. Post-v0.3.1


### PR DESCRIPTION
Three coupled changes that surfaced from a real production hang where the
codex CLI sat at 0% CPU producing zero output for 98 minutes, and a wrapping
subagent then hallucinated a config-level cause ("--oss flag in
~/.conductor/providers/codex.toml") for paths and flags that don't exist.

1. Stall watchdog (--max-stall-seconds, opt-in, default off).
   Codex exec() now uses Popen with a streaming reader thread instead of
   subprocess.run. The main loop tracks time-since-last-byte; if it exceeds
   --max-stall-seconds, we SIGTERM the child (SIGKILL after 5s grace) and
   raise the new ProviderStalledError. The wall-clock --timeout from PR #35
   remains independent: a long run with steady output finishes; a hung run
   with no output dies fast. Partial-NDJSON session_id recovery from PR #35
   plugs into both kill paths via a shared _message_with_partial_session_id
   helper.

2. Liveness signal (default on, configurable). When Popen has produced no
   output for liveness_interval_sec (default 30s), conductor writes a single
   line to stderr: `[conductor] no output from codex for Xs...`. This lets
   wrapping agents and operators distinguish "slow but working" from "dead"
   without staring at a stuck terminal. Goes to sys.stderr directly so it
   surfaces even when conductor is invoked outside a click context.

3. Verification reflex in delegation subagent templates. The four subagent
   templates (kimi, gemini, codex, ollama) now include a "Verification reflex"
   paragraph instructing delegation agents to verify named paths/flags exist
   before acting on a conductor-config-level diagnosis. Hallucinated causes
   propagate downstream; the reflex is `ls`/`grep`/`conductor doctor` before
   recommending action. Existing wired projects pick this up on their next
   `conductor init` run.

Other providers (claude, gemini, deepseek, kimi, ollama, shell) accept
max_stall_sec in their exec() signature for API parity but no-op it — only
codex implements the streaming pipeline today. Documented inline.

call() is unchanged — it stays on subprocess.run with its protective 180s
constructor-default timeout. The streaming complexity is only on the exec
path where multi-minute agent sessions are the norm.

7 new tests: stall kills silent provider with structured error + partial
session_id; streaming output resets the stall clock; no watchdog by default;
liveness signal emits at the configured cadence; call() is unaffected by
the streaming changes; --max-stall-seconds CLI flag propagates; CLI default
is None.

520 tests passing (was 513). Lint clean.

Implementation delegated via `conductor exec --with codex`; reviewed and
verified by hand before commit.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
