### PR TITLE
feat(cli): --task-file flag for safe brief delivery (#44)

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -22,6 +22,7 @@ import json
 import os
 import sys
 from dataclasses import asdict
+from pathlib import Path
 
 import click
 
@@ -57,15 +58,32 @@ VALID_EFFORT_LEVELS = ("minimal", "low", "medium", "high", "max")
 # --------------------------------------------------------------------------- #
 
 
-def _read_task(task: str | None) -> str:
+def _read_task(task: str | None, task_file: str | None) -> str:
+    if task is not None and task_file is not None:
+        raise click.UsageError(
+            "task source is ambiguous. Use exactly one of --task, --task-file, or stdin; "
+            "got --task, --task-file."
+        )
+
     if task is not None:
         body = task
+    elif task_file is not None:
+        if task_file == "-":
+            body = sys.stdin.read()
+        else:
+            try:
+                body = Path(task_file).read_text(encoding="utf-8")
+            except OSError as e:
+                raise click.UsageError(
+                    f"could not read --task-file {task_file!r}: {e.strerror or e}"
+                ) from e
     elif not sys.stdin.isatty():
         body = sys.stdin.read()
     else:
         raise click.UsageError(
-            "no task provided. Pass --task '...' or pipe content on stdin."
+            "no task provided. Pass --task '...', --task-file PATH, or pipe content on stdin."
         )
+
     body = body.strip()
     if not body:
         raise click.UsageError("task is empty after stripping whitespace.")
@@ -692,7 +710,14 @@ def main() -> None:
 @click.option(
     "--task",
     default=None,
-    help="The task / prompt. If omitted, read from stdin.",
+    help="The task / prompt. Reads stdin if omitted.\n"
+    "For long briefs, prefer --task-file or stdin to keep the prompt\n"
+    "out of `ps aux`.",
+)
+@click.option(
+    "--task-file",
+    default=None,
+    help="Read the task / prompt from a UTF-8 file. Use '-' to read stdin.",
 )
 @click.option(
     "--model",
@@ -740,6 +765,7 @@ def call(
     effort: str | None,
     exclude: str | None,
     task: str | None,
+    task_file: str | None,
     model: str | None,
     as_json: bool,
     verbose_route: bool,
@@ -766,7 +792,7 @@ def call(
             f"--with {provider_id} and --exclude {exclude} contradict each other."
         )
 
-    body = _read_task(task)
+    body = _read_task(task, task_file)
     effort_value = _parse_effort(effort)
 
     decision: RouteDecision | None = None
@@ -910,7 +936,18 @@ def call(
         "--max-stall-seconds 600 (10 minutes of silence = stalled)."
     ),
 )
-@click.option("--task", default=None, help="The task / prompt. Reads stdin if omitted.")
+@click.option(
+    "--task",
+    default=None,
+    help="The task / prompt. Reads stdin if omitted.\n"
+    "For long briefs, prefer --task-file or stdin to keep the prompt\n"
+    "out of `ps aux`.",
+)
+@click.option(
+    "--task-file",
+    default=None,
+    help="Read the task / prompt from a UTF-8 file. Use '-' to read stdin.",
+)
 @click.option("--model", default=None, help="Override the provider's default model.")
 @click.option(
     "--json",
@@ -947,6 +984,7 @@ def exec_cmd(
     timeout_sec: int | None,
     max_stall_sec: int | None,
     task: str | None,
+    task_file: str | None,
     model: str | None,
     as_json: bool,
     verbose_route: bool,
@@ -967,7 +1005,7 @@ def exec_cmd(
             "--resume requires --with <provider> (sessions are provider-specific)."
         )
 
-    body = _read_task(task)
+    body = _read_task(task, task_file)
     tools_set = _validate_tools(tools)
     sandbox_value = _validate_sandbox(sandbox)
     effort_value = _parse_effort(effort)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,6 +39,32 @@ def test_call_missing_task_and_no_stdin_errors():
     assert "task" in result.output.lower() and "empty" in result.output.lower()
 
 
+def test_call_task_file_reads_file(monkeypatch, tmp_path):
+    monkeypatch.setenv(CLOUDFLARE_API_TOKEN_ENV, "cf-test-token")
+    monkeypatch.setenv(CLOUDFLARE_ACCOUNT_ID_ENV, _TEST_ACCOUNT_ID)
+    brief = tmp_path / "brief.md"
+    brief.write_text("brief from file\n", encoding="utf-8")
+
+    with respx.mock() as router:
+        route = router.post(_CF_CHAT_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "model": KIMI_DEFAULT_MODEL,
+                    "choices": [{"message": {"content": "hello back"}}],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 2},
+                },
+            )
+        )
+        result = CliRunner().invoke(
+            main, ["call", "--with", "kimi", "--task-file", str(brief)]
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "hello back" in result.output
+    assert route.calls.last.request.content.decode("utf-8").count("brief from file") == 1
+
+
 def test_call_kimi_happy_path(monkeypatch):
     monkeypatch.setenv(CLOUDFLARE_API_TOKEN_ENV, "cf-test-token")
     monkeypatch.setenv(CLOUDFLARE_ACCOUNT_ID_ENV, _TEST_ACCOUNT_ID)

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -279,6 +279,48 @@ def test_exec_unknown_sandbox_errors_with_hint():
     assert "read-only" in result.output
 
 
+def test_exec_task_file_dash_reads_stdin(mocker):
+    _stub_all_configured(mocker, {"codex"})
+    exec_mock = mocker.patch.object(
+        CodexProvider, "exec", return_value=_fake_response("codex")
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["exec", "--with", "codex", "--task-file", "-"],
+        input="do the thing from stdin\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert exec_mock.call_args.args[0] == "do the thing from stdin"
+
+
+def test_exec_rejects_task_and_task_file_together(mocker):
+    _stub_all_configured(mocker, {"codex"})
+
+    result = CliRunner().invoke(
+        main,
+        ["exec", "--with", "codex", "--task", "hi", "--task-file", "brief.md"],
+    )
+
+    assert result.exit_code == 2
+    assert "exactly one of --task, --task-file, or stdin" in result.output
+
+
+def test_exec_missing_task_file_errors(mocker, tmp_path):
+    _stub_all_configured(mocker, {"codex"})
+    missing = tmp_path / "missing-brief.md"
+
+    result = CliRunner().invoke(
+        main,
+        ["exec", "--with", "codex", "--task-file", str(missing)],
+    )
+
+    assert result.exit_code == 2
+    assert "could not read --task-file" in result.output
+    assert str(missing) in result.output
+
+
 def test_exec_cli_default_passes_no_timeout_to_provider(mocker):
     """`conductor exec --with codex --task ...` (no --timeout) must hand
     the provider `timeout_sec=None` so subprocess.run runs unbounded.


### PR DESCRIPTION
Today users default to `--task "$(cat brief.md)"` because that's the
natural shape, which exposes the brief to `ps aux`. The stdin path
solves it but is undiscoverable. Add a first-class `--task-file <path>`
flag so the safe path is the discoverable path.

Behavior:

- `--task-file <path>` reads UTF-8 contents and uses them as the task
- `--task-file -` is the explicit stdin form (alias for omitting both)
- `--task` and `--task-file` together raise UsageError
- `--task` help text updated: "for long briefs, prefer --task-file
  or stdin to keep the prompt out of `ps aux`"

No changes to existing `--task` or stdin behavior — pure addition.

Closes #44.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
