### PR TITLE
fix(test-openrouter): no_key fixture recursion (caught in #61 review)

### DIFF
--- a/tests/test_openrouter.py
+++ b/tests/test_openrouter.py
@@ -33,8 +33,11 @@ def no_key(monkeypatch):
     # only the env var still resolves the key. Force the resolver to return
     # None for these unconfigured-path tests.
     from conductor import credentials as _credentials
+    _orig_get = _credentials.get
     monkeypatch.setattr(
-        _credentials, "get", lambda key: None if key == OPENROUTER_API_KEY_ENV else _credentials.get(key)
+        _credentials,
+        "get",
+        lambda key: None if key == OPENROUTER_API_KEY_ENV else _orig_get(key),
     )
 
 


### PR DESCRIPTION
The fixture's lambda referenced `_credentials.get(key)` after monkeypatch
replaced `_credentials.get` with that same lambda — infinite recursion
for any key other than OPENROUTER_API_KEY_ENV. Latent today (the tests
only ever probe the OR key, which short-circuits) but the next test
that lands and looks up a different key would hang.

Capture the original get before the setattr and reference that.

Codex flagged this in PR #61's review.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
