### PR TITLE
feat(codex): early session_id stderr signal + forensic NDJSON log on failure

### DIFF
--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -15,13 +15,16 @@ autumn-garage `plans/sentinel-conductor-migration.md`, future).
 from __future__ import annotations
 
 import json
+import os
 import queue
 import shutil
 import subprocess
 import sys
 import threading
 import time
+from pathlib import Path  # noqa: TC003 — runtime import so tests can patch Path.write_text
 
+from conductor.offline_mode import _cache_dir
 from conductor.providers.interface import (
     CallResponse,
     ProviderConfigError,
@@ -414,6 +417,7 @@ class CodexProvider:
         stdout_done = False
         last_output = start
         last_liveness = start
+        session_id_emitted = False
         while True:
             now = time.monotonic()
             if timeout is not None and now - start > timeout:
@@ -469,6 +473,13 @@ class CodexProvider:
             stdout_parts.append(item)
             last_output = time.monotonic()
             last_liveness = last_output
+
+            if not session_id_emitted:
+                sid = self._extract_session_id_fast(item)
+                if sid is not None:
+                    sys.stderr.write(f"[conductor] codex session_id={sid}\n")
+                    sys.stderr.flush()
+                    session_id_emitted = True
 
         returncode = process.wait()
         self._join_reader_threads(stdout_thread, stderr_thread)
@@ -540,10 +551,57 @@ class CodexProvider:
 
     def _message_with_partial_session_id(self, prefix: str, stdout: str) -> str:
         _, _, _, partial_session_id = self._parse_ndjson(stdout)
-        if not partial_session_id:
-            return prefix
-        return (
-            f"{prefix} (partial session_id={partial_session_id} — "
-            f"resume with `conductor exec --with codex "
-            f"--resume {partial_session_id} ...`)"
-        )
+        log_path = self._save_forensic_log(stdout)
+        parts = [prefix]
+        if partial_session_id:
+            parts.append(
+                f" (partial session_id={partial_session_id} — "
+                f"resume with `conductor exec --with codex "
+                f"--resume {partial_session_id} ...`"
+            )
+            if log_path is not None:
+                parts.append(f"; raw NDJSON saved to {log_path})")
+            else:
+                parts.append(")")
+        elif log_path is not None:
+            parts.append(f" (raw NDJSON saved to {log_path})")
+        return "".join(parts)
+
+    def _save_forensic_log(self, stdout: str) -> Path | None:
+        """Persist captured NDJSON to the cache dir on failure.
+
+        Returns the path on success, or None if there was nothing to save
+        or the write failed. A failure here MUST NOT propagate — the call
+        is already failing for a different reason; losing the forensic
+        log is acceptable, but masking the original error with a disk
+        error is not.
+        """
+        if not stdout.strip():
+            return None
+        try:
+            cache_dir = _cache_dir()
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            ts = int(time.time())
+            path = cache_dir / f"codex-{os.getpid()}-{ts}.ndjson"
+            path.write_text(stdout, encoding="utf-8")
+            return path
+        except OSError:
+            return None
+
+    @staticmethod
+    def _extract_session_id_fast(line: str) -> str | None:
+        """Cheap substring filter + JSON parse for the session.created event.
+
+        Called on every line in the streaming read loop, so the substring
+        check matters: full json.loads on every NDJSON event would parse
+        events we never care about (item.started, turn.completed, etc.).
+        """
+        if "session.created" not in line:
+            return None
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            return None
+        if event.get("type") != "session.created":
+            return None
+        return event.get("session_id") or event.get("id")

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -637,6 +637,147 @@ def test_codex_call_unaffected_by_streaming_changes(mocker):
     assert not popen_mock.called
 
 
+def test_codex_exec_emits_session_id_to_stderr_when_received(mocker, capsys):
+    """Once codex emits the `session.created` NDJSON event, conductor must
+    surface the session_id on stderr immediately so a wrapping agent can
+    correlate logs and (if needed) `--resume` mid-flight. Without this the
+    session_id only became visible at completion or on error."""
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    lines = [
+        '{"type":"session.created","session_id":"sess-early-1"}\n',
+        '{"type":"item.completed","item":{"type":"agent_message","text":"ok"}}\n',
+        '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}\n',
+    ]
+    fake = _FakePopen(stdout_schedule=[(0, line) for line in lines])
+    _patch_codex_popen(mocker, fake)
+
+    CodexProvider().exec("hi", liveness_interval_sec=0)
+
+    captured = capsys.readouterr()
+    assert "[conductor] codex session_id=sess-early-1" in captured.err, (
+        f"Expected session_id stderr line. Got: {captured.err!r}"
+    )
+
+
+def test_codex_exec_emits_session_id_only_once(mocker, capsys):
+    """If codex emits multiple session.created events (shouldn't happen,
+    but the parser must tolerate it), conductor surfaces the first one
+    and stays quiet on duplicates — operator stderr stays clean."""
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    lines = [
+        '{"type":"session.created","session_id":"sess-first"}\n',
+        '{"type":"session.created","session_id":"sess-second"}\n',
+        '{"type":"item.completed","item":{"type":"agent_message","text":"ok"}}\n',
+        '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}\n',
+    ]
+    fake = _FakePopen(stdout_schedule=[(0, line) for line in lines])
+    _patch_codex_popen(mocker, fake)
+
+    CodexProvider().exec("hi", liveness_interval_sec=0)
+
+    err = capsys.readouterr().err
+    assert err.count("[conductor] codex session_id=") == 1
+    assert "sess-first" in err
+    assert "sess-second" not in err
+
+
+def test_codex_exec_writes_forensic_log_on_stall(mocker, tmp_path, monkeypatch):
+    """When the stall watchdog fires with partial NDJSON in the buffer,
+    conductor saves the raw NDJSON to the cache dir and includes the path
+    in the error message. This is the forensic trail for hangs that
+    happen without a recoverable session_id (or in addition to one)."""
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    partial = '{"type":"session.created","session_id":"sess-forensic-1"}\n'
+    fake = _FakePopen(
+        stdout_schedule=[(0, partial)],
+        hang_after_stdout=True,
+    )
+    _patch_codex_popen(mocker, fake)
+
+    with pytest.raises(ProviderStalledError) as exc:
+        CodexProvider().exec("hi", max_stall_sec=0.05, liveness_interval_sec=0)
+
+    msg = str(exc.value)
+    assert "raw NDJSON saved to" in msg
+    log_dir = tmp_path / "conductor"
+    log_files = list(log_dir.glob("codex-*.ndjson"))
+    assert len(log_files) == 1, f"expected one log file, got {log_files}"
+    assert log_files[0].read_text() == partial
+    assert str(log_files[0]) in msg
+
+
+def test_codex_exec_writes_forensic_log_on_streaming_timeout(mocker, tmp_path, monkeypatch):
+    """Same forensic-log behavior on the wall-clock timeout path."""
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    partial = (
+        '{"type":"session.created","session_id":"sess-forensic-2"}\n'
+        '{"type":"item.started","item":{"type":"agent_message"}}\n'
+    )
+    fake = _FakePopen(
+        stdout_schedule=[(0, line) for line in partial.splitlines(keepends=True)],
+        hang_after_stdout=True,
+    )
+    _patch_codex_popen(mocker, fake)
+
+    with pytest.raises(ProviderError) as exc:
+        CodexProvider().exec("hi", timeout_sec=0.1, liveness_interval_sec=0)
+
+    msg = str(exc.value)
+    assert "raw NDJSON saved to" in msg
+    log_files = list((tmp_path / "conductor").glob("codex-*.ndjson"))
+    assert len(log_files) == 1
+    assert log_files[0].read_text() == partial
+
+
+def test_codex_exec_no_forensic_log_when_no_partial_output(mocker, tmp_path, monkeypatch):
+    """If the stall fires before any output arrived, there's nothing to
+    save — don't litter the cache dir with empty files, and don't mention
+    a path that doesn't exist in the error message."""
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    fake = _FakePopen(stdout_schedule=[], hang_after_stdout=True)
+    _patch_codex_popen(mocker, fake)
+
+    with pytest.raises(ProviderStalledError) as exc:
+        CodexProvider().exec("hi", max_stall_sec=0.05, liveness_interval_sec=0)
+
+    msg = str(exc.value)
+    assert "raw NDJSON saved to" not in msg
+    log_dir = tmp_path / "conductor"
+    if log_dir.exists():
+        assert list(log_dir.glob("codex-*.ndjson")) == []
+
+
+def test_codex_exec_forensic_log_disk_failure_does_not_mask_real_error(
+    mocker, tmp_path, monkeypatch
+):
+    """If the cache write itself fails (read-only fs, ENOSPC, etc.), the
+    original ProviderStalledError must still propagate cleanly — losing
+    the forensic log is acceptable, masking the original error is not."""
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    partial = '{"type":"session.created","session_id":"sess-disk-fail"}\n'
+    fake = _FakePopen(stdout_schedule=[(0, partial)], hang_after_stdout=True)
+    _patch_codex_popen(mocker, fake)
+
+    # Force write_text to raise — simulates a read-only fs / quota failure.
+    mocker.patch(
+        "conductor.providers.codex.Path.write_text",
+        side_effect=OSError("disk full"),
+    )
+
+    with pytest.raises(ProviderStalledError) as exc:
+        CodexProvider().exec("hi", max_stall_sec=0.05, liveness_interval_sec=0)
+    msg = str(exc.value)
+    # Original error info still present:
+    assert "stalled" in msg
+    assert "sess-disk-fail" in msg
+    # No fabricated log path mentioned:
+    assert "raw NDJSON saved to" not in msg
+
+
 # ---------------------------------------------------------------------------
 # Gemini
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two observability fixes for the silent-hang scenario from yesterday's
production trace, surfaced in agent feedback:

1. Stream session_id to stderr the moment it arrives.
   The codex CLI emits a `session.created` NDJSON event near the start of
   every session. Conductor previously only surfaced the session_id in the
   final response (or in stall/timeout error messages). For long-running
   exec sessions, a wrapping agent had no way to correlate stderr with
   codex's own logs, or to capture a session_id for `--resume` until codex
   finished — which defeats the point when codex is wedged. We now write
   `[conductor] codex session_id=<id>` to stderr as soon as we read the
   session.created line. Cheap substring filter + json.loads avoids
   parsing every NDJSON event in the read loop.

2. Save raw NDJSON to the cache dir on failure.
   When the stall watchdog or wall-clock timeout fires, conductor now
   persists the captured partial NDJSON to
   `$XDG_CACHE_HOME/conductor/codex-<pid>-<ts>.ndjson` and includes the
   path in the error message. The session_id recovery from PR #35 only
   helps if codex emitted session.created before wedging; the forensic
   log helps regardless. Disk failures during the save (read-only fs,
   ENOSPC) are swallowed silently — losing the forensic log is acceptable;
   masking the original ProviderStalledError with a disk error is not.

The non-streaming `_run` path used by `call()` picks up the forensic-log
behavior automatically because both error paths route through the same
`_message_with_partial_session_id` helper.

6 new tests: session_id emission happy-path, deduplication on duplicate
session.created events, forensic log on stall, forensic log on streaming
timeout, no log when buffer is empty, disk-failure does not mask the
real error.

526 tests passing (was 520). Lint clean.

Triaged from agent feedback: this addresses items #2 and #6 from the
list. Item #1 (stream `--json` output) was substantially addressed in
v0.5.0; item #3 (hard-fail on zero-output) is what `--max-stall-seconds`
already does; item #4 (590s timeout ceiling) is hallucinated — no such
ceiling exists; item #5 (`conductor doctor` API health probe) is a
separate code path and deferred to its own PR.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
