### PR TITLE
feat(gemini): prefer Homebrew install path on macOS (#48)

### DIFF
--- a/src/conductor/providers/gemini.py
+++ b/src/conductor/providers/gemini.py
@@ -78,7 +78,10 @@ class GeminiProvider:
 
     # One-liner shown under the failure reason in `conductor list`. The CLI's
     # first interactive run triggers OAuth; there's no separate login command.
-    fix_command = "npm install -g @google/gemini-cli  # then run `gemini` once for OAuth"
+    fix_command = (
+        "brew install gemini-cli  # macOS; then run `gemini` once for OAuth "
+        "(or npm install -g @google/gemini-cli on other platforms)"
+    )
 
     def __init__(
         self,

--- a/src/conductor/wizard.py
+++ b/src/conductor/wizard.py
@@ -116,7 +116,8 @@ _INFO: dict[str, _ProviderInfo] = {
             "`gemini` CLI with GEMINI_API_KEY or gcloud ADC."
         ),
         install_cmds=[
-            "npm install -g @google/gemini-cli",
+            "brew install gemini-cli                    # macOS",
+            "npm install -g @google/gemini-cli          # any platform",
         ],
         auth_cmds=[
             "export GEMINI_API_KEY=...                   # from aistudio.google.com",

--- a/tests/test_openrouter.py
+++ b/tests/test_openrouter.py
@@ -28,6 +28,14 @@ def configured(monkeypatch):
 @pytest.fixture
 def no_key(monkeypatch):
     monkeypatch.delenv(OPENROUTER_API_KEY_ENV, raising=False)
+    # The credential resolver falls through env → key_command → keychain;
+    # in dev environments where conductor's keychain entry exists, deleting
+    # only the env var still resolves the key. Force the resolver to return
+    # None for these unconfigured-path tests.
+    from conductor import credentials as _credentials
+    monkeypatch.setattr(
+        _credentials, "get", lambda key: None if key == OPENROUTER_API_KEY_ENV else _credentials.get(key)
+    )
 
 
 def test_configured_true_when_env_set(configured):


### PR DESCRIPTION
`brew search gemini-cli` confirms a Homebrew formula exists. Update
gemini's fix_command to lead with `brew install gemini-cli` and the
wizard's install_cmds list to show brew first, npm second.

Why: original feedback (touchstone session, 2026-04-27) hit EACCES on
/usr/local/lib/node_modules/ when following the npm path on a
system-Node setup. `brew install gemini-cli` worked first-try.

Also fixes a pre-existing test isolation bug in tests/test_openrouter.py:
the `no_key` fixture only unset the env var, but conductor's resolver
falls through env → key_command → keychain. With OPENROUTER_API_KEY
in the maintainer's keychain (a real setup just landed),
"unconfigured" tests resolved a real key and failed. The fixture now
patches conductor.credentials.get to force None for the OR key.

Closes #48.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
