### PR TITLE
feat(openrouter): catalog client + selector + models CLI (PR 2 of 4)

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -26,13 +26,16 @@ from pathlib import Path
 
 import click
 
+import conductor.providers.openrouter_catalog as openrouter_catalog
 from conductor import __version__, credentials, offline_mode
 from conductor.banner import print_caller_banner
 from conductor.providers import (
     QUALITY_TIERS,
     CallResponse,
+    OpenRouterProvider,
     ProviderConfigError,
     ProviderError,
+    ProviderHTTPError,
     UnsupportedCapability,
     get_provider,
     known_providers,
@@ -447,24 +450,51 @@ def _invoke_with_fallback(
         provider = get_provider(candidate.name)
         try:
             if mode == "exec":
-                response = provider.exec(
-                    task,
-                    model=model,
-                    effort=effort,
-                    tools=tools,
-                    sandbox=sandbox,
-                    cwd=cwd,
-                    timeout_sec=timeout_sec,
-                    max_stall_sec=max_stall_sec,
-                    resume_session_id=resume_session_id,
-                )
+                if isinstance(provider, OpenRouterProvider):
+                    response = provider.exec(
+                        task,
+                        model=model,
+                        effort=effort,
+                        task_tags=list(decision.task_tags),
+                        prefer=decision.prefer,
+                        log_selection=not silent,
+                        tools=tools,
+                        sandbox=sandbox,
+                        cwd=cwd,
+                        timeout_sec=timeout_sec,
+                        max_stall_sec=max_stall_sec,
+                        resume_session_id=resume_session_id,
+                    )
+                else:
+                    response = provider.exec(
+                        task,
+                        model=model,
+                        effort=effort,
+                        tools=tools,
+                        sandbox=sandbox,
+                        cwd=cwd,
+                        timeout_sec=timeout_sec,
+                        max_stall_sec=max_stall_sec,
+                        resume_session_id=resume_session_id,
+                    )
             else:
-                response = provider.call(
-                    task,
-                    model=model,
-                    effort=effort,
-                    resume_session_id=resume_session_id,
-                )
+                if isinstance(provider, OpenRouterProvider):
+                    response = provider.call(
+                        task,
+                        model=model,
+                        effort=effort,
+                        task_tags=list(decision.task_tags),
+                        prefer=decision.prefer,
+                        log_selection=not silent,
+                        resume_session_id=resume_session_id,
+                    )
+                else:
+                    response = provider.call(
+                        task,
+                        model=model,
+                        effort=effort,
+                        resume_session_id=resume_session_id,
+                    )
             mark_outcome(candidate.name, "success")
             return response, fallbacks
         except ProviderConfigError:
@@ -658,6 +688,29 @@ def _emit_usage_log(response: CallResponse, *, silent: bool) -> None:
     click.echo(_format_usage_line(response), err=True)
 
 
+def _openrouter_catalog_or_exit() -> openrouter_catalog.CatalogSnapshot:
+    try:
+        snapshot = openrouter_catalog.read_cached_catalog()
+    except ProviderHTTPError as e:
+        raise click.ClickException(str(e)) from e
+    if snapshot is None:
+        raise click.ClickException(
+            "OpenRouter catalog cache not found. Run `conductor models refresh` first."
+        )
+    return snapshot
+
+
+def _model_capabilities(model: openrouter_catalog.ModelEntry) -> str:
+    caps = []
+    if model.supports_thinking:
+        caps.append("thinking")
+    if model.supports_tools:
+        caps.append("tools")
+    if model.supports_vision:
+        caps.append("vision")
+    return ",".join(caps) or "-"
+
+
 @click.group()
 @click.version_option(__version__, prog_name="conductor")
 def main() -> None:
@@ -676,7 +729,7 @@ def main() -> None:
     default=None,
     help=(
         "Provider identifier "
-        "(kimi, claude, codex, deepseek-chat, deepseek-reasoner, gemini, ollama). "
+        "(kimi, claude, codex, deepseek-chat, deepseek-reasoner, gemini, ollama, openrouter). "
         "Mutually exclusive with --auto."
     ),
 )
@@ -832,7 +885,7 @@ def call(
             click.echo(f"conductor: {e}", err=True)
             sys.exit(1)
     else:
-        if prefer is not None:
+        if prefer is not None and provider_id != "openrouter":
             raise click.UsageError("--prefer is only meaningful with --auto.")
         # Earlier guard `if not auto and not provider_id: raise` makes this
         # narrowing safe; the assert documents it for mypy and future readers.
@@ -843,12 +896,23 @@ def call(
             raise click.UsageError(str(e)) from e
         print_caller_banner(provider_id, silent=silent_route or as_json)
         try:
-            response = provider.call(
-                body,
-                model=model,
-                effort=effort_value,
-                resume_session_id=resume_session_id,
-            )
+            if isinstance(provider, OpenRouterProvider):
+                response = provider.call(
+                    body,
+                    model=model,
+                    effort=effort_value,
+                    task_tags=_parse_csv(tags),
+                    prefer=_validate_prefer(prefer),
+                    log_selection=not (silent_route or as_json),
+                    resume_session_id=resume_session_id,
+                )
+            else:
+                response = provider.call(
+                    body,
+                    model=model,
+                    effort=effort_value,
+                    resume_session_id=resume_session_id,
+                )
         except ProviderConfigError as e:
             click.echo(f"conductor: {e}", err=True)
             sys.exit(2)
@@ -1052,6 +1116,8 @@ def exec_cmd(
             click.echo(f"conductor: {e}", err=True)
             sys.exit(1)
     else:
+        if prefer is not None and provider_id != "openrouter":
+            raise click.UsageError("--prefer is only meaningful with --auto.")
         # Same narrowing as in `call()` — the early guard rejects the case
         # where neither --auto nor --with was passed.
         assert provider_id is not None
@@ -1061,17 +1127,33 @@ def exec_cmd(
             raise click.UsageError(str(e)) from e
         print_caller_banner(provider_id, silent=silent_route or as_json)
         try:
-            response = provider.exec(
-                body,
-                model=model,
-                effort=effort_value,
-                tools=tools_set,
-                sandbox=sandbox_value,
-                cwd=cwd,
-                timeout_sec=timeout_sec,
-                max_stall_sec=max_stall_sec,
-                resume_session_id=resume_session_id,
-            )
+            if isinstance(provider, OpenRouterProvider):
+                response = provider.exec(
+                    body,
+                    model=model,
+                    effort=effort_value,
+                    task_tags=_parse_csv(tags),
+                    prefer=_validate_prefer(prefer),
+                    log_selection=not (silent_route or as_json),
+                    tools=tools_set,
+                    sandbox=sandbox_value,
+                    cwd=cwd,
+                    timeout_sec=timeout_sec,
+                    max_stall_sec=max_stall_sec,
+                    resume_session_id=resume_session_id,
+                )
+            else:
+                response = provider.exec(
+                    body,
+                    model=model,
+                    effort=effort_value,
+                    tools=tools_set,
+                    sandbox=sandbox_value,
+                    cwd=cwd,
+                    timeout_sec=timeout_sec,
+                    max_stall_sec=max_stall_sec,
+                    resume_session_id=resume_session_id,
+                )
         except UnsupportedCapability as e:
             click.echo(f"conductor: {e}", err=True)
             sys.exit(2)
@@ -1767,6 +1849,100 @@ def _run_unwire() -> int:
         for path, reason in report.skipped:
             click.echo(f"  {path}  — {reason}")
     return 0
+
+
+# --------------------------------------------------------------------------- #
+# models — inspect and refresh the OpenRouter catalog cache
+# --------------------------------------------------------------------------- #
+
+
+@main.group()
+def models() -> None:
+    """Inspect and refresh the cached OpenRouter model catalog."""
+
+
+@models.command("refresh")
+def models_refresh() -> None:
+    """Fetch the live OpenRouter catalog and rewrite the local cache."""
+    try:
+        snapshot = openrouter_catalog.load_catalog_snapshot(force_refresh=True)
+    except ProviderHTTPError as e:
+        raise click.ClickException(str(e)) from e
+
+    click.echo(
+        f"Refreshed OpenRouter catalog at "
+        f"{openrouter_catalog.format_timestamp(snapshot.fetched_at)}"
+    )
+    click.echo(
+        f"  {len(snapshot.models)} models · cache TTL "
+        f"{openrouter_catalog.cache_ttl_hours()}h · written to "
+        f"{openrouter_catalog.display_cache_path()}"
+    )
+
+
+@models.command("list")
+def models_list() -> None:
+    """Print the cached OpenRouter catalog summary."""
+    snapshot = _openrouter_catalog_or_exit()
+    click.echo(
+        f"{len(snapshot.models)} models indexed, last refresh: "
+        f"{openrouter_catalog.format_timestamp(snapshot.fetched_at)}"
+    )
+    click.echo(
+        f"  cache TTL {openrouter_catalog.cache_ttl_hours()}h · "
+        f"cache file {openrouter_catalog.display_cache_path()}"
+    )
+    click.echo("")
+
+    sorted_models = sorted(snapshot.models, key=lambda model: model.id)
+    id_w = max(len("MODEL"), max(len(model.id) for model in sorted_models))
+    ctx_w = max(len("CTX"), max(len(f"{model.context_length:,}") for model in sorted_models))
+    header = (
+        f"{'MODEL':<{id_w}}  {'CTX':>{ctx_w}}  {'IN/1K':>10}  "
+        f"{'OUT/1K':>10}  CAPS"
+    )
+    click.echo(header)
+    click.echo("-" * len(header))
+    for model in sorted_models:
+        click.echo(
+            f"{model.id:<{id_w}}  "
+            f"{model.context_length:>{ctx_w},}  "
+            f"{model.pricing_prompt:>10.6f}  "
+            f"{model.pricing_completion:>10.6f}  "
+            f"{_model_capabilities(model)}"
+        )
+
+
+@models.command("show")
+@click.argument("slug")
+def models_show(slug: str) -> None:
+    """Print one cached OpenRouter model's parsed details."""
+    snapshot = _openrouter_catalog_or_exit()
+    model = next((entry for entry in snapshot.models if entry.id == slug), None)
+    if model is None:
+        raise click.ClickException(
+            f"OpenRouter model {slug!r} was not found in the local cache. "
+            "Run `conductor models refresh`."
+        )
+
+    thinking_price = (
+        "n/a"
+        if model.pricing_thinking is None
+        else f"{model.pricing_thinking:.6f} USD / 1k"
+    )
+    click.echo(model.id)
+    click.echo(f"  name: {model.name}")
+    click.echo(f"  created: {openrouter_catalog.format_timestamp(model.created)}")
+    click.echo(f"  context length: {model.context_length:,}")
+    click.echo(f"  prompt price: {model.pricing_prompt:.6f} USD / 1k")
+    click.echo(f"  completion price: {model.pricing_completion:.6f} USD / 1k")
+    click.echo(f"  thinking price: {thinking_price}")
+    click.echo(
+        "  capabilities: "
+        f"thinking={'yes' if model.supports_thinking else 'no'} · "
+        f"tools={'yes' if model.supports_tools else 'no'} · "
+        f"vision={'yes' if model.supports_vision else 'no'}"
+    )
 
 
 # --------------------------------------------------------------------------- #

--- a/src/conductor/providers/openrouter.py
+++ b/src/conductor/providers/openrouter.py
@@ -8,6 +8,7 @@ the follow-up migration PRs.
 
 from __future__ import annotations
 
+import sys
 import time
 
 import httpx
@@ -16,10 +17,13 @@ from conductor import credentials
 from conductor.providers.interface import (
     CallResponse,
     ProviderConfigError,
+    ProviderError,
     ProviderHTTPError,
     UnsupportedCapability,
     resolve_effort_tokens,
 )
+
+from . import openrouter_catalog
 
 OPENROUTER_API_KEY_ENV = "OPENROUTER_API_KEY"
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
@@ -98,12 +102,7 @@ class OpenRouterProvider:
         }
 
     def _reasoning_payload(self, effort: str | int) -> dict[str, str] | None:
-        if not isinstance(effort, str):
-            return None
-        mapped = _OPENROUTER_REASONING_EFFORTS.get(effort)
-        if mapped is None:
-            return None
-        return {"effort": mapped}
+        return _reasoning_payload(effort)
 
     def configured(self) -> tuple[bool, str | None]:
         if self._api_key or credentials.get(OPENROUTER_API_KEY_ENV):
@@ -156,6 +155,10 @@ class OpenRouterProvider:
         model: str | None = None,
         *,
         effort: str | int = "medium",
+        task_tags: list[str] | tuple[str, ...] | None = None,
+        prefer: str = "balanced",
+        exclude: set[str] | frozenset[str] | None = None,
+        log_selection: bool = True,
         resume_session_id: str | None = None,
     ) -> CallResponse:
         if resume_session_id:
@@ -164,15 +167,37 @@ class OpenRouterProvider:
                 "stateless. To replay context, prepend the prior turns to `task`."
             )
 
-        model = model or self.default_model
+        # Fail on missing credentials before any selector/catalog work so an
+        # unconfigured provider doesn't mask the real setup error behind a
+        # catalog refresh failure.
+        self._resolve_key()
         thinking_budget = resolve_effort_tokens(effort, self.effort_to_thinking)
         payload: dict = {
-            "model": model,
             "messages": [{"role": "user", "content": task}],
         }
-        reasoning = self._reasoning_payload(effort)
-        if reasoning is not None:
-            payload["reasoning"] = reasoning
+        selected_model = model
+        if selected_model is None:
+            selector_payload = select_model_for_task(
+                task_tags=task_tags,
+                prefer=prefer,
+                effort=effort,
+                exclude=exclude,
+            )
+            payload.update(selector_payload)
+            selected_model = str(payload["model"])
+            if payload.get("reasoning") is None:
+                payload.pop("reasoning", None)
+            if log_selection:
+                _log_selector_choice(
+                    task_tags=task_tags,
+                    prefer=prefer,
+                    payload=selector_payload,
+                )
+        else:
+            payload["model"] = selected_model
+            reasoning = self._reasoning_payload(effort)
+            if reasoning is not None:
+                payload["reasoning"] = reasoning
 
         start = time.monotonic()
         body = self._post_chat(payload)
@@ -189,7 +214,7 @@ class OpenRouterProvider:
         return CallResponse(
             text=text,
             provider=self.name,
-            model=body.get("model", model),
+            model=body.get("model", selected_model),
             duration_ms=duration_ms,
             usage={
                 "input_tokens": usage.get("prompt_tokens"),
@@ -212,6 +237,10 @@ class OpenRouterProvider:
         model: str | None = None,
         *,
         effort: str | int = "medium",
+        task_tags: list[str] | tuple[str, ...] | None = None,
+        prefer: str = "balanced",
+        exclude: set[str] | frozenset[str] | None = None,
+        log_selection: bool = True,
         tools: frozenset[str] = frozenset(),
         sandbox: str = "none",
         cwd: str | None = None,
@@ -239,4 +268,112 @@ class OpenRouterProvider:
                 f"{self.name}.exec() sandbox={sandbox!r} is not meaningful "
                 "without tools. Use sandbox='none' for a text-only exec."
             )
-        return self.call(task, model=model, effort=effort)
+        return self.call(
+            task,
+            model=model,
+            effort=effort,
+            task_tags=task_tags,
+            prefer=prefer,
+            exclude=exclude,
+            log_selection=log_selection,
+        )
+
+
+def select_model_for_task(
+    task_tags: list[str] | tuple[str, ...] | None,
+    prefer: str,
+    effort: str | int,
+    exclude: set[str] | frozenset[str] | None = None,
+) -> dict[str, object]:
+    """Select an OpenRouter model from the live catalog.
+
+    `prefer=fastest` currently uses price as a latency proxy because the public
+    catalog has no latency field. Cheaper models tend to be smaller and faster;
+    a future version can swap in measured latency when a reliable source exists.
+    """
+    if prefer not in {"best", "balanced", "cheapest", "fastest"}:
+        raise ProviderError(
+            f"OpenRouter selector got unsupported prefer={prefer!r}. "
+            "Use best, balanced, cheapest, or fastest."
+        )
+
+    task_tag_set = set(task_tags or [])
+    exclude_set = set(exclude or ())
+    candidates = []
+    for entry in openrouter_catalog.load_catalog():
+        if entry.id in exclude_set:
+            continue
+        if {"strong-reasoning", "thinking"} & task_tag_set and not entry.supports_thinking:
+            continue
+        if "tool-use" in task_tag_set and not entry.supports_tools:
+            continue
+        if "vision" in task_tag_set and not entry.supports_vision:
+            continue
+        if "long-context" in task_tag_set and entry.context_length < 100_000:
+            continue
+        candidates.append(entry)
+
+    if not candidates:
+        raise ProviderError(
+            "OpenRouter selector found no models matching "
+            f"tags={sorted(task_tag_set)} exclude={sorted(exclude_set)}. "
+            "Run `conductor models refresh` or choose `--model` explicitly."
+        )
+
+    ranked = sorted(candidates, key=_catalog_cost_sort_key)
+    if prefer in {"cheapest", "fastest"}:
+        return {"model": ranked[0].id, "reasoning": None}
+
+    shortlist = sorted(candidates, key=_catalog_recency_sort_key)[:6]
+    return {
+        "model": OPENROUTER_DEFAULT_MODEL,
+        "plugins": [
+            {
+                "id": "auto-router",
+                "allowed_models": [entry.id for entry in shortlist],
+            }
+        ],
+        "reasoning": _reasoning_payload(effort),
+    }
+
+
+def _catalog_cost_sort_key(entry: openrouter_catalog.ModelEntry) -> tuple[float, int, str]:
+    return (entry.total_price_per_1k, -entry.created, entry.id)
+
+
+def _catalog_recency_sort_key(
+    entry: openrouter_catalog.ModelEntry,
+) -> tuple[int, float, str]:
+    return (-entry.created, entry.total_price_per_1k, entry.id)
+
+
+def _reasoning_payload(effort: str | int) -> dict[str, str] | None:
+    if not isinstance(effort, str):
+        return None
+    mapped = _OPENROUTER_REASONING_EFFORTS.get(effort)
+    if mapped is None:
+        return None
+    return {"effort": mapped}
+
+
+def _log_selector_choice(
+    *,
+    task_tags: list[str] | tuple[str, ...] | None,
+    prefer: str,
+    payload: dict[str, object],
+) -> None:
+    tags_text = ",".join(task_tags or []) or "none"
+    if payload["model"] == OPENROUTER_DEFAULT_MODEL:
+        plugins = payload.get("plugins") or []
+        shortlist = []
+        if plugins and isinstance(plugins, list):
+            first = plugins[0]
+            if isinstance(first, dict):
+                shortlist = list(first.get("allowed_models") or [])
+        target = f"auto shortlist={shortlist}"
+    else:
+        target = f"model={payload['model']}"
+    sys.stderr.write(
+        f"[conductor] openrouter selector: tags={tags_text} prefer={prefer} -> {target}\n"
+    )
+    sys.stderr.flush()

--- a/src/conductor/providers/openrouter_catalog.py
+++ b/src/conductor/providers/openrouter_catalog.py
@@ -1,0 +1,275 @@
+"""OpenRouter model catalog — fetch, parse, and cache the live model list.
+
+The catalog is derived state. We persist it only as a time-bounded cache so
+selection can run without hard-coded model slugs and without an HTTP round-trip
+ on every call. `conductor models refresh` is the explicit rebuild path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from conductor.providers.interface import ProviderHTTPError
+
+OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
+OPENROUTER_CATALOG_TIMEOUT_SEC = 30.0
+DEFAULT_CATALOG_TTL_HOURS = 24
+CONDUCTOR_CATALOG_TTL_HOURS_ENV = "CONDUCTOR_CATALOG_TTL_HOURS"
+OPENROUTER_CATALOG_CACHE_PATH = (
+    Path.home() / ".cache" / "conductor" / "openrouter-catalog.json"
+)
+
+
+@dataclass(frozen=True)
+class ModelEntry:
+    id: str
+    name: str
+    created: int
+    context_length: int
+    pricing_prompt: float
+    pricing_completion: float
+    pricing_thinking: float | None
+    supports_thinking: bool
+    supports_tools: bool
+    supports_vision: bool
+
+    @property
+    def total_price_per_1k(self) -> float:
+        return self.pricing_prompt + self.pricing_completion
+
+
+@dataclass(frozen=True)
+class CatalogSnapshot:
+    fetched_at: int
+    models: list[ModelEntry]
+
+
+def cache_path() -> Path:
+    return OPENROUTER_CATALOG_CACHE_PATH
+
+
+def cache_ttl_hours() -> int:
+    raw = os.environ.get(CONDUCTOR_CATALOG_TTL_HOURS_ENV)
+    if raw:
+        try:
+            ttl = int(raw)
+            if ttl > 0:
+                return ttl
+        except ValueError:
+            pass
+    return DEFAULT_CATALOG_TTL_HOURS
+
+
+def format_timestamp(timestamp: int) -> str:
+    return datetime.fromtimestamp(timestamp, UTC).isoformat().replace("+00:00", "Z")
+
+
+def display_cache_path(path: Path | None = None) -> str:
+    target = path or cache_path()
+    home = Path.home()
+    try:
+        return f"~/{target.relative_to(home)}"
+    except ValueError:
+        return str(target)
+
+
+def read_cached_catalog() -> CatalogSnapshot | None:
+    path = cache_path()
+    try:
+        raw = path.read_text()
+    except FileNotFoundError:
+        return None
+    except OSError as e:
+        raise ProviderHTTPError(
+            f"failed reading OpenRouter catalog cache {path}: {e}"
+        ) from e
+
+    try:
+        payload = json.loads(raw)
+    except ValueError as e:
+        raise ProviderHTTPError(
+            f"OpenRouter catalog cache {path} was not valid JSON: {e}"
+        ) from e
+
+    try:
+        fetched_at = int(payload["fetched_at"])
+        models = [_model_entry_from_cache(item) for item in payload["models"]]
+    except (KeyError, TypeError, ValueError) as e:
+        raise ProviderHTTPError(
+            f"OpenRouter catalog cache {path} had an invalid schema: {e}"
+        ) from e
+
+    return CatalogSnapshot(fetched_at=fetched_at, models=models)
+
+
+def load_catalog(force_refresh: bool = False) -> list[ModelEntry]:
+    return load_catalog_snapshot(force_refresh=force_refresh).models
+
+
+def load_catalog_snapshot(force_refresh: bool = False) -> CatalogSnapshot:
+    cached = _read_cached_catalog_for_load()
+    if cached is not None and not force_refresh and _is_fresh(cached):
+        return cached
+
+    try:
+        fresh = _fetch_catalog()
+        _write_cache(fresh)
+        return fresh
+    except ProviderHTTPError as e:
+        if cached is None:
+            raise
+        print(
+            "[conductor] OpenRouter catalog refresh failed; "
+            f"using stale cache from {format_timestamp(cached.fetched_at)}: {e}",
+            file=sys.stderr,
+        )
+        return cached
+
+
+def _read_cached_catalog_for_load() -> CatalogSnapshot | None:
+    try:
+        return read_cached_catalog()
+    except ProviderHTTPError as e:
+        print(
+            f"[conductor] ignoring invalid OpenRouter catalog cache: {e}",
+            file=sys.stderr,
+        )
+        return None
+
+
+def _is_fresh(snapshot: CatalogSnapshot) -> bool:
+    age_sec = max(0, time.time() - snapshot.fetched_at)
+    return age_sec < cache_ttl_hours() * 3600
+
+
+def _fetch_catalog() -> CatalogSnapshot:
+    try:
+        with httpx.Client(timeout=OPENROUTER_CATALOG_TIMEOUT_SEC) as client:
+            response = client.get(OPENROUTER_MODELS_URL)
+    except httpx.HTTPError as e:
+        raise ProviderHTTPError(
+            f"network error refreshing OpenRouter catalog: {e}"
+        ) from e
+
+    if response.status_code != 200:
+        raise ProviderHTTPError(
+            "OpenRouter catalog refresh returned "
+            f"HTTP {response.status_code}: {response.text[:500]}"
+        )
+
+    try:
+        body = response.json()
+    except ValueError as e:
+        raise ProviderHTTPError(
+            f"OpenRouter catalog response was not JSON: {e}"
+        ) from e
+
+    try:
+        models = [_parse_model_entry(entry) for entry in body["data"]]
+    except (KeyError, TypeError, ValueError) as e:
+        raise ProviderHTTPError(
+            f"OpenRouter catalog response had an unexpected schema: {e}"
+        ) from e
+
+    return CatalogSnapshot(fetched_at=int(time.time()), models=models)
+
+
+def _write_cache(snapshot: CatalogSnapshot) -> None:
+    path = cache_path()
+    payload = {
+        "fetched_at": snapshot.fetched_at,
+        "models": [asdict(model) for model in snapshot.models],
+    }
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    except OSError as e:
+        raise ProviderHTTPError(
+            f"failed writing OpenRouter catalog cache {path}: {e}"
+        ) from e
+
+
+def _model_entry_from_cache(raw: dict[str, Any]) -> ModelEntry:
+    return ModelEntry(
+        id=str(raw["id"]),
+        name=str(raw["name"]),
+        created=int(raw["created"]),
+        context_length=int(raw["context_length"]),
+        pricing_prompt=float(raw["pricing_prompt"]),
+        pricing_completion=float(raw["pricing_completion"]),
+        pricing_thinking=(
+            None if raw["pricing_thinking"] is None else float(raw["pricing_thinking"])
+        ),
+        supports_thinking=bool(raw["supports_thinking"]),
+        supports_tools=bool(raw["supports_tools"]),
+        supports_vision=bool(raw["supports_vision"]),
+    )
+
+
+def _parse_model_entry(raw: dict[str, Any]) -> ModelEntry:
+    supported_parameters = _supported_parameters(raw.get("supported_parameters"))
+    architecture = raw.get("architecture") or {}
+    pricing = raw.get("pricing") or {}
+
+    return ModelEntry(
+        id=str(raw["id"]),
+        name=str(raw.get("name") or raw["id"]),
+        created=int(raw["created"]),
+        context_length=int(raw["context_length"]),
+        pricing_prompt=_price_per_1k(pricing["prompt"]),
+        pricing_completion=_price_per_1k(pricing["completion"]),
+        pricing_thinking=(
+            None
+            if pricing.get("reasoning") is None
+            else _price_per_1k(pricing["reasoning"])
+        ),
+        supports_thinking=bool(
+            {"reasoning", "reasoning_effort"} & supported_parameters
+        ),
+        supports_tools="tools" in supported_parameters,
+        supports_vision=_supports_vision(architecture),
+    )
+
+
+def _supported_parameters(raw: Any) -> set[str]:
+    if not isinstance(raw, list):
+        return set()
+
+    normalized: set[str] = set()
+    for item in raw:
+        if isinstance(item, str):
+            normalized.add(item.strip().lower())
+            continue
+        if isinstance(item, dict):
+            for key in ("name", "id", "parameter"):
+                value = item.get(key)
+                if isinstance(value, str) and value.strip():
+                    normalized.add(value.strip().lower())
+                    break
+    return normalized
+
+
+def _supports_vision(architecture: Any) -> bool:
+    if not isinstance(architecture, dict):
+        return False
+
+    modality = architecture.get("modality")
+    if isinstance(modality, str):
+        left_hand = modality.split("->", 1)[0].lower()
+        return "image" in left_hand
+    if isinstance(modality, list):
+        return any(isinstance(item, str) and "image" in item.lower() for item in modality)
+    return False
+
+
+def _price_per_1k(raw: Any) -> float:
+    return float(raw) * 1000.0

--- a/src/conductor/router.py
+++ b/src/conductor/router.py
@@ -48,7 +48,6 @@ from conductor.providers import (
 # Priority (v0.1 carry-over, tiebreak only).
 # --------------------------------------------------------------------------- #
 DEFAULT_PRIORITY: tuple[str, ...] = ("kimi", "claude", "mistral", "codex", "gemini", "ollama")
-_AUTO_ROUTING_DISABLED: frozenset[str] = frozenset({"openrouter"})
 
 PreferMode = Literal["best", "cheapest", "fastest", "balanced"]
 VALID_PREFER_MODES: tuple[str, ...] = ("best", "cheapest", "fastest", "balanced")
@@ -306,7 +305,7 @@ def pick(
         )
 
     # Deterministic provider iteration order: priority first, then alphabetical.
-    routed_names = set(known_providers()) - _AUTO_ROUTING_DISABLED
+    routed_names = set(known_providers())
     order = [p for p in priority if p in routed_names]
     order += sorted(routed_names - set(order))
     priority_index = {name: i for i, name in enumerate(order)}

--- a/tests/test_cli_auto.py
+++ b/tests/test_cli_auto.py
@@ -26,9 +26,16 @@ def _stub_only_kimi_configured(mocker):
         CodexProvider,
         GeminiProvider,
         OllamaProvider,
+        OpenRouterProvider,
     )
 
-    for cls in (ClaudeProvider, CodexProvider, GeminiProvider, OllamaProvider):
+    for cls in (
+        ClaudeProvider,
+        CodexProvider,
+        GeminiProvider,
+        OllamaProvider,
+        OpenRouterProvider,
+    ):
         mocker.patch.object(cls, "configured", lambda self: (False, "stubbed off"))
 
 
@@ -108,6 +115,7 @@ def test_call_auto_with_no_configured_providers_exits_2(mocker):
         GeminiProvider,
         KimiProvider,
         OllamaProvider,
+        OpenRouterProvider,
     )
 
     for cls in (
@@ -116,6 +124,7 @@ def test_call_auto_with_no_configured_providers_exits_2(mocker):
         GeminiProvider,
         KimiProvider,
         OllamaProvider,
+        OpenRouterProvider,
     ):
         mocker.patch.object(cls, "configured", lambda self: (False, "nope"))
 
@@ -144,6 +153,8 @@ def test_call_auto_emits_shadow_hint_when_unconfigured_outranks(monkeypatch, moc
         OllamaProvider,
     )
 
+    from conductor.providers import OpenRouterProvider
+
     mocker.patch.object(ClaudeProvider, "configured", lambda self: (False, "nope"))
     mocker.patch.object(
         CodexProvider,
@@ -152,6 +163,7 @@ def test_call_auto_emits_shadow_hint_when_unconfigured_outranks(monkeypatch, moc
     )
     mocker.patch.object(GeminiProvider, "configured", lambda self: (False, "nope"))
     mocker.patch.object(OllamaProvider, "configured", lambda self: (False, "nope"))
+    mocker.patch.object(OpenRouterProvider, "configured", lambda self: (False, "nope"))
     monkeypatch.setenv(CLOUDFLARE_API_TOKEN_ENV, "cf-test-token")
     monkeypatch.setenv(CLOUDFLARE_ACCOUNT_ID_ENV, _TEST_ACCOUNT_ID)
 
@@ -248,6 +260,8 @@ def test_call_auto_silent_route_suppresses_shadow_hint(monkeypatch, mocker):
         OllamaProvider,
     )
 
+    from conductor.providers import OpenRouterProvider
+
     mocker.patch.object(ClaudeProvider, "configured", lambda self: (False, "nope"))
     mocker.patch.object(
         CodexProvider,
@@ -256,6 +270,7 @@ def test_call_auto_silent_route_suppresses_shadow_hint(monkeypatch, mocker):
     )
     mocker.patch.object(GeminiProvider, "configured", lambda self: (False, "nope"))
     mocker.patch.object(OllamaProvider, "configured", lambda self: (False, "nope"))
+    mocker.patch.object(OpenRouterProvider, "configured", lambda self: (False, "nope"))
     monkeypatch.setenv(CLOUDFLARE_API_TOKEN_ENV, "cf-test-token")
     monkeypatch.setenv(CLOUDFLARE_ACCOUNT_ID_ENV, _TEST_ACCOUNT_ID)
 

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -1,0 +1,110 @@
+"""Smoke tests for `conductor models ...` commands."""
+
+from __future__ import annotations
+
+import httpx
+import respx
+from click.testing import CliRunner
+
+import conductor.providers.openrouter_catalog as openrouter_catalog
+from conductor.cli import main
+
+
+def _patch_catalog_cache(monkeypatch, tmp_path):
+    path = tmp_path / "openrouter-catalog.json"
+    monkeypatch.setattr(openrouter_catalog, "OPENROUTER_CATALOG_CACHE_PATH", path)
+    return path
+
+
+def _catalog_response() -> dict:
+    return {
+        "data": [
+            {
+                "id": "anthropic/claude-sonnet-4.6",
+                "name": "Claude Sonnet 4.6",
+                "created": 1_710_000_000,
+                "context_length": 200_000,
+                "pricing": {
+                    "prompt": "0.000003",
+                    "completion": "0.000015",
+                    "reasoning": "0.000004",
+                },
+                "supported_parameters": ["reasoning", "tools"],
+                "architecture": {"modality": "text+image->text"},
+            },
+            {
+                "id": "google/gemini-flash-1.5",
+                "name": "Gemini Flash 1.5",
+                "created": 1_709_000_000,
+                "context_length": 64_000,
+                "pricing": {
+                    "prompt": "0.0000003",
+                    "completion": "0.0000012",
+                },
+                "supported_parameters": [],
+                "architecture": {"modality": "text->text"},
+            },
+        ]
+    }
+
+
+def test_models_refresh_fetches_and_prints_summary(monkeypatch, tmp_path):
+    cache_path = _patch_catalog_cache(monkeypatch, tmp_path)
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.get("/models").mock(
+            return_value=httpx.Response(200, json=_catalog_response())
+        )
+        result = CliRunner().invoke(main, ["models", "refresh"])
+
+    assert result.exit_code == 0, result.output
+    assert "Refreshed OpenRouter catalog at" in result.output
+    assert "2 models" in result.output
+    assert cache_path.exists()
+
+
+def test_models_list_reads_cached_catalog(monkeypatch, tmp_path):
+    _patch_catalog_cache(monkeypatch, tmp_path)
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.get("/models").mock(
+            return_value=httpx.Response(200, json=_catalog_response())
+        )
+        refresh = CliRunner().invoke(main, ["models", "refresh"])
+    assert refresh.exit_code == 0, refresh.output
+
+    result = CliRunner().invoke(main, ["models", "list"])
+
+    assert result.exit_code == 0, result.output
+    assert "models indexed, last refresh:" in result.output
+    assert "anthropic/claude-sonnet-4.6" in result.output
+    assert "google/gemini-flash-1.5" in result.output
+
+
+def test_models_show_prints_one_model(monkeypatch, tmp_path):
+    _patch_catalog_cache(monkeypatch, tmp_path)
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.get("/models").mock(
+            return_value=httpx.Response(200, json=_catalog_response())
+        )
+        refresh = CliRunner().invoke(main, ["models", "refresh"])
+    assert refresh.exit_code == 0, refresh.output
+
+    result = CliRunner().invoke(
+        main, ["models", "show", "anthropic/claude-sonnet-4.6"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Claude Sonnet 4.6" in result.output
+    assert "context length: 200,000" in result.output
+    assert "thinking=yes" in result.output
+
+
+def test_models_list_errors_when_cache_is_missing(monkeypatch, tmp_path):
+    _patch_catalog_cache(monkeypatch, tmp_path)
+
+    result = CliRunner().invoke(main, ["models", "list"])
+
+    assert result.exit_code != 0
+    assert "Run `conductor models refresh` first" in result.output

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -15,7 +15,9 @@ from __future__ import annotations
 
 import json
 
+import httpx
 import pytest
+import respx
 from click.testing import CliRunner
 
 from conductor.cli import main
@@ -26,6 +28,7 @@ from conductor.providers import (
     GeminiProvider,
     KimiProvider,
     OllamaProvider,
+    OpenRouterProvider,
 )
 from conductor.router import reset_health
 
@@ -45,6 +48,7 @@ def _stub_all_configured(mocker, configured_names: set[str]) -> None:
         "codex": CodexProvider,
         "gemini": GeminiProvider,
         "ollama": OllamaProvider,
+        "openrouter": OpenRouterProvider,
     }
     for name, cls in classes.items():
         ok = name in configured_names
@@ -227,6 +231,68 @@ def test_call_verbose_route_prints_full_ranking(mocker):
     assert "1. claude" in result.stderr
     assert "codex" in result.stderr
     assert "ollama" in result.stderr
+
+
+def test_call_auto_can_route_to_openrouter_and_shortlist_cheap_models(
+    mocker, monkeypatch
+):
+    import conductor.providers.openrouter_catalog as openrouter_catalog
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+    _stub_all_configured(mocker, {"claude", "openrouter"})
+    mocker.patch(
+        "conductor.providers.openrouter_catalog.load_catalog",
+        return_value=[
+            openrouter_catalog.ModelEntry(
+                id="cheap/newest",
+                name="Cheap Newest",
+                created=500,
+                context_length=64_000,
+                pricing_prompt=0.001,
+                pricing_completion=0.001,
+                pricing_thinking=None,
+                supports_thinking=False,
+                supports_tools=False,
+                supports_vision=False,
+            ),
+            openrouter_catalog.ModelEntry(
+                id="expensive/older",
+                name="Expensive Older",
+                created=400,
+                context_length=64_000,
+                pricing_prompt=0.010,
+                pricing_completion=0.010,
+                pricing_thinking=None,
+                supports_thinking=False,
+                supports_tools=False,
+                supports_vision=False,
+            ),
+        ],
+    )
+    captured: dict[str, object] = {}
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        captured["payload"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "model": "cheap/newest",
+                "choices": [{"message": {"content": "ok"}}],
+                "usage": {},
+            },
+        )
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.post("/chat/completions").mock(side_effect=_record)
+        result = CliRunner().invoke(
+            main,
+            ["call", "--auto", "--tags", "cheap", "--task", "hi"],
+        )
+
+    assert result.exit_code == 0, result.stderr
+    assert "→ openrouter" in result.stderr
+    assert captured["payload"]["model"] == "openrouter/auto"
+    assert captured["payload"]["plugins"][0]["allowed_models"][0] == "cheap/newest"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_openrouter.py
+++ b/tests/test_openrouter.py
@@ -74,7 +74,10 @@ def test_call_returns_normalized_response(configured):
         router.post("/chat/completions").mock(
             return_value=httpx.Response(200, json=body)
         )
-        response = OpenRouterProvider().call("What is 2+2?")
+        response = OpenRouterProvider().call(
+            "What is 2+2?",
+            model="anthropic/claude-sonnet-4",
+        )
 
     assert isinstance(response, CallResponse)
     assert response.text == "4"
@@ -129,16 +132,71 @@ def test_call_sends_reasoning_effort_and_openrouter_headers(configured):
 
     with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
         router.post("/chat/completions").mock(side_effect=_record)
-        OpenRouterProvider().call("hi", effort="max")
+        OpenRouterProvider().call("hi", model="anthropic/claude-sonnet-4", effort="max")
 
     assert captured["authorization"] == "Bearer or-test-key"
     assert captured["http_referer"] == "https://github.com/autumngarage/conductor"
     assert captured["x_title"] == "conductor"
     assert captured["payload"] == {
-        "model": OPENROUTER_DEFAULT_MODEL,
+        "model": "anthropic/claude-sonnet-4",
         "messages": [{"role": "user", "content": "hi"}],
         "reasoning": {"effort": "xhigh"},
     }
+
+
+def test_call_without_model_invokes_selector_and_builds_payload(configured, mocker):
+    selector = mocker.patch(
+        "conductor.providers.openrouter.select_model_for_task",
+        return_value={
+            "model": OPENROUTER_DEFAULT_MODEL,
+            "plugins": [
+                {
+                    "id": "auto-router",
+                    "allowed_models": ["google/gemini-flash-1.5", "openai/gpt-5.2"],
+                }
+            ],
+            "reasoning": {"effort": "medium"},
+        },
+    )
+    captured: dict[str, object] = {}
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        captured["payload"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "model": "google/gemini-flash-1.5",
+                "choices": [{"message": {"content": "ok"}}],
+                "usage": {},
+            },
+        )
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.post("/chat/completions").mock(side_effect=_record)
+        response = OpenRouterProvider().call(
+            "hi",
+            task_tags=["cheap"],
+            prefer="balanced",
+        )
+
+    selector.assert_called_once_with(
+        task_tags=["cheap"],
+        prefer="balanced",
+        effort="medium",
+        exclude=None,
+    )
+    assert captured["payload"] == {
+        "model": OPENROUTER_DEFAULT_MODEL,
+        "messages": [{"role": "user", "content": "hi"}],
+        "plugins": [
+            {
+                "id": "auto-router",
+                "allowed_models": ["google/gemini-flash-1.5", "openai/gpt-5.2"],
+            }
+        ],
+        "reasoning": {"effort": "medium"},
+    }
+    assert response.model == "google/gemini-flash-1.5"
 
 
 def test_exec_with_tools_raises_unsupported(configured):

--- a/tests/test_openrouter_catalog.py
+++ b/tests/test_openrouter_catalog.py
@@ -1,0 +1,163 @@
+"""Tests for the OpenRouter catalog cache and parser."""
+
+from __future__ import annotations
+
+import time
+
+import httpx
+import pytest
+import respx
+
+import conductor.providers.openrouter_catalog as openrouter_catalog
+from conductor.providers.interface import ProviderHTTPError
+
+
+@pytest.fixture
+def catalog_response() -> dict:
+    return {
+        "data": [
+            {
+                "id": "anthropic/claude-sonnet-4.6",
+                "name": "Claude Sonnet 4.6",
+                "created": 1_710_000_000,
+                "context_length": 200_000,
+                "pricing": {
+                    "prompt": "0.000003",
+                    "completion": "0.000015",
+                    "reasoning": "0.000004",
+                },
+                "supported_parameters": ["reasoning", "tools"],
+                "architecture": {"modality": "text+image->text"},
+            },
+            {
+                "id": "openai/gpt-4.1-mini",
+                "name": "GPT-4.1 mini",
+                "created": 1_709_000_000,
+                "context_length": 64_000,
+                "pricing": {
+                    "prompt": "0.0000003",
+                    "completion": "0.0000012",
+                },
+                "supported_parameters": [],
+                "architecture": {"modality": "text->text"},
+            },
+        ]
+    }
+
+
+@pytest.fixture
+def catalog_cache(tmp_path, monkeypatch):
+    path = tmp_path / "openrouter-catalog.json"
+    monkeypatch.setattr(openrouter_catalog, "OPENROUTER_CATALOG_CACHE_PATH", path)
+    return path
+
+
+def _write_snapshot(path, *, fetched_at: int, model_id: str = "cached/model") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "{\n"
+        f'  "fetched_at": {fetched_at},\n'
+        '  "models": [\n'
+        "    {\n"
+        f'      "id": "{model_id}",\n'
+        '      "name": "Cached model",\n'
+        '      "created": 1700000000,\n'
+        '      "context_length": 32000,\n'
+        '      "pricing_prompt": 0.001,\n'
+        '      "pricing_completion": 0.002,\n'
+        '      "pricing_thinking": null,\n'
+        '      "supports_thinking": false,\n'
+        '      "supports_tools": false,\n'
+        '      "supports_vision": false\n'
+        "    }\n"
+        "  ]\n"
+        "}\n"
+    )
+
+
+def test_load_catalog_fetches_and_caches_on_cache_miss(catalog_response, catalog_cache):
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.get("/models").mock(return_value=httpx.Response(200, json=catalog_response))
+        snapshot = openrouter_catalog.load_catalog_snapshot()
+
+    assert len(snapshot.models) == 2
+    assert catalog_cache.exists()
+    cached = openrouter_catalog.read_cached_catalog()
+    assert cached is not None
+    assert cached.models[0].id == "anthropic/claude-sonnet-4.6"
+
+
+def test_load_catalog_uses_fresh_cache_without_http(catalog_cache):
+    _write_snapshot(catalog_cache, fetched_at=int(time.time()))
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1"):
+        snapshot = openrouter_catalog.load_catalog_snapshot()
+
+    assert [model.id for model in snapshot.models] == ["cached/model"]
+
+
+def test_load_catalog_refreshes_stale_cache(catalog_response, catalog_cache):
+    _write_snapshot(catalog_cache, fetched_at=int(time.time()) - (48 * 3600))
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        route = router.get("/models").mock(
+            return_value=httpx.Response(200, json=catalog_response)
+        )
+        snapshot = openrouter_catalog.load_catalog_snapshot()
+
+    assert route.called
+    assert snapshot.models[0].id == "anthropic/claude-sonnet-4.6"
+
+
+def test_force_refresh_bypasses_fresh_cache(catalog_response, catalog_cache):
+    _write_snapshot(catalog_cache, fetched_at=int(time.time()))
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        route = router.get("/models").mock(
+            return_value=httpx.Response(200, json=catalog_response)
+        )
+        snapshot = openrouter_catalog.load_catalog_snapshot(force_refresh=True)
+
+    assert route.called
+    assert snapshot.models[1].id == "openai/gpt-4.1-mini"
+
+
+def test_load_catalog_falls_back_to_stale_cache_on_network_error(
+    capsys, catalog_cache
+):
+    stale_at = int(time.time()) - (48 * 3600)
+    _write_snapshot(catalog_cache, fetched_at=stale_at)
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.get("/models").mock(side_effect=httpx.ConnectError("network down"))
+        snapshot = openrouter_catalog.load_catalog_snapshot()
+
+    assert [model.id for model in snapshot.models] == ["cached/model"]
+    assert "using stale cache" in capsys.readouterr().err
+
+
+def test_load_catalog_raises_without_cache_on_network_error(catalog_cache):
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.get("/models").mock(side_effect=httpx.ConnectError("network down"))
+        with pytest.raises(ProviderHTTPError, match="network error refreshing OpenRouter catalog"):
+            openrouter_catalog.load_catalog_snapshot()
+
+
+def test_read_cached_catalog_returns_none_when_missing(catalog_cache):
+    assert openrouter_catalog.read_cached_catalog() is None
+
+
+def test_parser_derives_capabilities_and_per_1k_pricing(
+    catalog_response, catalog_cache
+):
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.get("/models").mock(return_value=httpx.Response(200, json=catalog_response))
+        models = openrouter_catalog.load_catalog()
+
+    sonnet = models[0]
+    assert sonnet.pricing_prompt == pytest.approx(0.003)
+    assert sonnet.pricing_completion == pytest.approx(0.015)
+    assert sonnet.pricing_thinking == pytest.approx(0.004)
+    assert sonnet.supports_thinking is True
+    assert sonnet.supports_tools is True
+    assert sonnet.supports_vision is True

--- a/tests/test_openrouter_selector.py
+++ b/tests/test_openrouter_selector.py
@@ -1,0 +1,160 @@
+"""Tests for OpenRouter catalog-driven model selection."""
+
+from __future__ import annotations
+
+import pytest
+
+import conductor.providers.openrouter_catalog as openrouter_catalog
+from conductor.providers.interface import ProviderError
+from conductor.providers.openrouter import OPENROUTER_DEFAULT_MODEL, select_model_for_task
+
+
+@pytest.fixture
+def fixture_catalog() -> list[openrouter_catalog.ModelEntry]:
+    return [
+        openrouter_catalog.ModelEntry(
+            id="cheap/basic",
+            name="Cheap Basic",
+            created=100,
+            context_length=32_000,
+            pricing_prompt=0.001,
+            pricing_completion=0.001,
+            pricing_thinking=None,
+            supports_thinking=False,
+            supports_tools=False,
+            supports_vision=False,
+        ),
+        openrouter_catalog.ModelEntry(
+            id="cheap/thinker",
+            name="Cheap Thinker",
+            created=200,
+            context_length=64_000,
+            pricing_prompt=0.002,
+            pricing_completion=0.002,
+            pricing_thinking=0.001,
+            supports_thinking=True,
+            supports_tools=False,
+            supports_vision=False,
+        ),
+        openrouter_catalog.ModelEntry(
+            id="expensive/reasoner",
+            name="Expensive Reasoner",
+            created=300,
+            context_length=128_000,
+            pricing_prompt=0.009,
+            pricing_completion=0.009,
+            pricing_thinking=0.004,
+            supports_thinking=True,
+            supports_tools=True,
+            supports_vision=False,
+        ),
+        openrouter_catalog.ModelEntry(
+            id="tool/vision",
+            name="Tool Vision",
+            created=250,
+            context_length=64_000,
+            pricing_prompt=0.004,
+            pricing_completion=0.004,
+            pricing_thinking=None,
+            supports_thinking=False,
+            supports_tools=True,
+            supports_vision=True,
+        ),
+        openrouter_catalog.ModelEntry(
+            id="long/context",
+            name="Long Context",
+            created=275,
+            context_length=200_000,
+            pricing_prompt=0.003,
+            pricing_completion=0.003,
+            pricing_thinking=None,
+            supports_thinking=False,
+            supports_tools=False,
+            supports_vision=False,
+        ),
+        openrouter_catalog.ModelEntry(
+            id="recent/general",
+            name="Recent General",
+            created=400,
+            context_length=64_000,
+            pricing_prompt=0.005,
+            pricing_completion=0.005,
+            pricing_thinking=None,
+            supports_tools=False,
+            supports_thinking=False,
+            supports_vision=False,
+        ),
+    ]
+
+
+def test_prefer_cheapest_returns_direct_model(mocker, fixture_catalog):
+    mocker.patch(
+        "conductor.providers.openrouter_catalog.load_catalog",
+        return_value=fixture_catalog,
+    )
+
+    payload = select_model_for_task(["thinking"], "cheapest", "medium")
+
+    assert payload == {"model": "cheap/thinker", "reasoning": None}
+
+
+def test_prefer_best_returns_auto_with_shortlist(mocker, fixture_catalog):
+    mocker.patch(
+        "conductor.providers.openrouter_catalog.load_catalog",
+        return_value=fixture_catalog,
+    )
+
+    payload = select_model_for_task([], "best", "medium")
+
+    assert payload["model"] == OPENROUTER_DEFAULT_MODEL
+    assert payload["reasoning"] == {"effort": "medium"}
+    shortlist = payload["plugins"][0]["allowed_models"]
+    assert len(shortlist) == 6
+    assert shortlist[0] == "recent/general"
+
+
+@pytest.mark.parametrize(
+    ("tags", "expected"),
+    [
+        (["thinking"], {"cheap/thinker", "expensive/reasoner"}),
+        (["tool-use"], {"expensive/reasoner", "tool/vision"}),
+        (["vision"], {"tool/vision"}),
+        (["long-context"], {"expensive/reasoner", "long/context"}),
+    ],
+)
+def test_capability_filters_reduce_candidate_set(mocker, fixture_catalog, tags, expected):
+    mocker.patch(
+        "conductor.providers.openrouter_catalog.load_catalog",
+        return_value=fixture_catalog,
+    )
+
+    payload = select_model_for_task(tags, "best", "medium")
+    shortlist = set(payload["plugins"][0]["allowed_models"])
+
+    assert shortlist == expected
+
+
+def test_exclude_removes_named_models(mocker, fixture_catalog):
+    mocker.patch(
+        "conductor.providers.openrouter_catalog.load_catalog",
+        return_value=fixture_catalog,
+    )
+
+    payload = select_model_for_task(
+        ["thinking"],
+        "cheapest",
+        "medium",
+        exclude={"cheap/thinker"},
+    )
+
+    assert payload["model"] == "expensive/reasoner"
+
+
+def test_empty_filtered_result_raises_clear_error(mocker, fixture_catalog):
+    mocker.patch(
+        "conductor.providers.openrouter_catalog.load_catalog",
+        return_value=fixture_catalog,
+    )
+
+    with pytest.raises(ProviderError, match="found no models matching"):
+        select_model_for_task(["vision", "thinking"], "cheapest", "medium")

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -41,6 +41,7 @@ def _stub_configured(mocker, results: dict[str, bool]):
         GeminiProvider,
         KimiProvider,
         OllamaProvider,
+        OpenRouterProvider,
     )
 
     classes = {
@@ -51,6 +52,7 @@ def _stub_configured(mocker, results: dict[str, bool]):
         "deepseek-reasoner": DeepSeekReasonerProvider,
         "gemini": GeminiProvider,
         "ollama": OllamaProvider,
+        "openrouter": OpenRouterProvider,
     }
     for name, cls in classes.items():
         ok = results.get(name, False)
@@ -129,6 +131,7 @@ def test_route_decision_surfaces_skipped_with_reasons(mocker):
         "deepseek-reasoner",
         "gemini",
         "ollama",
+        "openrouter",
     }
 
 
@@ -141,14 +144,11 @@ def test_priority_order_is_stable():
     assert DEFAULT_PRIORITY == ("kimi", "claude", "mistral", "codex", "gemini", "ollama")
 
 
-def test_openrouter_is_not_considered_for_auto_routing(mocker):
-    from conductor.providers import OpenRouterProvider
-
-    _stub_configured(mocker, {})
-    mocker.patch.object(OpenRouterProvider, "configured", lambda self: (True, None))
-    with pytest.raises(NoConfiguredProvider) as exc:
-        pick([])
-    assert "openrouter" not in str(exc.value)
+def test_openrouter_can_now_participate_in_auto_routing(mocker):
+    _stub_configured(mocker, {"claude": True, "openrouter": True})
+    provider, decision = pick(["cheap"])
+    assert provider.name == "openrouter"
+    assert decision.provider == "openrouter"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
PR 2 of the OpenRouter migration documented in
.cortex/plans/openrouter-migration.md. Today (after PR 1 #57)
`--with openrouter` works only with an explicit `--model <slug>`.
This PR adds catalog-driven model selection so the user can route by
intent without ever hard-coding a model name.

What ships:

- src/conductor/providers/openrouter_catalog.py — new module. Fetches
  GET /api/v1/models, parses each entry into ModelEntry (id, name,
  created, context_length, pricing, capability flags), caches to
  ~/.cache/conductor/openrouter-catalog.json with 24h TTL
  (configurable via CONDUCTOR_CATALOG_TTL_HOURS). Network failure
  during refresh falls back to stale cache with a stderr warning;
  no cache + network failure raises ProviderHTTPError (no silent
  failures principle).

- src/conductor/providers/openrouter.py — selector logic. When
  call() is invoked without an explicit model:
    prefer=cheapest|fastest → bypass :auto, sort catalog by
       cost, pick top-1 directly (NotDiamond is quality-first
       by design — using :auto here would defeat the cost-aware
       intent).
    prefer=best|balanced  → delegate to openrouter/auto with
       plugins.allowed_models constraining the candidate set
       to the top 6 models by recency+cost. plugins.allowed_models
       is the documented constraint primitive; `models: [...]`
       is sequential failover, not a constraint.
  Selector decisions log to stderr alongside the existing route log.

- src/conductor/cli.py — new `conductor models refresh|list|show`
  command group. refresh forces a catalog re-fetch; list reads the
  cache; show <slug> prints one model's details. The catch-all path
  for "what is openrouter actually offering me right now" without
  burning credits.

- src/conductor/router.py — remove the temporary
  _AUTO_ROUTING_DISABLED guard introduced in PR 1. openrouter is
  now a normal candidate in --auto scoring; the selector then drills
  down to a specific model. Two-layer routing: conductor router
  picks the provider, openrouter selector picks the model.

- tests added: test_openrouter_catalog.py (cache TTL, fallback,
  raises on no-cache+failure), test_openrouter_selector.py
  (capability filters, cost vs. recency sort, prefer-mode branching,
  exclude filter), test_cli_models.py (CLI subcommand smoke).
  Existing tests updated to include OpenRouterProvider in their
  stub lists (auto-mode now sees it).

Validation: 573 passed, 15 skipped (was 547 after PR 1).
ruff check src/ tests/ clean.

Closes the catalog/selector slice of the migration. Next: PR 3
(migrate kimi to route through openrouter), then PR 4 (deepseek).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
