### PR TITLE
docs(plan): fix PR count header in OpenRouter migration plan

### DIFF
--- a/.cortex/plans/openrouter-migration.md
+++ b/.cortex/plans/openrouter-migration.md
@@ -129,7 +129,7 @@ From the OpenRouter `:auto` research dispatched 2026-04-27:
 7. **Presets are a server-side feature** (`model: "@preset/<name>"`). Powerful but couples to OR's dashboard config. Skip in v1, revisit if inline requests get bloated.
 8. **NotDiamond direct, Martian, RouteLLM** are credible alternatives if `:auto`'s quality-first bias becomes painful. Not v1 scope.
 
-## Migration plan: three sequential PRs
+## Migration plan: four sequential PRs
 
 Each PR is independently reversible.
 


### PR DESCRIPTION
Codex review flagged that the section header said "three sequential
PRs" but the body enumerated four. The four-PR split (add adapter,
selector, migrate kimi, migrate deepseek) is the intended plan; the
header was stale from an earlier draft that bundled selector logic
into PR 1.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
