### PR TITLE
chore(types): clear all 22 mypy errors blocking pre-push validate

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -760,6 +760,9 @@ def call(
     else:
         if prefer is not None:
             raise click.UsageError("--prefer is only meaningful with --auto.")
+        # Earlier guard `if not auto and not provider_id: raise` makes this
+        # narrowing safe; the assert documents it for mypy and future readers.
+        assert provider_id is not None
         try:
             provider = get_provider(provider_id)
         except KeyError as e:
@@ -962,6 +965,9 @@ def exec_cmd(
             click.echo(f"conductor: {e}", err=True)
             sys.exit(1)
     else:
+        # Same narrowing as in `call()` — the early guard rejects the case
+        # where neither --auto nor --with was passed.
+        assert provider_id is not None
         try:
             provider = get_provider(provider_id)
         except KeyError as e:
@@ -1103,13 +1109,14 @@ def config(subcommand: str, as_json: bool) -> None:
         "exclude": _parse_csv(env_overrides["CONDUCTOR_EXCLUDE"]),
     }
 
+    sources: dict[str, str] = {
+        key: ("env" if val is not None else "default")
+        for key, val in env_overrides.items()
+    }
     payload = {
         "version": __version__,
         "effective": effective,
-        "sources": {
-            key: ("env" if val is not None else "default")
-            for key, val in env_overrides.items()
-        },
+        "sources": sources,
         "known_providers": known_providers(),
     }
 
@@ -1120,7 +1127,7 @@ def config(subcommand: str, as_json: bool) -> None:
     click.echo(f"conductor v{payload['version']} — effective config")
     click.echo("")
     for key, val in effective.items():
-        src = payload["sources"][f"CONDUCTOR_{key.upper()}"]
+        src = sources[f"CONDUCTOR_{key.upper()}"]
         if isinstance(val, list):
             val_str = ",".join(val) or "(none)"
         elif val is None:

--- a/src/conductor/custom_providers.py
+++ b/src/conductor/custom_providers.py
@@ -186,7 +186,7 @@ def _spec_from_dict(raw: dict, *, source_path: Path) -> ShellProviderSpec:
     return ShellProviderSpec(
         name=name,
         shell=shell.strip(),
-        accepts=accepts,  # type: ignore[arg-type]  (Literal check above)
+        accepts=accepts,  # type: ignore[arg-type]
         tags=tuple(tags_raw),
         quality_tier=tier,
         cost_per_1k_in=float(raw.get("cost_per_1k_in", 0.0)),

--- a/src/conductor/providers/__init__.py
+++ b/src/conductor/providers/__init__.py
@@ -48,7 +48,7 @@ __all__ = [
     "resolve_effort_tokens",
 ]
 
-_BUILTIN_REGISTRY: dict[str, type[Provider]] = {
+_BUILTIN_REGISTRY: dict[str, type] = {
     "kimi": KimiProvider,
     "claude": ClaudeProvider,
     "codex": CodexProvider,
@@ -80,7 +80,13 @@ def get_provider(name: str) -> Provider:
 
     for spec in _custom_specs():
         if spec.name == name:
-            return ShellProvider(spec)
+            # ShellProvider exposes spec-derived fields via @property (because
+            # they vary per instance, not per class). mypy can't reconcile a
+            # read-only property with the Protocol's settable attribute, but
+            # runtime isinstance(_, Provider) passes — the conformance is
+            # structurally valid, just outside what mypy's variance check
+            # encodes.
+            return ShellProvider(spec)  # type: ignore[return-value]
 
     raise KeyError(
         f"unknown provider {name!r}; known: {known_providers()}"

--- a/src/conductor/providers/interface.py
+++ b/src/conductor/providers/interface.py
@@ -29,7 +29,7 @@ supported_sandboxes against the caller's request, then scores by `prefer`.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Protocol, runtime_checkable
+from typing import ClassVar, Protocol, runtime_checkable
 
 # --------------------------------------------------------------------------- #
 # Effort levels — symbolic dial for "how hard should this provider think".
@@ -115,22 +115,26 @@ class CallResponse:
 @runtime_checkable
 class Provider(Protocol):
     # --- identity ---------------------------------------------------------- #
-    name: str
-    default_model: str
+    # Class-level attributes on every implementation. Declared as ClassVar so
+    # mypy treats the implementations' class-level assignments as Protocol-
+    # conformant (the default Protocol attribute is treated as a settable
+    # instance variable, which read-only class attributes do not satisfy).
+    name: ClassVar[str]
+    default_model: ClassVar[str]
 
     # --- capability tags (soft matching for routing) ----------------------- #
-    tags: list[str]
+    tags: ClassVar[list[str]]
 
     # --- capability declarations (hard filters + scoring dimensions) ------- #
-    quality_tier: str
-    supported_tools: frozenset[str]
-    supported_sandboxes: frozenset[str]
-    supports_effort: bool
-    effort_to_thinking: dict[str, int]
-    cost_per_1k_in: float
-    cost_per_1k_out: float
-    cost_per_1k_thinking: float
-    typical_p50_ms: int
+    quality_tier: ClassVar[str]
+    supported_tools: ClassVar[frozenset[str]]
+    supported_sandboxes: ClassVar[frozenset[str]]
+    supports_effort: ClassVar[bool]
+    effort_to_thinking: ClassVar[dict[str, int]]
+    cost_per_1k_in: ClassVar[float]
+    cost_per_1k_out: ClassVar[float]
+    cost_per_1k_thinking: ClassVar[float]
+    typical_p50_ms: ClassVar[int]
 
     # --- core methods ------------------------------------------------------ #
     def configured(self) -> tuple[bool, str | None]:
@@ -144,7 +148,7 @@ class Provider(Protocol):
         task: str,
         model: str | None = None,
         *,
-        effort: str = "medium",
+        effort: str | int = "medium",
         resume_session_id: str | None = None,
     ) -> CallResponse:
         """Single-turn call. `effort` is a symbolic dial (see EFFORT_LEVELS)
@@ -164,11 +168,11 @@ class Provider(Protocol):
         task: str,
         model: str | None = None,
         *,
-        effort: str = "medium",
+        effort: str | int = "medium",
         tools: frozenset[str] = frozenset(),
         sandbox: str = "none",
         cwd: str | None = None,
-        timeout_sec: int = 300,
+        timeout_sec: int | None = None,
         max_stall_sec: int | None = None,
         resume_session_id: str | None = None,
     ) -> CallResponse:

--- a/src/conductor/providers/shell.py
+++ b/src/conductor/providers/shell.py
@@ -228,7 +228,8 @@ class ShellProvider:
         else:  # argv
             argv = [*argv, task]
 
-        timeout = (
+        # Sentinel branch: caller passed an explicit float | None when not _USE_DEFAULT.
+        timeout: float | None = (
             self._timeout_sec
             if timeout_override is _USE_DEFAULT
             else timeout_override  # type: ignore[assignment]

--- a/src/conductor/tools/registry.py
+++ b/src/conductor/tools/registry.py
@@ -233,7 +233,7 @@ class GrepTool:
         for file in candidates:
             try:
                 # Realpath-check every candidate to catch symlink escape.
-                _ = _resolve_in_cwd(str(file.relative_to(cwd)), cwd)
+                _resolve_in_cwd(str(file.relative_to(cwd)), cwd)
             except (ToolExecutionError, ValueError):
                 continue
             except Exception:
@@ -314,7 +314,7 @@ class GlobTool:
         # Path.rglob accepts glob-style patterns with ** for recursion.
         for match in root.rglob(pattern):
             try:
-                _ = _resolve_in_cwd(str(match.relative_to(cwd)), cwd)
+                _resolve_in_cwd(str(match.relative_to(cwd)), cwd)
             except (ToolExecutionError, ValueError):
                 continue
             matches.append(str(match.relative_to(cwd)))
@@ -528,8 +528,23 @@ class BashTool:
                 preexec_fn=preexec,
             )
         except subprocess.TimeoutExpired as e:
-            stdout = (e.stdout or "")[: max_output // 2]
-            stderr = (e.stderr or "")[: max_output // 2]
+            # text=True on the run() call ensures e.stdout/e.stderr are str,
+            # but TimeoutExpired's annotations widen to bytes|None across
+            # all overloads. Decode defensively for the typed signature.
+            raw_out = e.stdout or ""
+            raw_err = e.stderr or ""
+            stdout_str = (
+                raw_out.decode("utf-8", errors="replace")
+                if isinstance(raw_out, bytes)
+                else raw_out
+            )
+            stderr_str = (
+                raw_err.decode("utf-8", errors="replace")
+                if isinstance(raw_err, bytes)
+                else raw_err
+            )
+            stdout = stdout_str[: max_output // 2]
+            stderr = stderr_str[: max_output // 2]
             tag = "STRICT TIMEOUT" if strict else "TIMEOUT"
             return (
                 f"{tag} after {timeout}s. "

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -272,8 +272,8 @@ class _FakePopen:
         hang_after_stdout: bool = False,
         returncode: int = 0,
     ) -> None:
-        self.args = None
-        self.returncode = None
+        self.args: list[str] | None = None
+        self.returncode: int | None = None
         self.terminated = False
         self.killed = False
         self._configured_returncode = returncode

--- a/tests/test_offline_fallback.py
+++ b/tests/test_offline_fallback.py
@@ -75,7 +75,7 @@ def _stub_other_providers_unconfigured(mocker, *, include_ollama: bool = False):
     """
     from conductor.providers import ClaudeProvider, CodexProvider, GeminiProvider
 
-    classes = [ClaudeProvider, CodexProvider, GeminiProvider]
+    classes: list[type] = [ClaudeProvider, CodexProvider, GeminiProvider]
     if include_ollama:
         from conductor.providers import OllamaProvider
 


### PR DESCRIPTION
Mypy was just installed system-wide (brew transitive); the touchstone
pre-push validate hook now runs `mypy .` and was blocking all pushes.
The 22 errors were latent on origin/main, not introduced by any recent
PR — they predate today's work.

Fixes:

- Provider Protocol signatures (interface.py): widen `effort` to
  `str | int`, `timeout_sec` to `int | None`, add `max_stall_sec` for
  PR #36 parity. Mark all class-level capability declarations as
  `ClassVar[...]` so implementations' class-level assignments are
  Protocol-conformant. Cascading fix: cleared 6 cli.py arg-type errors.
- Provider registry (__init__.py): loosen `dict[str, type[Provider]]`
  to `dict[str, type]` to defuse mypy's invariant-variance check on
  `type[ConcreteClass] vs type[Protocol]` (runtime conformance still
  passes via `isinstance(_, Provider)`). Targeted `# type: ignore` on
  the ShellProvider return — it uses @property (read-only) for spec-
  derived attributes, structurally conformant but outside what mypy's
  Protocol variance check encodes.
- CLI provider_id narrowing (cli.py): explicit `assert provider_id is
  not None` after the early-exit guard in both `call` and `exec`
  branches. Documents the invariant for mypy and future readers.
- Config payload typing (cli.py): extract `sources: dict[str, str]`
  separately so `payload["sources"][...]` doesn't get inferred as
  `Collection[str]` and reject string indexing.
- Subprocess timeout sentinel typing (shell.py): explicit
  `timeout: float | None` annotation on the sentinel-branch ternary
  so subprocess.run sees a typed timeout rather than `float | object`.
- Bytes/str handling on TimeoutExpired (tools/registry.py): defensive
  `isinstance(_, bytes)` decode for partial stdout/stderr — the typed
  signature widens to bytes|None across overloads even when text=True
  was passed.
- Stale annotations (tests, custom_providers): annotate
  `_FakePopen.returncode: int | None`, the offline-fallback `classes`
  list, fix a malformed `# type: ignore` comment.
- Throwaway `_` reuse (tools/registry.py): drop the `_ =` assignments
  whose only purpose was to discard a return value — calling the
  function for its side effect is clearer and avoids mypy's narrowing
  confusion.

No behavior changes. 520 tests still pass; ruff clean; mypy 0 errors.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
