### PR TITLE
feat(codex): forensic envelope on watchdog kill + subagent template watchdog defaults

### DIFF
--- a/src/conductor/_agent_templates.py
+++ b/src/conductor/_agent_templates.py
@@ -249,14 +249,26 @@ When invoked:
 
 1. Describe the task precisely — Codex will run its own loop and you
    are giving it the initial prompt, not mid-conversation context.
-2. Run:
+2. Run (always include the watchdog flags for unattended runs):
 
        conductor exec --with codex --tools Read,Grep,Glob,Edit,Write,Bash \\
-           --sandbox workspace-write --task "<prompt>" --json
+           --sandbox workspace-write \\
+           --max-stall-seconds 600 --timeout 1800 \\
+           --task "<prompt>" --json
+
+   `--max-stall-seconds 600` kills the run if codex produces no output
+   for 10 minutes (the documented silent-hang failure mode — see
+   conductor's .cortex/journal/2026-04-26-codex-exec-wedge-trace.md).
+   `--timeout 1800` is a 30-minute wall-clock cap. Both can be tuned
+   per task: a larger refactor can take longer, a one-line fix should
+   not. Without these flags the run can hang indefinitely.
 
 3. Parse the JSON, extract `text`, and return it verbatim prefixed with
    "From Codex:". Note `session_id` in the JSON if present — callers can
-   resume by passing it back as `--resume`.
+   resume by passing it back as `--resume`. If the run was killed by
+   the watchdog, conductor's stderr message will name a forensic
+   envelope path (under `~/.cache/conductor/codex-*.json`) — surface
+   that path to the parent agent so the failure can be triaged.
 
 If the task is a quick one-shot question (no file tools needed), route
 it to a single-turn provider instead — `exec` mode carries more setup

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -24,6 +24,7 @@ import threading
 import time
 from pathlib import Path  # noqa: TC003 — runtime import so tests can patch Path.write_text
 
+from conductor import __version__ as _conductor_version
 from conductor.offline_mode import _cache_dir
 from conductor.providers.interface import (
     CallResponse,
@@ -326,11 +327,19 @@ class CodexProvider:
             partial_stdout = e.stdout or ""
             if isinstance(partial_stdout, bytes):
                 partial_stdout = partial_stdout.decode("utf-8", errors="replace")
+            partial_stderr = e.stderr or ""
+            if isinstance(partial_stderr, bytes):
+                partial_stderr = partial_stderr.decode("utf-8", errors="replace")
             elapsed = time.monotonic() - start
             raise ProviderError(
-                self._message_with_partial_session_id(
+                self._failure_message(
                     f"codex CLI timed out after {elapsed:.0f}s",
-                    partial_stdout,
+                    kind="timeout",
+                    elapsed_sec=elapsed,
+                    command=args,
+                    cwd=cwd,
+                    captured_stdout=partial_stdout,
+                    captured_stderr=partial_stderr,
                 )
             ) from e
         duration_ms = int((time.monotonic() - start) * 1000)
@@ -425,11 +434,17 @@ class CodexProvider:
                 self._join_reader_threads(stdout_thread, stderr_thread)
                 self._drain_stdout_queue(stdout_q, stdout_parts)
                 stdout = "".join(stdout_parts)
+                stderr = "".join(stderr_parts)
                 elapsed = time.monotonic() - start
                 raise ProviderError(
-                    self._message_with_partial_session_id(
+                    self._failure_message(
                         f"codex CLI timed out after {elapsed:.0f}s",
-                        stdout,
+                        kind="timeout",
+                        elapsed_sec=elapsed,
+                        command=args,
+                        cwd=cwd,
+                        captured_stdout=stdout,
+                        captured_stderr=stderr,
                     )
                 )
 
@@ -438,11 +453,17 @@ class CodexProvider:
                 self._join_reader_threads(stdout_thread, stderr_thread)
                 self._drain_stdout_queue(stdout_q, stdout_parts)
                 stdout = "".join(stdout_parts)
+                stderr = "".join(stderr_parts)
                 elapsed = time.monotonic() - last_output
                 raise ProviderStalledError(
-                    self._message_with_partial_session_id(
+                    self._failure_message(
                         f"codex CLI stalled after {elapsed:.0f}s with no output",
-                        stdout,
+                        kind="stall",
+                        elapsed_sec=elapsed,
+                        command=args,
+                        cwd=cwd,
+                        captured_stdout=stdout,
+                        captured_stderr=stderr,
                     )
                 )
 
@@ -549,9 +570,36 @@ class CodexProvider:
             if item is not None:
                 stdout_parts.append(item)
 
-    def _message_with_partial_session_id(self, prefix: str, stdout: str) -> str:
-        _, _, _, partial_session_id = self._parse_ndjson(stdout)
-        log_path = self._save_forensic_log(stdout)
+    def _failure_message(
+        self,
+        prefix: str,
+        *,
+        kind: str,
+        elapsed_sec: float,
+        command: list[str],
+        cwd: str | None,
+        captured_stdout: str,
+        captured_stderr: str,
+    ) -> str:
+        """Build a user-facing failure message + write the forensic envelope.
+
+        Always writes the envelope (even when codex emitted zero bytes) so
+        that wedges *before* `session.created` — the worst class of failure
+        documented in .cortex/journal/2026-04-26-codex-exec-wedge-trace.md
+        — leave the wrapping agent something to attribute the failure to.
+        Pre-fix, a zero-byte hang produced no session_id, no NDJSON, and
+        no diagnostic file: the wrapping agent had nothing to act on.
+        """
+        _, _, _, partial_session_id = self._parse_ndjson(captured_stdout)
+        envelope_path = self._save_forensic_envelope(
+            kind=kind,
+            reason=prefix,
+            elapsed_sec=elapsed_sec,
+            command=command,
+            cwd=cwd,
+            captured_stdout=captured_stdout,
+            captured_stderr=captured_stderr,
+        )
         parts = [prefix]
         if partial_session_id:
             parts.append(
@@ -559,31 +607,54 @@ class CodexProvider:
                 f"resume with `conductor exec --with codex "
                 f"--resume {partial_session_id} ...`"
             )
-            if log_path is not None:
-                parts.append(f"; raw NDJSON saved to {log_path})")
+            if envelope_path is not None:
+                parts.append(f"; forensic envelope: {envelope_path})")
             else:
                 parts.append(")")
-        elif log_path is not None:
-            parts.append(f" (raw NDJSON saved to {log_path})")
+        elif envelope_path is not None:
+            parts.append(f" (forensic envelope: {envelope_path})")
         return "".join(parts)
 
-    def _save_forensic_log(self, stdout: str) -> Path | None:
-        """Persist captured NDJSON to the cache dir on failure.
+    def _save_forensic_envelope(
+        self,
+        *,
+        kind: str,
+        reason: str,
+        elapsed_sec: float,
+        command: list[str],
+        cwd: str | None,
+        captured_stdout: str,
+        captured_stderr: str,
+    ) -> Path | None:
+        """Persist a structured failure envelope to the cache dir.
 
-        Returns the path on success, or None if there was nothing to save
-        or the write failed. A failure here MUST NOT propagate — the call
-        is already failing for a different reason; losing the forensic
-        log is acceptable, but masking the original error with a disk
-        error is not.
+        Always writes when called: codex wedges that produce zero bytes
+        still benefit from having `(command, cwd, version)` on disk so an
+        operator or wrapping agent has *something* to pin the failure to.
+        Returns the path on success, or None if the write failed. A disk
+        failure MUST NOT mask the original error — the call is already
+        failing; losing the forensic envelope is acceptable.
         """
-        if not stdout.strip():
-            return None
+        envelope = {
+            "kind": kind,
+            "reason": reason,
+            "elapsed_sec": round(elapsed_sec, 2),
+            "conductor_version": _conductor_version,
+            "codex_path": shutil.which(self._cli),
+            "command": command,
+            "cwd": cwd,
+            "captured_stdout": captured_stdout,
+            "captured_stderr": captured_stderr,
+        }
         try:
             cache_dir = _cache_dir()
             cache_dir.mkdir(parents=True, exist_ok=True)
             ts = int(time.time())
-            path = cache_dir / f"codex-{os.getpid()}-{ts}.ndjson"
-            path.write_text(stdout, encoding="utf-8")
+            path = cache_dir / f"codex-{os.getpid()}-{ts}.json"
+            path.write_text(
+                json.dumps(envelope, indent=2, default=str),
+                encoding="utf-8",
+            )
             return path
         except OSError:
             return None

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -681,11 +681,12 @@ def test_codex_exec_emits_session_id_only_once(mocker, capsys):
     assert "sess-second" not in err
 
 
-def test_codex_exec_writes_forensic_log_on_stall(mocker, tmp_path, monkeypatch):
-    """When the stall watchdog fires with partial NDJSON in the buffer,
-    conductor saves the raw NDJSON to the cache dir and includes the path
-    in the error message. This is the forensic trail for hangs that
-    happen without a recoverable session_id (or in addition to one)."""
+def test_codex_exec_writes_forensic_envelope_on_stall(mocker, tmp_path, monkeypatch):
+    """Envelope captures everything needed to attribute a stall:
+    command, cwd, conductor version, partial stdout, partial stderr.
+    Independent of whether codex emitted any NDJSON."""
+    import json as _json
+
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
     mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
     partial = '{"type":"session.created","session_id":"sess-forensic-1"}\n'
@@ -699,16 +700,29 @@ def test_codex_exec_writes_forensic_log_on_stall(mocker, tmp_path, monkeypatch):
         CodexProvider().exec("hi", max_stall_sec=0.05, liveness_interval_sec=0)
 
     msg = str(exc.value)
-    assert "raw NDJSON saved to" in msg
+    assert "forensic envelope:" in msg
     log_dir = tmp_path / "conductor"
-    log_files = list(log_dir.glob("codex-*.ndjson"))
-    assert len(log_files) == 1, f"expected one log file, got {log_files}"
-    assert log_files[0].read_text() == partial
+    log_files = list(log_dir.glob("codex-*.json"))
+    assert len(log_files) == 1, f"expected one envelope file, got {log_files}"
+    envelope = _json.loads(log_files[0].read_text())
+    assert envelope["kind"] == "stall"
+    # The CLI argv keeps the literal `codex` (not the resolved PATH).
+    # The envelope's separate `codex_path` field is what shutil.which()
+    # resolved at the time of failure.
+    assert envelope["command"][0] == "codex"
+    assert envelope["codex_path"] == "/usr/bin/codex"
+    assert "exec" in envelope["command"]
+    assert envelope["captured_stdout"] == partial
+    assert envelope["conductor_version"]  # whatever it is, it's set
     assert str(log_files[0]) in msg
 
 
-def test_codex_exec_writes_forensic_log_on_streaming_timeout(mocker, tmp_path, monkeypatch):
-    """Same forensic-log behavior on the wall-clock timeout path."""
+def test_codex_exec_writes_forensic_envelope_on_streaming_timeout(
+    mocker, tmp_path, monkeypatch
+):
+    """Same envelope behavior on the wall-clock timeout path."""
+    import json as _json
+
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
     mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
     partial = (
@@ -725,37 +739,59 @@ def test_codex_exec_writes_forensic_log_on_streaming_timeout(mocker, tmp_path, m
         CodexProvider().exec("hi", timeout_sec=0.1, liveness_interval_sec=0)
 
     msg = str(exc.value)
-    assert "raw NDJSON saved to" in msg
-    log_files = list((tmp_path / "conductor").glob("codex-*.ndjson"))
+    assert "forensic envelope:" in msg
+    log_files = list((tmp_path / "conductor").glob("codex-*.json"))
     assert len(log_files) == 1
-    assert log_files[0].read_text() == partial
+    envelope = _json.loads(log_files[0].read_text())
+    assert envelope["kind"] == "timeout"
+    assert envelope["captured_stdout"] == partial
 
 
-def test_codex_exec_no_forensic_log_when_no_partial_output(mocker, tmp_path, monkeypatch):
-    """If the stall fires before any output arrived, there's nothing to
-    save — don't litter the cache dir with empty files, and don't mention
-    a path that doesn't exist in the error message."""
+def test_codex_exec_writes_envelope_when_codex_emits_zero_bytes(
+    mocker, tmp_path, monkeypatch
+):
+    """The high-leverage case from .cortex/journal/2026-04-26-codex-exec-
+    wedge-trace.md: codex wedges *before* session.created fires and
+    produces no output at all. Pre-fix, this left the wrapping agent
+    with nothing — no session_id, no NDJSON file, nothing to attribute
+    the failure to. The envelope must still be written, capturing
+    (command, cwd, conductor_version) so an operator can pin the run."""
+    import json as _json
+
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
     mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
     fake = _FakePopen(stdout_schedule=[], hang_after_stdout=True)
     _patch_codex_popen(mocker, fake)
 
     with pytest.raises(ProviderStalledError) as exc:
-        CodexProvider().exec("hi", max_stall_sec=0.05, liveness_interval_sec=0)
+        CodexProvider().exec(
+            "test prompt body",
+            max_stall_sec=0.05,
+            liveness_interval_sec=0,
+        )
 
     msg = str(exc.value)
-    assert "raw NDJSON saved to" not in msg
-    log_dir = tmp_path / "conductor"
-    if log_dir.exists():
-        assert list(log_dir.glob("codex-*.ndjson")) == []
+    assert "forensic envelope:" in msg
+    log_files = list((tmp_path / "conductor").glob("codex-*.json"))
+    assert len(log_files) == 1, (
+        "Envelope MUST be written even when codex emitted zero bytes — "
+        "this is the wedge-before-session.created class of failure that "
+        "had no diagnostics pre-fix."
+    )
+    envelope = _json.loads(log_files[0].read_text())
+    assert envelope["kind"] == "stall"
+    assert envelope["captured_stdout"] == ""
+    # The prompt body must be in the captured command (last positional after
+    # `codex exec`), so an operator can correlate the wedge with the request.
+    assert "test prompt body" in envelope["command"]
 
 
-def test_codex_exec_forensic_log_disk_failure_does_not_mask_real_error(
+def test_codex_exec_forensic_envelope_disk_failure_does_not_mask_real_error(
     mocker, tmp_path, monkeypatch
 ):
     """If the cache write itself fails (read-only fs, ENOSPC, etc.), the
     original ProviderStalledError must still propagate cleanly — losing
-    the forensic log is acceptable, masking the original error is not."""
+    the forensic envelope is acceptable, masking the original error is not."""
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
     mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
     partial = '{"type":"session.created","session_id":"sess-disk-fail"}\n'
@@ -774,8 +810,8 @@ def test_codex_exec_forensic_log_disk_failure_does_not_mask_real_error(
     # Original error info still present:
     assert "stalled" in msg
     assert "sess-disk-fail" in msg
-    # No fabricated log path mentioned:
-    assert "raw NDJSON saved to" not in msg
+    # No fabricated envelope path mentioned:
+    assert "forensic envelope:" not in msg
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Addresses items #1 and #2 from .cortex/journal/2026-04-26-codex-exec-
wedge-trace.md, the production trace where codex exec wedges *before*
session.created fires (3-for-3 in the journal's window).

The PR #36 stall watchdog correctly bounds losses, but PR #38's
session_id stderr signal and forensic NDJSON log both depend on codex
emitting at least one event before wedging — and the trace shows that
assumption is wrong on a meaningful fraction of dispatches today.
Pre-fix, a zero-byte hang produced no session_id, no NDJSON file, and
no diagnostic data. Wrapping agents had nothing to attribute the
failure to.

1. Conductor-side forensic envelope (always written on stall/timeout).

   `_save_forensic_envelope` replaces `_save_forensic_log` and writes a
   structured JSON file under $XDG_CACHE_HOME/conductor/codex-<pid>-
   <ts>.json regardless of whether codex emitted any output. Captures:

     - kind: "stall" | "timeout"
     - reason, elapsed_sec
     - conductor_version + resolved codex_path (shutil.which)
     - command (full argv: prompt, tools, sandbox, --effort translation)
     - cwd
     - captured_stdout + captured_stderr (whatever codex did emit)

   Critically, the envelope is written even when captured_stdout is
   empty — that's the wedge-before-session.created class of failure
   that previously left no diagnostic trail. The argv contains the
   prompt body and the sandbox/tool config, so an operator or wrapping
   agent has enough to correlate a wedge with a specific dispatch.

   Disk failures during the write are still swallowed silently
   (preserves the original ProviderStalledError), tested explicitly.

2. Subagent template watchdog defaults.

   `SUBAGENT_CODEX_CODING_AGENT` now recommends
   `--max-stall-seconds 600 --timeout 1800` in the documented invocation
   pattern. The journal noted: v0.5.1 still had the old example
   invocation and new users wouldn't know the watchdog flag exists
   without reading the changelog. The template also now tells delegation
   subagents to surface the forensic envelope path to parent agents
   when a watchdog kill happens, so the new diagnostic actually flows
   upward.

   Existing wired projects pick this up on their next `conductor init`.

Tests:
  - Envelope is written when stdout is non-empty (existing behavior).
  - Envelope is written on streaming-timeout path (existing behavior).
  - Envelope IS WRITTEN even when codex emitted zero bytes — the
    high-leverage new test, asserting the journal's #1 ask.
  - Disk failure during envelope write does NOT mask the original
    ProviderStalledError.
  - Envelope contains: kind, command, codex_path, captured_stdout,
    conductor_version (verified by parsing the JSON file).

526 tests passing. Lint clean. Mypy 0 errors.

Items #3 (smoke/exec health-probe asymmetry), #4 (--effort translation
regression watch), #5 (per-failure tarball with subagent prompt + env)
deferred to follow-up PRs. #5 is partially covered by the envelope's
captured command + cwd; the remaining ask is environment + parent
context, which lives in the subagent layer rather than codex.py.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
