### PR TITLE
fix(cli-models): guard `models list` against empty catalog cache (#64 review)

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -1895,6 +1895,9 @@ def models_list() -> None:
     click.echo("")
 
     sorted_models = sorted(snapshot.models, key=lambda model: model.id)
+    if not sorted_models:
+        click.echo("(catalog cache is empty — run `conductor models refresh` to populate)")
+        return
     id_w = max(len("MODEL"), max(len(model.id) for model in sorted_models))
     ctx_w = max(len("CTX"), max(len(f"{model.context_length:,}") for model in sorted_models))
     header = (


### PR DESCRIPTION
Codex review on PR #64 caught an unhandled `ValueError: max() arg is an
empty sequence` when `conductor models list` runs against an empty
cache (e.g. a hand-crafted JSON with `data: []`, or after a corrupted
write). The column-width calculation called `max()` on a generator
over `sorted_models` without checking for emptiness first.

Guard with an explicit empty-cache message that points the user at
`conductor models refresh`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
