### PR TITLE
fix(codex-review): event-based stall watchdog instead of wall-clock cap

### DIFF
--- a/.codex-review.toml
+++ b/.codex-review.toml
@@ -34,11 +34,15 @@ safe_by_default = false
 # Override for a single run with: CODEX_REVIEW_MODE=review-only git push
 mode = "review-only"
 
-# Wall-clock timeout per reviewer invocation, in seconds. 0 = no timeout.
-# Safety net for wedged reviewer processes, NOT a thinking-time budget — real
-# reviews on big diffs can run 8–10 minutes. On timeout the cascade now falls
-# through to the next reviewer instead of silently passing the push.
-# timeout = 1800
+# Stall threshold per reviewer invocation, in seconds. 0 = no watchdog.
+# Event-based kill condition: the reviewer is killed only if it produces NO
+# output for this long — slow-but-progressing reviews are not punished. This
+# is strictly better than a wall-clock cap, which forced us to pick an
+# arbitrary "long enough" number that still bit on big diffs (PR #57's review
+# at effort=max hit a 300s wall-clock at 837 lines). 300s of pure silence is
+# a strong signal of a wedged reviewer process; bumping higher trades faster
+# wedge-detection for tolerance of longer thinking pauses.
+max_stall_sec = 300
 
 # What to do when the reviewer fails (crash, timeout, malformed output).
 # "fail-open"   = exit 0, allow push (default — infrastructure errors don't block)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,3 +142,16 @@ Deferred (see `~/Repos/autumn-garage/.cortex/plans/conductor-bootstrap.md` for t
 1. **Mock httpx with respx, not with `monkeypatch`-on-the-class.** The test suite uses `respx.mock(base_url=...)` so adapter code reaches the real `httpx.Client(...)` codepath; this catches signature drift between Conductor and httpx that monkey-patched mocks would silently swallow.
 2. **Click's `CliRunner` attaches an empty stdin (isatty=False).** Tests that exercise "no input provided" hit the empty-task branch, not the no-stdin branch. Both are correct user errors; tests assert on the user-visible substring, not the internal branch.
 3. **Provider quirks live in the adapter, never in shared code.** Kimi clamps temperature to `[0,1]`; Moonshot disallows `tool_choice="required"`. When those constraints become reachable (v0.2+ features), they belong in `kimi.py`, never in `interface.py` or the router. The Provider Protocol exists to keep the rest of Conductor ignorant of provider-specific gotchas.
+
+## Delegating to codex via `conductor exec`
+
+When a parent agent (like Claude Code) hands a feature build to codex via `conductor exec --with codex --sandbox workspace-write`, the codex sandbox blocks two things by default that matter for shipping a PR:
+
+- **`.git/` is not writable.** `git checkout -b`, `git commit`, `git push` all fail with `Operation not permitted`.
+- **No network.** Even with `.git/` open, `git push` would fail because the sandbox blocks outbound network access in `workspace-write` mode.
+
+This means **codex cannot run the full branch → commit → push → open-pr.sh workflow itself.** Don't put those steps in a brief sent to codex — it'll waste minutes hitting the boundary, then report failure.
+
+**The pattern that works:** scope the codex brief to *code* (write files, run tests, validate). The parent agent picks up afterward and does the git work on the host side: `git status` to see what changed, `git checkout -b`, stage explicit paths, commit, push, run `bash scripts/open-pr.sh --auto-merge`. PR #57 (OpenRouter adapter) shipped this way after the parent re-did the brief mid-flight to handle git on the outside.
+
+If you want codex to do everything end-to-end including git, you'd need to open both sandbox boundaries (`--add-dir <repo>/.git` plus a network whitelist), which is a real safety escalation worth a deliberate design decision rather than a default.

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -62,7 +62,13 @@
 #   CODEX_REVIEW_MAX_ITERATIONS       — fix loop cap (default: from config, or 3)
 #   CODEX_REVIEW_MAX_DIFF_LINES       — skip review if diff > this many lines (default: 5000)
 #   CODEX_REVIEW_CACHE_CLEAN          — cache exact-input clean reviews (default: true)
-#   CODEX_REVIEW_TIMEOUT              — wall-clock timeout per invocation in seconds (default: 300, 0=none)
+#   CODEX_REVIEW_MAX_STALL_SEC        — kill the reviewer if it produces no output for this many
+#                                       seconds (default: 300, 0=disable). Event-based: tolerates
+#                                       slow-but-progressing reviews; only kills wedged processes.
+#   CODEX_REVIEW_TIMEOUT              — DEPRECATED wall-clock alias kept for back-compat. If set
+#                                       and CODEX_REVIEW_MAX_STALL_SEC is unset, its value is used
+#                                       as the stall threshold (the legacy semantics shipped on
+#                                       a wall-clock cap; the new semantics are stall-based).
 #   CODEX_REVIEW_ON_ERROR             — fail-open (default) or fail-closed
 #   CODEX_REVIEW_DISABLE_CACHE        — set to true/1 to force a fresh review
 #   CODEX_REVIEW_FORCE                — set to true/1 to run even on non-default-branch pushes
@@ -94,7 +100,8 @@ CACHE_CLEAN_REVIEWS="${CODEX_REVIEW_CACHE_CLEAN:-true}"
 NO_AUTOFIX="${CODEX_REVIEW_NO_AUTOFIX:-false}"
 CONFIG_MODE=""
 REVIEW_ENABLED="${CODEX_REVIEW_ENABLED:-true}"
-REVIEW_TIMEOUT="${CODEX_REVIEW_TIMEOUT:-300}"
+REVIEW_MAX_STALL_SEC="${CODEX_REVIEW_MAX_STALL_SEC:-${CODEX_REVIEW_TIMEOUT:-300}}"
+REVIEW_TIMEOUT="$REVIEW_MAX_STALL_SEC"  # back-compat alias for legacy callers
 ON_ERROR="${CODEX_REVIEW_ON_ERROR:-fail-open}"
 UNSAFE_PATHS=""
 REVIEWER_CASCADE=()
@@ -611,7 +618,14 @@ if [ -f "$CONFIG_FILE" ]; then
         CONFIG_MODE="$val"
         ;;
       timeout*=*)
-        REVIEW_TIMEOUT="${CODEX_REVIEW_TIMEOUT:-$(trim "${line#*=}")}"
+        # Legacy wall-clock key, repurposed as stall threshold for back-compat.
+        # Prefer max_stall_sec in new configs.
+        REVIEW_MAX_STALL_SEC="${CODEX_REVIEW_MAX_STALL_SEC:-${CODEX_REVIEW_TIMEOUT:-$(trim "${line#*=}")}}"
+        REVIEW_TIMEOUT="$REVIEW_MAX_STALL_SEC"
+        ;;
+      max_stall_sec*=*)
+        REVIEW_MAX_STALL_SEC="${CODEX_REVIEW_MAX_STALL_SEC:-${CODEX_REVIEW_TIMEOUT:-$(trim "${line#*=}")}}"
+        REVIEW_TIMEOUT="$REVIEW_MAX_STALL_SEC"
         ;;
       on_error*=*)
         val="$(trim "${line#*=}")"
@@ -974,7 +988,11 @@ reviewer_conductor_exec() {
   if [ "$subcommand" = "exec" ]; then
     args+=(--tools "$tools")
     args+=(--sandbox "$sandbox")
-    args+=(--timeout "${CODEX_REVIEW_TIMEOUT:-300}")
+    # Event-based watchdog: kill only on actual silence, not slow progress.
+    # The legacy wall-clock --timeout caused PR #57's review to die at 300s on
+    # a real, still-progressing 837-line review. Stall semantics tolerate long
+    # thinking pauses but still catch wedged processes.
+    args+=(--max-stall-seconds "$REVIEW_MAX_STALL_SEC")
   fi
 
   # Pass the prompt via stdin. Avoids argv length limits on large diffs and


### PR DESCRIPTION
The merge reviewer was killed mid-review on PR #57 (837 lines at
effort=max) because scripts/codex-review.sh wrapped conductor exec in
a 300s wall-clock budget. The diff says directly that "real reviews
on big diffs can run 8–10 minutes" — the wall-clock was always going
to bite. Bumping the number is just picking a different arbitrary
threshold.

Switch to conductor exec's event-based --max-stall-seconds: kill the
reviewer only when it actually goes silent for the threshold, not
when total elapsed time reaches some guess. Slow-but-progressing
reviews are no longer punished.

Changes:

- scripts/codex-review.sh: line 977 now passes --max-stall-seconds
  instead of --timeout. New env var CODEX_REVIEW_MAX_STALL_SEC; the
  legacy CODEX_REVIEW_TIMEOUT is honored as a stall threshold for
  back-compat (its old wall-clock semantics are dropped — it was a
  conductor-internal contract, never a public API).

- .codex-review.toml: rename `timeout` → `max_stall_sec`. Both keys
  are accepted by the script's parser; the comment now explains the
  event-based semantics.

- CLAUDE.md: new "Delegating to codex via conductor exec" section
  documenting that codex's workspace-write sandbox blocks .git/
  writes AND outbound network. Briefs sent to codex must scope to
  code (write files, run tests); the parent agent does the git
  branch/commit/push/open-pr.sh work on the host side. PR #57's
  brief asked codex to do git, codex couldn't, and minutes were
  wasted hitting "Operation not permitted." The pattern is now
  documented so future sessions don't repeat it.

Default stall threshold remains 300s — same number, very different
meaning. 300s of pure silence from conductor exec is a strong signal
of a wedged process; 300s of total time, on a 1000-line review with
deep thinking, is just normal.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
