### PR TITLE
feat(cli): named profiles for `conductor call` and `exec` (#50)

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -29,6 +29,7 @@ import click
 import conductor.providers.openrouter_catalog as openrouter_catalog
 from conductor import __version__, credentials, offline_mode
 from conductor.banner import print_caller_banner
+from conductor.profiles import ProfileError, ProfileSpec, get_profile, load_profiles
 from conductor.providers import (
     QUALITY_TIERS,
     CallResponse,
@@ -54,6 +55,9 @@ from conductor.wizard import run_init_wizard
 VALID_TOOLS = ("Read", "Grep", "Glob", "Edit", "Write", "Bash")
 VALID_SANDBOXES = ("read-only", "workspace-write", "strict", "none")
 VALID_EFFORT_LEVELS = ("minimal", "low", "medium", "high", "max")
+PROFILE_PRECEDENCE_TEXT = (
+    "Resolution order: profile defaults < CONDUCTOR_* env vars < explicit CLI flags."
+)
 
 
 # --------------------------------------------------------------------------- #
@@ -97,6 +101,29 @@ def _parse_csv(raw: str | None) -> list[str]:
     if not raw:
         return []
     return [t.strip() for t in raw.split(",") if t.strip()]
+
+
+def _resolve_layered_value(
+    cli_value: str | None,
+    *,
+    env_key: str,
+    profile_value: str | None = None,
+) -> str | None:
+    if cli_value is not None:
+        return cli_value
+    env_value = os.environ.get(env_key)
+    if env_value is not None:
+        return env_value
+    return profile_value
+
+
+def _load_named_profile(name: str | None) -> ProfileSpec | None:
+    if name is None:
+        return None
+    try:
+        return get_profile(name)
+    except ProfileError as e:
+        raise click.UsageError(str(e)) from e
 
 
 def _parse_effort(raw: str | None) -> str | int:
@@ -734,6 +761,14 @@ def main() -> None:
     ),
 )
 @click.option(
+    "--profile",
+    default=None,
+    help=(
+        "Apply defaults from a named profile before env vars and explicit flags. "
+        "Resolution order: profile defaults < CONDUCTOR_* env vars < explicit CLI flags."
+    ),
+)
+@click.option(
     "--auto",
     is_flag=True,
     default=False,
@@ -812,6 +847,7 @@ def main() -> None:
 )
 def call(
     provider_id: str | None,
+    profile: str | None,
     auto: bool,
     tags: str | None,
     prefer: str | None,
@@ -827,6 +863,25 @@ def call(
     offline: bool | None,
 ) -> None:
     """Send a task to a provider and print the response."""
+    explicit_prefer = prefer
+    profile_spec = _load_named_profile(profile)
+    provider_id = _resolve_layered_value(provider_id, env_key="CONDUCTOR_WITH")
+    tags = _resolve_layered_value(
+        tags,
+        env_key="CONDUCTOR_TAGS",
+        profile_value=profile_spec.tags if profile_spec else None,
+    )
+    prefer = _resolve_layered_value(
+        prefer,
+        env_key="CONDUCTOR_PREFER",
+        profile_value=profile_spec.prefer if profile_spec else None,
+    )
+    effort = _resolve_layered_value(
+        effort,
+        env_key="CONDUCTOR_EFFORT",
+        profile_value=profile_spec.effort if profile_spec else None,
+    )
+    exclude = _resolve_layered_value(exclude, env_key="CONDUCTOR_EXCLUDE")
     provider_id, auto = _apply_offline_flag(
         offline=offline, provider_id=provider_id, auto=auto
     )
@@ -885,7 +940,7 @@ def call(
             click.echo(f"conductor: {e}", err=True)
             sys.exit(1)
     else:
-        if prefer is not None and provider_id != "openrouter":
+        if explicit_prefer is not None and provider_id != "openrouter":
             raise click.UsageError("--prefer is only meaningful with --auto.")
         # Earlier guard `if not auto and not provider_id: raise` makes this
         # narrowing safe; the assert documents it for mypy and future readers.
@@ -940,6 +995,14 @@ def call(
     "provider_id",
     default=None,
     help="Provider identifier. Mutually exclusive with --auto.",
+)
+@click.option(
+    "--profile",
+    default=None,
+    help=(
+        "Apply defaults from a named profile before env vars and explicit flags. "
+        "Resolution order: profile defaults < CONDUCTOR_* env vars < explicit CLI flags."
+    ),
 )
 @click.option(
     "--auto",
@@ -1037,6 +1100,7 @@ def call(
 )
 def exec_cmd(
     provider_id: str | None,
+    profile: str | None,
     auto: bool,
     tags: str | None,
     prefer: str | None,
@@ -1057,6 +1121,29 @@ def exec_cmd(
     offline: bool | None,
 ) -> None:
     """Run a task as an agent session with tool access (exec mode)."""
+    profile_spec = _load_named_profile(profile)
+    provider_id = _resolve_layered_value(provider_id, env_key="CONDUCTOR_WITH")
+    tags = _resolve_layered_value(
+        tags,
+        env_key="CONDUCTOR_TAGS",
+        profile_value=profile_spec.tags if profile_spec else None,
+    )
+    prefer = _resolve_layered_value(
+        prefer,
+        env_key="CONDUCTOR_PREFER",
+        profile_value=profile_spec.prefer if profile_spec else None,
+    )
+    effort = _resolve_layered_value(
+        effort,
+        env_key="CONDUCTOR_EFFORT",
+        profile_value=profile_spec.effort if profile_spec else None,
+    )
+    sandbox = _resolve_layered_value(
+        sandbox,
+        env_key="CONDUCTOR_SANDBOX",
+        profile_value=profile_spec.sandbox if profile_spec else None,
+    )
+    exclude = _resolve_layered_value(exclude, env_key="CONDUCTOR_EXCLUDE")
     provider_id, auto = _apply_offline_flag(
         offline=offline, provider_id=provider_id, auto=auto
     )
@@ -1268,6 +1355,7 @@ def config(subcommand: str, as_json: bool) -> None:
         "CONDUCTOR_PREFER": os.environ.get("CONDUCTOR_PREFER"),
         "CONDUCTOR_EFFORT": os.environ.get("CONDUCTOR_EFFORT"),
         "CONDUCTOR_TAGS": os.environ.get("CONDUCTOR_TAGS"),
+        "CONDUCTOR_SANDBOX": os.environ.get("CONDUCTOR_SANDBOX"),
         "CONDUCTOR_WITH": os.environ.get("CONDUCTOR_WITH"),
         "CONDUCTOR_EXCLUDE": os.environ.get("CONDUCTOR_EXCLUDE"),
     }
@@ -1275,6 +1363,7 @@ def config(subcommand: str, as_json: bool) -> None:
         "prefer": env_overrides["CONDUCTOR_PREFER"] or "balanced",
         "effort": env_overrides["CONDUCTOR_EFFORT"] or "medium",
         "tags": _parse_csv(env_overrides["CONDUCTOR_TAGS"]),
+        "sandbox": env_overrides["CONDUCTOR_SANDBOX"] or "none",
         "with": env_overrides["CONDUCTOR_WITH"] or None,
         "exclude": _parse_csv(env_overrides["CONDUCTOR_EXCLUDE"]),
     }
@@ -1308,6 +1397,54 @@ def config(subcommand: str, as_json: bool) -> None:
     click.echo("")
     click.echo(f"Known providers: {', '.join(payload['known_providers'])}")
     click.echo("Run `conductor list` for per-provider configured status.")
+
+
+# --------------------------------------------------------------------------- #
+# profiles — inspect built-in + user-defined defaults
+# --------------------------------------------------------------------------- #
+
+
+@main.group(name="profiles")
+def profiles_cmd() -> None:
+    """Inspect named profiles for call/exec defaults."""
+
+
+@profiles_cmd.command(name="list")
+def profiles_list() -> None:
+    """List built-in and user-defined profiles."""
+    try:
+        profiles = load_profiles()
+    except ProfileError as e:
+        raise click.UsageError(str(e)) from e
+
+    for name in sorted(profiles):
+        spec = profiles[name]
+        click.echo(
+            f"{name:<12} "
+            f"prefer={spec.prefer or '-'} "
+            f"effort={spec.effort or '-'} "
+            f"tags={spec.tags or '-'} "
+            f"sandbox={spec.sandbox or '-'} "
+            f"[{spec.source}]"
+        )
+
+
+@profiles_cmd.command(name="show")
+@click.argument("name")
+def profiles_show(name: str) -> None:
+    """Show one profile and the precedence rules around it."""
+    try:
+        spec = get_profile(name)
+    except ProfileError as e:
+        raise click.UsageError(str(e)) from e
+
+    click.echo(f"{spec.name} [{spec.source}]")
+    click.echo(f"  prefer   = {spec.prefer or '(unset)'}")
+    click.echo(f"  effort   = {spec.effort or '(unset)'}")
+    click.echo(f"  tags     = {spec.tags or '(unset)'}")
+    click.echo(f"  sandbox  = {spec.sandbox or '(unset)'}")
+    click.echo("")
+    click.echo(PROFILE_PRECEDENCE_TEXT)
 
 
 # --------------------------------------------------------------------------- #

--- a/src/conductor/profiles.py
+++ b/src/conductor/profiles.py
@@ -1,0 +1,225 @@
+"""Named CLI profiles for ``conductor call`` / ``conductor exec``.
+
+Profiles live in a user-local TOML file, defaulting to
+``~/.config/conductor/profiles.toml``. Built-ins ship in code and user
+entries override built-ins by name.
+
+File schema:
+
+    [profiles.my-coding]
+    prefer = "best"
+    effort = "high"
+    tags = "coding,tool-use"
+    sandbox = "workspace-write"
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+CONFIG_ENV = "CONDUCTOR_PROFILES_FILE"
+DEFAULT_PROFILES_PATH = Path.home() / ".config" / "conductor" / "profiles.toml"
+
+VALID_PREFER_MODES = ("best", "cheapest", "fastest", "balanced")
+VALID_SANDBOXES = ("read-only", "workspace-write", "strict", "none")
+VALID_EFFORT_LEVELS = ("minimal", "low", "medium", "high", "max")
+
+
+@dataclass(frozen=True)
+class ProfileSpec:
+    name: str
+    prefer: str | None = None
+    effort: str | None = None
+    tags: str | None = None
+    sandbox: str | None = None
+    source: str = "built-in"
+
+
+class ProfileError(ValueError):
+    """Raised when the profile config is malformed or a name is unknown."""
+
+
+BUILTIN_PROFILES: dict[str, ProfileSpec] = {
+    "coding": ProfileSpec(
+        name="coding",
+        prefer="best",
+        effort="high",
+        tags="coding,tool-use",
+        sandbox="workspace-write",
+        source="built-in",
+    ),
+    "review": ProfileSpec(
+        name="review",
+        prefer="balanced",
+        effort="medium",
+        tags="code-review",
+        sandbox="read-only",
+        source="built-in",
+    ),
+    "chat": ProfileSpec(
+        name="chat",
+        prefer="cheapest",
+        effort="low",
+        tags="cheap",
+        sandbox="none",
+        source="built-in",
+    ),
+}
+
+
+def profiles_file_path() -> Path:
+    override = os.environ.get(CONFIG_ENV)
+    if override:
+        return Path(override).expanduser()
+    return DEFAULT_PROFILES_PATH
+
+
+def load_profiles() -> dict[str, ProfileSpec]:
+    """Return built-ins plus user overrides from ``profiles.toml``."""
+    profiles = dict(BUILTIN_PROFILES)
+    profiles.update(_load_user_profiles())
+    return profiles
+
+
+def get_profile(name: str) -> ProfileSpec:
+    profiles = load_profiles()
+    if name not in profiles:
+        known = ", ".join(sorted(profiles))
+        raise ProfileError(
+            f"unknown profile {name!r}. Known profiles: {known}."
+        )
+    return profiles[name]
+
+
+def _load_user_profiles() -> dict[str, ProfileSpec]:
+    path = profiles_file_path()
+    if not path.exists():
+        return {}
+    try:
+        with path.open("rb") as f:
+            data = tomllib.load(f)
+    except tomllib.TOMLDecodeError as e:
+        raise ProfileError(
+            f"profile config {path} is not valid TOML: {e}. "
+            "Fix the file or remove it to fall back to built-ins."
+        ) from e
+
+    raw_profiles = data.get("profiles") or {}
+    if not isinstance(raw_profiles, dict):
+        raise ProfileError(
+            f"profile config {path}: `profiles` must be a TOML table."
+        )
+
+    parsed: dict[str, ProfileSpec] = {}
+    for name, raw in raw_profiles.items():
+        parsed[name] = _profile_from_dict(name, raw, source_path=path)
+    return parsed
+
+
+def _profile_from_dict(name: str, raw: object, *, source_path: Path) -> ProfileSpec:
+    if not isinstance(name, str) or not name.strip():
+        raise ProfileError(
+            f"profile config {source_path}: profile names must be non-empty strings."
+        )
+    if not isinstance(raw, dict):
+        raise ProfileError(
+            f"profile config {source_path}: `profiles.{name}` must be a TOML table."
+        )
+
+    allowed = {"prefer", "effort", "tags", "sandbox"}
+    unknown = sorted(set(raw) - allowed)
+    if unknown:
+        raise ProfileError(
+            f"profile config {source_path}: `profiles.{name}` has unknown keys: {unknown}."
+        )
+
+    prefer = _optional_string(raw.get("prefer"), field="prefer", name=name, source_path=source_path)
+    effort = _optional_string(
+        raw.get("effort"),
+        field="effort",
+        name=name,
+        source_path=source_path,
+    )
+    tags = _tags_string(raw.get("tags"), name=name, source_path=source_path)
+    sandbox = _optional_string(
+        raw.get("sandbox"),
+        field="sandbox",
+        name=name,
+        source_path=source_path,
+    )
+
+    if prefer is not None and prefer not in VALID_PREFER_MODES:
+        raise ProfileError(
+            f"profile config {source_path}: `profiles.{name}.prefer` must be one of "
+            f"{list(VALID_PREFER_MODES)}, got {prefer!r}."
+        )
+    if effort is not None:
+        if effort.lstrip("-").isdigit():
+            if int(effort) < 0:
+                raise ProfileError(
+                    f"profile config {source_path}: `profiles.{name}.effort` must be "
+                    f">= 0 when given as an integer, got {effort!r}."
+                )
+        elif effort not in VALID_EFFORT_LEVELS:
+            raise ProfileError(
+                f"profile config {source_path}: `profiles.{name}.effort` must be one of "
+                f"{list(VALID_EFFORT_LEVELS)} or a non-negative integer string, got "
+                f"{effort!r}."
+            )
+    if sandbox is not None and sandbox not in VALID_SANDBOXES:
+        raise ProfileError(
+            f"profile config {source_path}: `profiles.{name}.sandbox` must be one of "
+            f"{list(VALID_SANDBOXES)}, got {sandbox!r}."
+        )
+
+    return ProfileSpec(
+        name=name,
+        prefer=prefer,
+        effort=effort,
+        tags=tags,
+        sandbox=sandbox,
+        source=str(source_path),
+    )
+
+
+def _optional_string(
+    value: object,
+    *,
+    field: str,
+    name: str,
+    source_path: Path,
+) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ProfileError(
+            f"profile config {source_path}: `profiles.{name}.{field}` must be a "
+            "non-empty string."
+        )
+    return value.strip()
+
+
+def _tags_string(value: object, *, name: str, source_path: Path) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            raise ProfileError(
+                f"profile config {source_path}: `profiles.{name}.tags` must not be empty."
+            )
+        return stripped
+    if isinstance(value, list) and all(isinstance(item, str) for item in value):
+        tags = [item.strip() for item in value if item.strip()]
+        if not tags:
+            raise ProfileError(
+                f"profile config {source_path}: `profiles.{name}.tags` must not be empty."
+            )
+        return ",".join(tags)
+    raise ProfileError(
+        f"profile config {source_path}: `profiles.{name}.tags` must be a comma-separated "
+        "string or a list of strings."
+    )

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from conductor.cli import PROFILE_PRECEDENCE_TEXT, main
+from conductor.providers import CallResponse
+from conductor.router import RankedCandidate, RouteDecision
+
+
+def _fake_response(provider: str = "codex") -> CallResponse:
+    return CallResponse(
+        text="ok",
+        provider=provider,
+        model="stub-model",
+        duration_ms=10,
+        usage={},
+        cost_usd=0.0,
+        raw={},
+    )
+
+
+def _fake_decision(provider: str = "codex") -> RouteDecision:
+    candidate = RankedCandidate(
+        name=provider,
+        tier="frontier",
+        tier_rank=4,
+        matched_tags=("coding",),
+        tag_score=1,
+        cost_score=0.01,
+        latency_ms=1000,
+        health_penalty=0.0,
+        combined_score=10.0,
+    )
+    return RouteDecision(
+        provider=provider,
+        prefer="best",
+        effort="high",
+        thinking_budget=4000,
+        tier="frontier",
+        task_tags=("coding",),
+        matched_tags=("coding",),
+        tools_requested=("Read",),
+        sandbox="workspace-write",
+        ranked=(candidate,),
+        candidates_skipped=(),
+    )
+
+
+def test_call_profile_applies_builtin_defaults(mocker):
+    pick_mock = mocker.patch(
+        "conductor.cli.pick",
+        return_value=("codex", _fake_decision()),
+    )
+    mocker.patch(
+        "conductor.cli._invoke_with_fallback",
+        return_value=(_fake_response(), []),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["call", "--auto", "--profile", "coding", "--task", "hi"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert pick_mock.call_args.args[0] == ["coding", "tool-use"]
+    assert pick_mock.call_args.kwargs["prefer"] == "best"
+    assert pick_mock.call_args.kwargs["effort"] == "high"
+
+
+def test_exec_profile_applies_builtin_sandbox(mocker):
+    pick_mock = mocker.patch(
+        "conductor.cli.pick",
+        return_value=("codex", _fake_decision()),
+    )
+    mocker.patch(
+        "conductor.cli._invoke_with_fallback",
+        return_value=(_fake_response(), []),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["exec", "--auto", "--profile", "coding", "--tools", "Read", "--task", "hi"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert pick_mock.call_args.kwargs["sandbox"] == "workspace-write"
+
+
+def test_user_profile_overrides_builtin(mocker, monkeypatch, tmp_path):
+    profiles_file = tmp_path / "profiles.toml"
+    profiles_file.write_text(
+        '[profiles.coding]\n'
+        'prefer = "balanced"\n'
+        'effort = "low"\n'
+        'tags = "cheap"\n'
+        'sandbox = "read-only"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CONDUCTOR_PROFILES_FILE", str(profiles_file))
+
+    pick_mock = mocker.patch(
+        "conductor.cli.pick",
+        return_value=("codex", _fake_decision()),
+    )
+    mocker.patch(
+        "conductor.cli._invoke_with_fallback",
+        return_value=(_fake_response(), []),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["exec", "--auto", "--profile", "coding", "--tools", "Read", "--task", "hi"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert pick_mock.call_args.args[0] == ["cheap"]
+    assert pick_mock.call_args.kwargs["prefer"] == "balanced"
+    assert pick_mock.call_args.kwargs["effort"] == "low"
+    assert pick_mock.call_args.kwargs["sandbox"] == "read-only"
+
+
+def test_unknown_profile_raises_usage_error():
+    result = CliRunner().invoke(
+        main,
+        ["exec", "--auto", "--profile", "does-not-exist", "--task", "hi"],
+    )
+
+    assert result.exit_code == 2
+    assert "unknown profile" in result.output.lower()
+
+
+def test_explicit_flags_override_profile_defaults(mocker):
+    pick_mock = mocker.patch(
+        "conductor.cli.pick",
+        return_value=("codex", _fake_decision()),
+    )
+    mocker.patch(
+        "conductor.cli._invoke_with_fallback",
+        return_value=(_fake_response(), []),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--auto",
+            "--profile",
+            "review",
+            "--prefer",
+            "best",
+            "--effort",
+            "high",
+            "--tags",
+            "coding,tool-use",
+            "--sandbox",
+            "workspace-write",
+            "--tools",
+            "Read",
+            "--task",
+            "hi",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert pick_mock.call_args.args[0] == ["coding", "tool-use"]
+    assert pick_mock.call_args.kwargs["prefer"] == "best"
+    assert pick_mock.call_args.kwargs["effort"] == "high"
+    assert pick_mock.call_args.kwargs["sandbox"] == "workspace-write"
+
+
+def test_profile_env_cli_precedence(mocker, monkeypatch):
+    monkeypatch.setenv("CONDUCTOR_PREFER", "fastest")
+    monkeypatch.setenv("CONDUCTOR_EFFORT", "low")
+    monkeypatch.setenv("CONDUCTOR_TAGS", "cheap")
+    monkeypatch.setenv("CONDUCTOR_SANDBOX", "strict")
+
+    pick_mock = mocker.patch(
+        "conductor.cli.pick",
+        return_value=("codex", _fake_decision()),
+    )
+    mocker.patch(
+        "conductor.cli._invoke_with_fallback",
+        return_value=(_fake_response(), []),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--auto",
+            "--profile",
+            "review",
+            "--effort",
+            "high",
+            "--tags",
+            "coding,tool-use",
+            "--tools",
+            "Read",
+            "--task",
+            "hi",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert pick_mock.call_args.args[0] == ["coding", "tool-use"]
+    assert pick_mock.call_args.kwargs["prefer"] == "fastest"
+    assert pick_mock.call_args.kwargs["effort"] == "high"
+    assert pick_mock.call_args.kwargs["sandbox"] == "strict"
+
+
+def test_profiles_list_and_show_smoke(monkeypatch, tmp_path):
+    profiles_file = tmp_path / "profiles.toml"
+    profiles_file.write_text(
+        '[profiles.local]\n'
+        'prefer = "balanced"\n'
+        'effort = "medium"\n'
+        'tags = "cheap"\n'
+        'sandbox = "read-only"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CONDUCTOR_PROFILES_FILE", str(profiles_file))
+
+    runner = CliRunner()
+    list_result = runner.invoke(main, ["profiles", "list"])
+    show_result = runner.invoke(main, ["profiles", "show", "coding"])
+
+    assert list_result.exit_code == 0, list_result.output
+    assert "coding" in list_result.output
+    assert "local" in list_result.output
+
+    assert show_result.exit_code == 0, show_result.output
+    assert "coding" in show_result.output
+    assert "workspace-write" in show_result.output
+    assert PROFILE_PRECEDENCE_TEXT in show_result.output


### PR DESCRIPTION
Common combinations of --prefer / --effort / --tags / --sandbox are
repetitive. Add a `--profile <name>` option that bundles them, with
explicit flags still winning. Closes #50.

What ships:

- New src/conductor/profiles.py module: built-in profiles (`coding`,
  `review`, `chat`) plus user-defined profiles loaded from
  ~/.config/conductor/profiles.toml. Unknown profile name raises a
  clear UsageError.

- src/conductor/cli.py: --profile flag on call/exec. Resolution
  order: profile defaults < CONDUCTOR_* env vars < explicit CLI
  flags. The check that --prefer is meaningless without --auto now
  uses explicit_prefer (the value as passed by the user, not the
  profile-resolved one) and exempts --with openrouter (PR 2 made
  --prefer meaningful for the openrouter selector).

- New `conductor profiles list|show <name>` subcommands for
  inspecting which flags a profile applies.

- tests/test_profiles.py covers built-ins, user override of built-ins,
  unknown name → UsageError, explicit flag wins over profile default,
  and resolution-order precedence.

Validation: 580 passed, 15 skipped (was 573 after PR 2 + lint
follow-ups). ruff clean.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
