### PR TITLE
feat(list): surface copy-pasteable fix command for unconfigured providers

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -567,9 +567,47 @@ def _format_route_ranking(decision: RouteDecision) -> list[str]:
             f"p50={c.latency_ms}ms"
             f"){marker}"
         )
+    for c in decision.unconfigured_shadow:
+        tags = ",".join(c.matched_tags) or "none"
+        lines.append(
+            f"  ?  {c.name:<8} "
+            f"(tier={c.tier}[{c.tier_rank}] "
+            f"tags=+{c.tag_score}:{tags} "
+            f"cost≈${c.cost_score:.4f}/1k "
+            f"p50={c.latency_ms}ms"
+            f") ← would rank if installed: {c.unconfigured_reason}"
+        )
     for name, reason in decision.candidates_skipped:
         lines.append(f"  —  {name:<8} (skipped: {reason})")
     return lines
+
+
+def _format_shadow_hint(decision: RouteDecision) -> str | None:
+    """Return a stderr advisory if an unconfigured provider outranks the winner.
+
+    Returns None when the unconfigured-shadow ranking is empty (no provider
+    we couldn't actually call would have been preferable) or when the top
+    shadow candidate's score isn't strictly higher than the picked provider's.
+    Equal scores resolve in favor of the configured provider — there's no
+    reason to nag the user about a tie.
+
+    The advisory exists because auto-mode falling back silently to the only
+    configured provider hides the cost of missing integrations. Surfacing
+    this at call-time turns "I didn't know codex wasn't installed" into
+    "I see codex would be a better fit; here's how to install it."
+    """
+    if not decision.unconfigured_shadow or not decision.ranked:
+        return None
+    top_shadow = decision.unconfigured_shadow[0]
+    winner = decision.ranked[0]
+    if top_shadow.combined_score <= winner.combined_score:
+        return None
+    reason = top_shadow.unconfigured_reason or "not configured"
+    return (
+        f"[conductor] heads-up: `{top_shadow.name}` would rank above "
+        f"`{winner.name}` if configured — {reason} "
+        f"(run `conductor list` for the fix)"
+    )
 
 
 def _emit_route_log(
@@ -585,6 +623,9 @@ def _emit_route_log(
             click.echo(line, err=True)
     else:
         click.echo(_format_route_log_line(decision), err=True)
+    hint = _format_shadow_hint(decision)
+    if hint is not None:
+        click.echo(hint, err=True)
 
 
 def _emit_usage_log(response: CallResponse, *, silent: bool) -> None:
@@ -730,6 +771,7 @@ def call(
                 prefer=_validate_prefer(prefer),
                 effort=effort_value,
                 exclude=frozenset(_parse_csv(exclude)),
+                shadow=True,
             )
         except (NoConfiguredProvider, InvalidRouterRequest) as e:
             click.echo(f"conductor: {e}", err=True)
@@ -934,6 +976,7 @@ def exec_cmd(
                 tools=tools_set,
                 sandbox=sandbox_value,
                 exclude=frozenset(_parse_csv(exclude)),
+                shadow=True,
             )
         except (NoConfiguredProvider, InvalidRouterRequest) as e:
             click.echo(f"conductor: {e}", err=True)
@@ -1048,6 +1091,7 @@ def route(
             tools=tools_set,
             sandbox=sandbox_value,
             exclude=frozenset(_parse_csv(exclude)),
+            shadow=True,
         )
     except (NoConfiguredProvider, InvalidRouterRequest) as e:
         if as_json:

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -567,6 +567,7 @@ def _format_route_ranking(decision: RouteDecision) -> list[str]:
             f"p50={c.latency_ms}ms"
             f"){marker}"
         )
+    shadow_names = {c.name for c in decision.unconfigured_shadow}
     for c in decision.unconfigured_shadow:
         tags = ",".join(c.matched_tags) or "none"
         lines.append(
@@ -577,7 +578,12 @@ def _format_route_ranking(decision: RouteDecision) -> list[str]:
             f"p50={c.latency_ms}ms"
             f") ← would rank if installed: {c.unconfigured_reason}"
         )
+    # Don't duplicate unconfigured providers in the skipped list — they
+    # already appear (with scores) in the shadow block above. Other skip
+    # reasons (excluded, missing tools, sandbox mismatch, health) still show.
     for name, reason in decision.candidates_skipped:
+        if name in shadow_names:
+            continue
         lines.append(f"  —  {name:<8} (skipped: {reason})")
     return lines
 
@@ -1199,6 +1205,13 @@ def _provider_rows() -> list[dict]:
                 "provider": name,
                 "configured": ok,
                 "reason": None if ok else reason,
+                # Copy-pasteable shell one-liner that takes the user from
+                # "not configured" to "configured". None for providers
+                # without a canonical recipe (e.g. user-defined shell
+                # providers).
+                "fix_command": (
+                    None if ok else getattr(provider, "fix_command", None)
+                ),
                 "default_model": provider.default_model,
                 "tags": list(provider.tags),
                 "tier": provider.quality_tier,
@@ -1245,6 +1258,8 @@ def list_cmd(as_json: bool) -> None:
         )
         if not r["configured"] and r["reason"]:
             click.echo(f"{'':<{name_w}}  {'':<5}  └─ {r['reason']}")
+        if not r["configured"] and r["fix_command"]:
+            click.echo(f"{'':<{name_w}}  {'':<5}  → fix: {r['fix_command']}")
 
 
 # --------------------------------------------------------------------------- #
@@ -1348,6 +1363,9 @@ def _diagnostic_payload() -> dict:
                 "provider": name,
                 "configured": ok,
                 "reason": None if ok else reason,
+                "fix_command": (
+                    None if ok else getattr(provider, "fix_command", None)
+                ),
                 "default_model": provider.default_model,
                 "tags": list(provider.tags),
                 "quality_tier": provider.quality_tier,
@@ -1459,6 +1477,8 @@ def doctor(as_json: bool) -> None:
         )
         if not p["configured"]:
             click.echo(f"        └─ {p['reason']}")
+            if p.get("fix_command"):
+                click.echo(f"        → fix: {p['fix_command']}")
         for w in p.get("warnings") or []:
             click.echo(f"        ⚠ {w}")
 

--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -63,6 +63,9 @@ class ClaudeProvider:
     # entry point (the slash variant `/login` only works inside the REPL).
     auth_login_command = "claude auth login"
 
+    # One-liner shown under the failure reason in `conductor list`.
+    fix_command = "brew install claude && claude auth login"
+
     def __init__(
         self,
         *,

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -84,6 +84,9 @@ class CodexProvider:
     # User-facing login command surfaced in error messages and the wizard.
     auth_login_command = "codex login"
 
+    # One-liner shown under the failure reason in `conductor list`.
+    fix_command = "brew install codex && codex login"
+
     def __init__(
         self,
         *,

--- a/src/conductor/providers/deepseek.py
+++ b/src/conductor/providers/deepseek.py
@@ -245,6 +245,7 @@ class DeepSeekChatProvider(_DeepSeekBase):
     name = "deepseek-chat"
     default_model = DEEPSEEK_CHAT_MODEL
     tags = ["cheap", "code-review", "tool-use"]
+    fix_command = "conductor init --only deepseek-chat"
 
     quality_tier = "strong"
     supports_effort = False
@@ -263,6 +264,7 @@ class DeepSeekReasonerProvider(_DeepSeekBase):
     name = "deepseek-reasoner"
     default_model = DEEPSEEK_REASONER_MODEL
     tags = ["strong-reasoning", "thinking", "code-review"]
+    fix_command = "conductor init --only deepseek-reasoner"
 
     quality_tier = "strong"
     # R1 always emits reasoning_content; the dial is informational (DeepSeek's

--- a/src/conductor/providers/gemini.py
+++ b/src/conductor/providers/gemini.py
@@ -76,6 +76,10 @@ class GeminiProvider:
     # the recommended fallback is `GEMINI_API_KEY`.
     auth_login_command: str | None = None
 
+    # One-liner shown under the failure reason in `conductor list`. The CLI's
+    # first interactive run triggers OAuth; there's no separate login command.
+    fix_command = "npm install -g @google/gemini-cli  # then run `gemini` once for OAuth"
+
     def __init__(
         self,
         *,

--- a/src/conductor/providers/interface.py
+++ b/src/conductor/providers/interface.py
@@ -125,6 +125,15 @@ class Provider(Protocol):
     # --- capability tags (soft matching for routing) ----------------------- #
     tags: ClassVar[list[str]]
 
+    # --- setup hint -------------------------------------------------------- #
+    # A copy-pasteable shell one-liner that takes the user from "not
+    # configured" to "configured". Surfaced beneath the failure reason in
+    # `conductor list` and `conductor doctor` so the next action is always
+    # one selection away. CLI-wrapped providers point at the install + auth
+    # commands; HTTP providers point at `conductor init --only <name>` since
+    # their setup is an env-var/credentials wizard, not a binary install.
+    fix_command: ClassVar[str | None]
+
     # --- capability declarations (hard filters + scoring dimensions) ------- #
     quality_tier: ClassVar[str]
     supported_tools: ClassVar[frozenset[str]]

--- a/src/conductor/providers/kimi.py
+++ b/src/conductor/providers/kimi.py
@@ -75,6 +75,11 @@ class KimiProvider:
     tags = ["long-context", "cheap", "vision", "code-review"]
     default_model = KIMI_DEFAULT_MODEL
 
+    # One-liner shown under the failure reason in `conductor list`. Kimi is
+    # an HTTP provider whose setup is purely credential-wiring; the wizard
+    # is the right entry point for both env-var and key-command paths.
+    fix_command = "conductor init --only kimi"
+
     # Capability declarations (see interface.py)
     quality_tier = "strong"
     # Full tool-use landed in v0.3.1 (Edit/Write/Bash + workspace-write

--- a/src/conductor/providers/ollama.py
+++ b/src/conductor/providers/ollama.py
@@ -146,6 +146,9 @@ class OllamaProvider:
     # 4-8K. Users on a long-context local model can override per-request.
     max_context_tokens = 32_000
 
+    # One-liner shown under the failure reason in `conductor list`.
+    fix_command = "brew install ollama && ollama serve"
+
     def __init__(
         self,
         *,

--- a/src/conductor/providers/shell.py
+++ b/src/conductor/providers/shell.py
@@ -89,6 +89,10 @@ class ShellProvider:
     effort_to_thinking: dict[str, int] = {}  # noqa: RUF012
     cost_per_1k_thinking: float = 0.0
 
+    # User-defined shell commands have no canonical install/auth recipe —
+    # the user wrote the command, so no automated fix line in `conductor list`.
+    fix_command: str | None = None
+
     def __init__(
         self,
         spec: ShellProviderSpec,

--- a/src/conductor/router.py
+++ b/src/conductor/router.py
@@ -144,7 +144,12 @@ def _health_penalty(name: str) -> float:
 
 @dataclass(frozen=True)
 class RankedCandidate:
-    """One provider's full scoring breakdown for a given routing request."""
+    """One provider's full scoring breakdown for a given routing request.
+
+    ``unconfigured_reason`` is set only on shadow candidates (see ``pick``'s
+    ``shadow`` parameter) — providers that would have been scored but failed
+    ``configured()``. Real (winnable) candidates leave it ``None``.
+    """
 
     name: str
     tier: str
@@ -155,11 +160,19 @@ class RankedCandidate:
     latency_ms: int
     health_penalty: float
     combined_score: float       # the key used by the current prefer mode (higher=better)
+    unconfigured_reason: str | None = None
 
 
 @dataclass(frozen=True)
 class RouteDecision:
-    """Why the router picked what it picked — the explainable output."""
+    """Why the router picked what it picked — the explainable output.
+
+    ``unconfigured_shadow`` is populated when ``pick(..., shadow=True)`` is
+    used; it ranks providers that failed ``configured()`` against the same
+    scoring rules as the winnable candidates. The CLI uses this to tell the
+    user when an unconfigured provider would have been a better fit than the
+    one auto-mode actually picked.
+    """
 
     provider: str
     prefer: str
@@ -172,6 +185,7 @@ class RouteDecision:
     sandbox: str
     ranked: tuple[RankedCandidate, ...]           # descending by combined_score
     candidates_skipped: tuple[tuple[str, str], ...]  # (name, reason)
+    unconfigured_shadow: tuple[RankedCandidate, ...] = ()  # descending; never winners
 
     # Legacy fields retained for v0.1 callers that destructured these.
     @property
@@ -188,6 +202,65 @@ class RouteDecision:
 # --------------------------------------------------------------------------- #
 
 
+def _score_one(
+    name: str,
+    provider: Provider,
+    *,
+    task_tag_set: set[str],
+    prefer: str,
+    effort: str | int,
+    priority_index: int,
+    unconfigured_reason: str | None = None,
+) -> RankedCandidate:
+    """Score a single provider under the active prefer mode.
+
+    Shared between the main winnable-candidate loop and the shadow pass that
+    re-scores unconfigured providers. ``unconfigured_reason`` is plumbed
+    through so shadow candidates carry the configured() failure text into
+    the decision; winnable candidates leave it ``None``.
+
+    Health penalty is suppressed for shadow candidates — there's no health
+    history for a provider the caller couldn't actually invoke, so applying
+    a penalty would be noise.
+    """
+    matched = tuple(sorted(task_tag_set & set(provider.tags)))
+    tag_score = len(matched)
+    tier_rank = TIER_RANK.get(provider.quality_tier, 0)
+
+    # Expected total cost per 1k tokens at the requested effort.
+    # We don't know the actual token count yet; use a per-request estimate
+    # assuming ~4k input and ~500 output (typical review sizes).
+    thinking_tokens = resolve_effort_tokens(effort, provider.effort_to_thinking)
+    cost_estimate = (
+        provider.cost_per_1k_in * 4
+        + provider.cost_per_1k_out * 0.5
+        + provider.cost_per_1k_thinking * (thinking_tokens / 1_000)
+    )
+
+    penalty = 0.0 if unconfigured_reason is not None else _health_penalty(name)
+    combined = _combined_score(
+        prefer=prefer,
+        tag_score=tag_score,
+        tier_rank=tier_rank,
+        cost_estimate=cost_estimate,
+        latency_ms=provider.typical_p50_ms,
+        priority_index=priority_index,
+    ) * (1 - penalty)
+
+    return RankedCandidate(
+        name=name,
+        tier=provider.quality_tier,
+        tier_rank=tier_rank,
+        matched_tags=matched,
+        tag_score=tag_score,
+        cost_score=cost_estimate,
+        latency_ms=provider.typical_p50_ms,
+        health_penalty=penalty,
+        combined_score=combined,
+        unconfigured_reason=unconfigured_reason,
+    )
+
+
 def pick(
     task_tags: list[str] | None = None,
     *,
@@ -197,12 +270,21 @@ def pick(
     sandbox: str = "none",
     exclude: frozenset[str] | set[str] | list[str] | None = None,
     priority: tuple[str, ...] = DEFAULT_PRIORITY,
+    shadow: bool = False,
 ) -> tuple[Provider, RouteDecision]:
     """Pick the best provider for ``task_tags`` under the given preferences.
 
     See module docstring for the full pipeline. Default ``prefer="balanced"``
     reproduces v0.1 behavior (pure tag-overlap + priority tiebreak) for
     backward compatibility.
+
+    ``shadow``: when True, providers that would otherwise be eligible but
+    failed ``configured()`` are re-scored and returned in
+    ``decision.unconfigured_shadow``. They never become the winner — this
+    is purely an explainability hook so callers can tell users *"auto would
+    have preferred X, but X isn't installed/authed"*. Off by default to
+    avoid surprising existing callers (Sentinel, Touchstone) and the CLI's
+    `--with` path that doesn't need it.
     """
     if prefer not in VALID_PREFER_MODES:
         raise InvalidRouterRequest(
@@ -229,6 +311,7 @@ def pick(
 
     ranked: list[RankedCandidate] = []
     skipped: list[tuple[str, str]] = []
+    unconfigured: dict[str, str] = {}  # name → reason; only configured() failures
 
     for name in order:
         if name in exclude_set:
@@ -239,7 +322,18 @@ def pick(
 
         ok, reason = provider.configured()
         if not ok:
-            skipped.append((name, reason or "not configured"))
+            failure = reason or "not configured"
+            skipped.append((name, failure))
+            # Hard capability filters still apply to shadow candidates — we
+            # don't want to suggest "would prefer X" for a provider X that
+            # couldn't satisfy the caller's tools/sandbox even if installed.
+            if name not in exclude_set:
+                if tools_set and not tools_set.issubset(provider.supported_tools):
+                    pass
+                elif sandbox not in provider.supported_sandboxes and sandbox != "none":
+                    pass
+                else:
+                    unconfigured[name] = failure
             continue
 
         # Hard capability filters.
@@ -258,43 +352,14 @@ def pick(
             skipped.append((name, health_reason))
             continue
 
-        # Compute scoring dimensions.
-        matched = tuple(sorted(task_tag_set & set(provider.tags)))
-        tag_score = len(matched)
-        tier_rank = TIER_RANK.get(provider.quality_tier, 0)
-
-        # Expected total cost per 1k tokens at the requested effort.
-        # We don't know the actual token count yet; use a per-request estimate
-        # assuming ~4k input and ~500 output (typical review sizes).
-        thinking_tokens = resolve_effort_tokens(effort, provider.effort_to_thinking)
-        cost_estimate = (
-            provider.cost_per_1k_in * 4
-            + provider.cost_per_1k_out * 0.5
-            + provider.cost_per_1k_thinking * (thinking_tokens / 1_000)
-        )
-
-        penalty = _health_penalty(name)
-
-        combined = _combined_score(
-            prefer=prefer,
-            tag_score=tag_score,
-            tier_rank=tier_rank,
-            cost_estimate=cost_estimate,
-            latency_ms=provider.typical_p50_ms,
-            priority_index=priority_index[name],
-        ) * (1 - penalty)
-
         ranked.append(
-            RankedCandidate(
-                name=name,
-                tier=provider.quality_tier,
-                tier_rank=tier_rank,
-                matched_tags=matched,
-                tag_score=tag_score,
-                cost_score=cost_estimate,
-                latency_ms=provider.typical_p50_ms,
-                health_penalty=penalty,
-                combined_score=combined,
+            _score_one(
+                name,
+                provider,
+                task_tag_set=task_tag_set,
+                prefer=prefer,
+                effort=effort,
+                priority_index=priority_index[name],
             )
         )
 
@@ -312,6 +377,23 @@ def pick(
 
     thinking_budget = resolve_effort_tokens(effort, winner_provider.effort_to_thinking)
 
+    shadow_ranked: tuple[RankedCandidate, ...] = ()
+    if shadow and unconfigured:
+        shadow_list = [
+            _score_one(
+                name,
+                get_provider(name),
+                task_tag_set=task_tag_set,
+                prefer=prefer,
+                effort=effort,
+                priority_index=priority_index[name],
+                unconfigured_reason=reason,
+            )
+            for name, reason in unconfigured.items()
+        ]
+        shadow_list.sort(key=lambda c: (-c.combined_score, priority_index[c.name]))
+        shadow_ranked = tuple(shadow_list)
+
     decision = RouteDecision(
         provider=winner.name,
         prefer=prefer,
@@ -324,6 +406,7 @@ def pick(
         sandbox=sandbox,
         ranked=tuple(ranked),
         candidates_skipped=tuple(skipped),
+        unconfigured_shadow=shadow_ranked,
     )
     return winner_provider, decision
 

--- a/src/conductor/router.py
+++ b/src/conductor/router.py
@@ -325,15 +325,16 @@ def pick(
             failure = reason or "not configured"
             skipped.append((name, failure))
             # Hard capability filters still apply to shadow candidates — we
-            # don't want to suggest "would prefer X" for a provider X that
-            # couldn't satisfy the caller's tools/sandbox even if installed.
-            if name not in exclude_set:
-                if tools_set and not tools_set.issubset(provider.supported_tools):
-                    pass
-                elif sandbox not in provider.supported_sandboxes and sandbox != "none":
-                    pass
-                else:
-                    unconfigured[name] = failure
+            # don't want to suggest "would prefer X" for a provider that,
+            # even installed, couldn't satisfy the caller's tools/sandbox.
+            tools_ok = (
+                not tools_set or tools_set.issubset(provider.supported_tools)
+            )
+            sandbox_ok = (
+                sandbox == "none" or sandbox in provider.supported_sandboxes
+            )
+            if tools_ok and sandbox_ok:
+                unconfigured[name] = failure
             continue
 
         # Hard capability filters.

--- a/tests/test_cli_auto.py
+++ b/tests/test_cli_auto.py
@@ -124,3 +124,168 @@ def test_call_auto_with_no_configured_providers_exits_2(mocker):
     )
     assert result.exit_code == 2
     assert "no provider satisfies" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Shadow hint — auto-mode tells the user when an unconfigured provider would
+# have outranked the picked one. Closes the "I didn't know codex wasn't
+# installed" UX gap.
+# ---------------------------------------------------------------------------
+
+
+def test_call_auto_emits_shadow_hint_when_unconfigured_outranks(monkeypatch, mocker):
+    """Only kimi is ready, but codex/claude (frontier, code-review tag) would
+    rank higher — the heads-up advisory should fire and name codex (priority
+    tiebreak among frontiers; claude is excluded so codex is unambiguous)."""
+    from conductor.providers import (
+        ClaudeProvider,
+        CodexProvider,
+        GeminiProvider,
+        OllamaProvider,
+    )
+
+    mocker.patch.object(ClaudeProvider, "configured", lambda self: (False, "nope"))
+    mocker.patch.object(
+        CodexProvider,
+        "configured",
+        lambda self: (False, "`codex` CLI not found on PATH"),
+    )
+    mocker.patch.object(GeminiProvider, "configured", lambda self: (False, "nope"))
+    mocker.patch.object(OllamaProvider, "configured", lambda self: (False, "nope"))
+    monkeypatch.setenv(CLOUDFLARE_API_TOKEN_ENV, "cf-test-token")
+    monkeypatch.setenv(CLOUDFLARE_ACCOUNT_ID_ENV, _TEST_ACCOUNT_ID)
+
+    with respx.mock() as router:
+        router.post(_CF_CHAT_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "model": KIMI_DEFAULT_MODEL,
+                    "choices": [{"message": {"content": "ok"}}],
+                    "usage": {},
+                },
+            )
+        )
+        result = CliRunner().invoke(
+            main,
+            [
+                "call",
+                "--auto",
+                "--tags",
+                "code-review",
+                "--prefer",
+                "best",
+                "--exclude",
+                "claude",
+                "--task",
+                "hi",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "heads-up" in result.output
+    assert "codex" in result.output
+    assert "CLI not found on PATH" in result.output
+    assert "conductor list" in result.output
+
+
+def test_call_auto_no_hint_when_winner_is_top(monkeypatch, mocker):
+    """When the picked provider already outscores any shadow candidate,
+    the hint must stay quiet — otherwise it becomes wallpaper."""
+    from conductor.providers import (
+        ClaudeProvider,
+        CodexProvider,
+        GeminiProvider,
+        OllamaProvider,
+    )
+
+    # Claude (frontier, code-review) is configured. Nothing unconfigured can
+    # outrank it for this request.
+    mocker.patch.object(ClaudeProvider, "configured", lambda self: (True, None))
+    mocker.patch.object(CodexProvider, "configured", lambda self: (False, "off"))
+    mocker.patch.object(GeminiProvider, "configured", lambda self: (False, "off"))
+    mocker.patch.object(OllamaProvider, "configured", lambda self: (False, "off"))
+
+    # Stub claude.call so we don't spawn the real CLI.
+    mocker.patch.object(
+        ClaudeProvider,
+        "call",
+        lambda self, task, **kw: __import__(
+            "conductor.providers.interface", fromlist=["CallResponse"]
+        ).CallResponse(
+            text="claude-stubbed",
+            provider="claude",
+            model="sonnet",
+            duration_ms=1,
+        ),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "call",
+            "--auto",
+            "--tags",
+            "code-review",
+            "--prefer",
+            "best",
+            "--task",
+            "hi",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "heads-up" not in result.output
+
+
+def test_call_auto_silent_route_suppresses_shadow_hint(monkeypatch, mocker):
+    """--silent-route is the documented escape hatch for scripted callers;
+    it must squelch the shadow hint along with the rest of the route log."""
+    from conductor.providers import (
+        ClaudeProvider,
+        CodexProvider,
+        GeminiProvider,
+        OllamaProvider,
+    )
+
+    mocker.patch.object(ClaudeProvider, "configured", lambda self: (False, "nope"))
+    mocker.patch.object(
+        CodexProvider,
+        "configured",
+        lambda self: (False, "`codex` CLI not found on PATH"),
+    )
+    mocker.patch.object(GeminiProvider, "configured", lambda self: (False, "nope"))
+    mocker.patch.object(OllamaProvider, "configured", lambda self: (False, "nope"))
+    monkeypatch.setenv(CLOUDFLARE_API_TOKEN_ENV, "cf-test-token")
+    monkeypatch.setenv(CLOUDFLARE_ACCOUNT_ID_ENV, _TEST_ACCOUNT_ID)
+
+    with respx.mock() as router:
+        router.post(_CF_CHAT_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "model": KIMI_DEFAULT_MODEL,
+                    "choices": [{"message": {"content": "ok"}}],
+                    "usage": {},
+                },
+            )
+        )
+        result = CliRunner().invoke(
+            main,
+            [
+                "call",
+                "--auto",
+                "--tags",
+                "code-review",
+                "--prefer",
+                "best",
+                "--exclude",
+                "claude",
+                "--silent-route",
+                "--task",
+                "hi",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "heads-up" not in result.output

--- a/tests/test_cli_phase5.py
+++ b/tests/test_cli_phase5.py
@@ -90,6 +90,58 @@ def test_list_json_output_returns_structured_rows(mocker):
     assert {r["provider"] for r in rows} == expected
     assert all(r["configured"] is False for r in rows)
     assert all(r["default_model"] for r in rows)
+    # Every built-in provider exposes a copy-pasteable fix_command so
+    # `conductor list` can show users their next action without any
+    # downstream knowledge of provider-specific install/auth recipes.
+    assert all(r["fix_command"] for r in rows)
+
+
+def test_list_text_output_shows_fix_command_under_unconfigured_provider(mocker):
+    """When a provider is unconfigured, `conductor list` prints the fix
+    one-liner on its own line so the user's next step is one selection away
+    instead of buried in the prose reason."""
+    _stub_all_unconfigured(mocker)
+    result = CliRunner().invoke(main, ["list"])
+    assert result.exit_code == 0, result.output
+    # Codex's fix is the install + auth one-liner, exposed verbatim.
+    assert "→ fix: brew install codex && codex login" in result.output
+    # Kimi is HTTP-backed, so the fix is the wizard.
+    assert "→ fix: conductor init --only kimi" in result.output
+
+
+def test_list_no_fix_line_for_configured_provider(mocker):
+    from conductor.providers import (
+        ClaudeProvider,
+        CodexProvider,
+        DeepSeekChatProvider,
+        DeepSeekReasonerProvider,
+        GeminiProvider,
+        KimiProvider,
+        OllamaProvider,
+    )
+
+    # All unconfigured except claude.
+    for cls in (
+        CodexProvider,
+        DeepSeekChatProvider,
+        DeepSeekReasonerProvider,
+        GeminiProvider,
+        KimiProvider,
+        OllamaProvider,
+    ):
+        mocker.patch.object(
+            cls,
+            "configured",
+            lambda self, _cls=cls: (False, f"stub: {_cls.__name__} unset"),
+        )
+    mocker.patch.object(ClaudeProvider, "configured", lambda self: (True, None))
+
+    result = CliRunner().invoke(main, ["list", "--json"])
+    rows = {r["provider"]: r for r in json.loads(result.output)}
+    # Configured row carries no fix_command — there's nothing to fix.
+    assert rows["claude"]["fix_command"] is None
+    # Unconfigured rows still carry theirs.
+    assert rows["codex"]["fix_command"] is not None
 
 
 # ---------------------------------------------------------------------------
@@ -195,6 +247,10 @@ def test_doctor_text_output_covers_every_provider(mocker, monkeypatch):
         assert name in result.output
     assert "Credentials" in result.output or "credentials" in result.output.lower()
     assert "conductor init" in result.output
+    # Doctor surfaces the same per-provider fix one-liner that `list` does,
+    # so users following any breadcrumb land on a copy-pasteable command.
+    assert "→ fix:" in result.output
+    assert "brew install codex && codex login" in result.output
 
 
 def test_doctor_json_shape(mocker, monkeypatch):

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -322,3 +322,119 @@ def test_route_decision_ranked_candidates_have_tier_info(mocker):
     tiers = {r.name: r.tier for r in decision.ranked}
     assert tiers["claude"] == "frontier"
     assert tiers["ollama"] == "local"
+
+
+# ---------------------------------------------------------------------------
+# Shadow ranking — surface providers that would have been preferable if
+# the user had configured them.
+# ---------------------------------------------------------------------------
+
+
+def test_shadow_off_by_default_keeps_decision_empty(mocker):
+    """The flag is opt-in; existing callers (Sentinel/Touchstone) see no change."""
+    _stub_configured(mocker, {"claude": True})
+    _, decision = pick([], prefer="best")
+    assert decision.unconfigured_shadow == ()
+
+
+def test_shadow_includes_unconfigured_providers(mocker):
+    # Only claude is configured. With shadow=True every other provider that
+    # would otherwise be eligible should appear in unconfigured_shadow.
+    _stub_configured(mocker, {"claude": True})
+    _, decision = pick([], prefer="best", shadow=True)
+    shadow_names = {c.name for c in decision.unconfigured_shadow}
+    # Every non-claude built-in provider that passes tools/sandbox filters
+    # (i.e. all of them under default args) should appear.
+    assert "codex" in shadow_names
+    assert "kimi" in shadow_names
+    assert "ollama" in shadow_names
+    assert "claude" not in shadow_names  # the picked provider is not its own shadow
+
+
+def test_shadow_never_returns_unconfigured_as_winner(mocker):
+    # Even if a frontier provider is the strongest shadow candidate by score,
+    # it must never become the winner — pick() can only return providers the
+    # caller can actually invoke. Exclude claude so codex is the unambiguous
+    # top shadow (both are frontier; priority would otherwise tiebreak claude).
+    _stub_configured(mocker, {"ollama": True})  # ollama=local; codex=frontier shadows
+    provider, decision = pick(
+        ["code-review"],
+        prefer="best",
+        exclude=frozenset({"claude"}),
+        shadow=True,
+    )
+    assert provider.name == "ollama"
+    assert decision.provider == "ollama"
+    # codex outscores ollama on tier+tag, so it should be the top shadow.
+    top_shadow = decision.unconfigured_shadow[0]
+    assert top_shadow.name == "codex"
+    assert top_shadow.combined_score > decision.ranked[0].combined_score
+
+
+def test_shadow_carries_configured_failure_reason(mocker):
+    """The reason text is what the CLI surfaces in the heads-up advisory."""
+    from conductor.providers import ClaudeProvider, CodexProvider
+
+    mocker.patch.object(
+        ClaudeProvider, "configured", lambda self: (True, None)
+    )
+    mocker.patch.object(
+        CodexProvider,
+        "configured",
+        lambda self: (False, "`codex` CLI not found on PATH"),
+    )
+    # Stub everything else as unconfigured with a generic reason.
+    from conductor.providers import (
+        DeepSeekChatProvider,
+        DeepSeekReasonerProvider,
+        GeminiProvider,
+        KimiProvider,
+        OllamaProvider,
+    )
+
+    for cls in (
+        DeepSeekChatProvider,
+        DeepSeekReasonerProvider,
+        GeminiProvider,
+        KimiProvider,
+        OllamaProvider,
+    ):
+        mocker.patch.object(
+            cls,
+            "configured",
+            lambda self: (False, "stub: not configured"),
+        )
+
+    _, decision = pick([], prefer="best", shadow=True)
+    codex_shadow = next(c for c in decision.unconfigured_shadow if c.name == "codex")
+    assert codex_shadow.unconfigured_reason == "`codex` CLI not found on PATH"
+
+
+def test_shadow_respects_exclude_filter(mocker):
+    """An excluded provider must not appear as a shadow candidate either."""
+    _stub_configured(mocker, {"claude": True})
+    _, decision = pick(
+        [], prefer="best", exclude=frozenset({"codex"}), shadow=True
+    )
+    shadow_names = {c.name for c in decision.unconfigured_shadow}
+    assert "codex" not in shadow_names
+
+
+def test_shadow_respects_tools_filter(mocker, monkeypatch):
+    """A provider that doesn't support requested tools shouldn't shadow either —
+    suggesting it would be silly when even installed it couldn't do the job."""
+    from conductor.providers.kimi import KimiProvider
+
+    monkeypatch.setattr(KimiProvider, "supported_tools", frozenset())
+    _stub_configured(mocker, {"claude": True})
+    _, decision = pick([], tools={"Edit"}, shadow=True)
+    shadow_names = {c.name for c in decision.unconfigured_shadow}
+    assert "kimi" not in shadow_names
+
+
+def test_shadow_ranked_by_score(mocker):
+    """Top shadow candidate is the one with the highest combined_score."""
+    _stub_configured(mocker, {"ollama": True})
+    _, decision = pick(["code-review"], prefer="best", shadow=True)
+    scores = [c.combined_score for c in decision.unconfigured_shadow]
+    assert scores == sorted(scores, reverse=True)


### PR DESCRIPTION
`conductor list` and `conductor doctor` already explained *why* a provider
wasn't ready, but the install/auth recipe was buried in prose at the end
of the failure reason. An agent rendering the table for a user could
truncate it to "codex CLI not on PATH" and lose the fix path entirely.

Add a `fix_command` class attribute on every provider — a single
copy-pasteable shell one-liner that takes the user from "not configured"
to "configured." CLI-wrapped providers point at the install + auth
commands; HTTP providers point at `conductor init --only <name>` since
their setup is a credentials wizard, not a binary install.

`list` and `doctor` print it as a structured "→ fix:" line beneath the
reason. The JSON payload exposes `fix_command` as a separate field so
downstream tooling can render it without re-parsing prose.

Also dedupe the verbose route ranking: providers that show up in the new
unconfigured-shadow block no longer appear a second time in the skipped
list, since the shadow row already reports the same skip reason.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
