### PR TITLE
chore(test-cli-auto): hoist late import to top of file

### DIFF
--- a/tests/test_cli_auto.py
+++ b/tests/test_cli_auto.py
@@ -151,9 +151,8 @@ def test_call_auto_emits_shadow_hint_when_unconfigured_outranks(monkeypatch, moc
         CodexProvider,
         GeminiProvider,
         OllamaProvider,
+        OpenRouterProvider,
     )
-
-    from conductor.providers import OpenRouterProvider
 
     mocker.patch.object(ClaudeProvider, "configured", lambda self: (False, "nope"))
     mocker.patch.object(
@@ -258,9 +257,8 @@ def test_call_auto_silent_route_suppresses_shadow_hint(monkeypatch, mocker):
         CodexProvider,
         GeminiProvider,
         OllamaProvider,
+        OpenRouterProvider,
     )
-
-    from conductor.providers import OpenRouterProvider
 
     mocker.patch.object(ClaudeProvider, "configured", lambda self: (False, "nope"))
     mocker.patch.object(


### PR DESCRIPTION
ruff caught a function-scope `from conductor.providers import OpenRouterProvider`
left over from a mid-PR fixup during PR 2's rebase. Hoist to the existing
top-level imports block.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
