### PR TITLE
feat(smoke): nudge `conductor smoke` after a provider configures (#49)

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -1862,6 +1862,10 @@ def doctor(as_json: bool) -> None:
             f"tier={p['quality_tier']:<8}  "
             f"default={p['default_model']}{effort_note}"
         )
+        if p["configured"]:
+            click.echo(
+                f"        Verify end-to-end: conductor smoke {p['provider']}"
+            )
         if not p["configured"]:
             click.echo(f"        └─ {p['reason']}")
             if p.get("fix_command"):

--- a/src/conductor/wizard.py
+++ b/src/conductor/wizard.py
@@ -1405,7 +1405,14 @@ def _wire_cursor_section(
 
 
 def _print_next_steps(outcomes: list[WizardOutcome]) -> None:
+    ok_names = [o.provider for o in outcomes if o.status == "ok"]
+
     click.echo("")
+    if ok_names:
+        click.echo("Setup complete. Verify with:")
+        click.echo("  conductor smoke <name>          (per provider)")
+        click.echo("  conductor smoke --all           (everything)")
+        click.echo("")
     click.echo("Next steps:")
     click.echo("  conductor list           # see providers + quality tiers")
     click.echo("  conductor smoke --all    # verify configured providers")

--- a/tests/test_cli_phase5.py
+++ b/tests/test_cli_phase5.py
@@ -268,6 +268,21 @@ def test_doctor_text_output_covers_every_provider(mocker, monkeypatch):
     assert "brew install codex && codex login" in result.output
 
 
+def test_doctor_text_output_shows_smoke_nudge_for_each_configured_provider(mocker):
+    from conductor.providers import CodexProvider, OpenRouterProvider
+
+    _stub_all_unconfigured(mocker)
+    mocker.patch.object(CodexProvider, "configured", lambda self: (True, None))
+    mocker.patch.object(OpenRouterProvider, "configured", lambda self: (True, None))
+
+    result = CliRunner().invoke(main, ["doctor"])
+    assert result.exit_code == 0, result.output
+    assert "✓ codex" in result.output
+    assert "Verify end-to-end: conductor smoke codex" in result.output
+    assert "✓ openrouter" in result.output
+    assert "Verify end-to-end: conductor smoke openrouter" in result.output
+
+
 def test_doctor_json_shape(mocker, monkeypatch):
     from conductor.providers import known_providers
 

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -1166,3 +1166,25 @@ def test_init_summary_and_next_steps_printed(mocker):
     assert "prefer=balanced" in result.output
     assert "effort=medium" in result.output
     assert "Touchstone" in result.output  # callers override example
+
+
+def test_init_prints_setup_complete_verify_nudge_after_success(mocker):
+    mocker.patch("conductor.wizard._is_tty", return_value=True)
+    mocker.patch("conductor.wizard._op_cli_available", return_value=False)
+
+    from conductor.providers import KimiProvider, OpenRouterProvider
+
+    mocker.patch.object(KimiProvider, "configured", lambda self: (False, "missing"))
+    mocker.patch.object(OpenRouterProvider, "smoke", return_value=(True, None))
+    mocker.patch("conductor.wizard.credentials.get", return_value=None)
+
+    result = CliRunner().invoke(
+        main,
+        ["init", "--only", "kimi"],
+        input="or-test-key\nprint\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Setup complete. Verify with:" in result.output
+    assert "conductor smoke <name>          (per provider)" in result.output
+    assert "conductor smoke --all           (everything)" in result.output


### PR DESCRIPTION
Today doctor reports `✓ codex configured` and stops there. Users
finish `conductor init`, see green checks, and assume they're good —
until the first real call surfaces an auth/endpoint issue that smoke
would have caught for the cost of one cheap round-trip.

Surface smoke in two places:

1. `conductor doctor` — under each configured provider's row, show:
       Verify end-to-end: conductor smoke <provider>
2. `conductor init` end-of-flow — when at least one provider was
   successfully configured, the wizard prints:
       Setup complete. Verify with:
         conductor smoke <name>          (per provider)
         conductor smoke --all           (everything)

No new commands, no behavior gates — purely making the verification
step discoverable.

Closes #49.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
