### PR TITLE
feat(exec): structured session log + sessions tail/list (#45)

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import time
 from dataclasses import asdict
 from pathlib import Path
 
@@ -56,6 +57,14 @@ from conductor.router import (
     mark_outcome,
     mark_rate_limited,
     pick,
+)
+from conductor.session_log import (
+    SessionLog,
+    SessionLogError,
+    SessionRecord,
+    find_session_record,
+    latest_active_session,
+    list_session_records,
 )
 from conductor.wizard import run_init_wizard
 
@@ -434,6 +443,7 @@ def _invoke_with_fallback(
     max_stall_sec: int | None,
     silent: bool,
     resume_session_id: str | None = None,
+    session_log: SessionLog | None = None,
 ) -> tuple[CallResponse, list[str]]:
     """Try the decision's ranked providers in order; fallback on retryable errors.
 
@@ -482,6 +492,20 @@ def _invoke_with_fallback(
     while idx < len(candidates):
         candidate = candidates[idx]
         provider = get_provider(candidate.name)
+        if session_log is not None:
+            session_log.bind_provider(candidate.name)
+            session_log.emit(
+                "provider_started",
+                {
+                    "provider": candidate.name,
+                    "mode": mode,
+                    "model": model,
+                    "tools": sorted(tools),
+                    "sandbox": sandbox,
+                    "cwd": cwd,
+                    "resume_session_id": resume_session_id,
+                },
+            )
         try:
             if mode == "exec":
                 if isinstance(provider, OpenRouterProvider):
@@ -498,6 +522,7 @@ def _invoke_with_fallback(
                         timeout_sec=timeout_sec,
                         max_stall_sec=max_stall_sec,
                         resume_session_id=resume_session_id,
+                        session_log=session_log,
                     )
                 else:
                     response = provider.exec(
@@ -510,6 +535,7 @@ def _invoke_with_fallback(
                         timeout_sec=timeout_sec,
                         max_stall_sec=max_stall_sec,
                         resume_session_id=resume_session_id,
+                        session_log=session_log,
                     )
             else:
                 if isinstance(provider, OpenRouterProvider):
@@ -530,6 +556,17 @@ def _invoke_with_fallback(
                         resume_session_id=resume_session_id,
                     )
             mark_outcome(candidate.name, "success")
+            if session_log is not None:
+                session_log.set_session_id(response.session_id)
+                session_log.emit(
+                    "provider_finished",
+                    {
+                        "provider": response.provider,
+                        "model": response.model,
+                        "duration_ms": response.duration_ms,
+                        "session_id": response.session_id,
+                    },
+                )
             return response, fallbacks
         except ProviderConfigError:
             # Config problems don't recover with a different provider using
@@ -546,6 +583,15 @@ def _invoke_with_fallback(
                 mark_rate_limited(candidate.name)
             mark_outcome(candidate.name, category)
             last_exc = e
+            if session_log is not None:
+                session_log.emit(
+                    "provider_failed",
+                    {
+                        "provider": candidate.name,
+                        "category": category,
+                        "error": str(e),
+                    },
+                )
             if not retryable:
                 raise
             fallbacks.append(candidate.name)
@@ -720,6 +766,83 @@ def _emit_usage_log(response: CallResponse, *, silent: bool) -> None:
     if silent:
         return
     click.echo(_format_usage_line(response), err=True)
+
+
+def _start_exec_session_log(
+    *,
+    log_file: str | None,
+    resume_session_id: str | None,
+) -> SessionLog:
+    try:
+        return SessionLog(
+            path=Path(log_file).expanduser() if log_file else None,
+            session_id=resume_session_id,
+        )
+    except SessionLogError as e:
+        raise click.ClickException(str(e)) from e
+
+
+def _emit_session_route_decision(
+    session_log: SessionLog | None,
+    decision: RouteDecision,
+) -> None:
+    if session_log is None:
+        return
+    session_log.emit(
+        "route_decision",
+        {
+            "provider": decision.provider,
+            "prefer": decision.prefer,
+            "effort": decision.effort,
+            "thinking_budget": decision.thinking_budget,
+            "task_tags": list(decision.task_tags),
+            "matched_tags": list(decision.matched_tags),
+            "tools_requested": list(decision.tools_requested),
+            "sandbox": decision.sandbox,
+            "ranked": [asdict(candidate) for candidate in decision.ranked],
+        },
+    )
+
+
+def _emit_session_usage(
+    session_log: SessionLog | None,
+    response: CallResponse,
+) -> None:
+    if session_log is None:
+        return
+    session_log.emit(
+        "usage",
+        {
+            "provider": response.provider,
+            "model": response.model,
+            "session_id": response.session_id,
+            "usage": response.usage,
+            "cost_usd": response.cost_usd,
+            "duration_ms": response.duration_ms,
+        },
+    )
+
+
+def _tail_record(record: SessionRecord) -> None:
+    offset = 0
+    current_path = record.log_path
+    current_status = record.status
+    while True:
+        if current_path.exists():
+            with current_path.open("r", encoding="utf-8") as fh:
+                fh.seek(offset)
+                chunk = fh.read()
+                if chunk:
+                    click.echo(chunk, nl=False)
+                offset = fh.tell()
+        if current_status != "running":
+            return
+        time.sleep(0.1)
+        refreshed = find_session_record(record.session_id) or find_session_record(record.run_id)
+        if refreshed is None:
+            return
+        current_path = refreshed.log_path
+        current_status = refreshed.status
 
 
 def _openrouter_catalog_or_exit() -> openrouter_catalog.CatalogSnapshot:
@@ -1084,6 +1207,14 @@ def call(
 )
 @click.option("--model", default=None, help="Override the provider's default model.")
 @click.option(
+    "--log-file",
+    default=None,
+    help=(
+        "Write structured NDJSON progress events to PATH. Defaults to "
+        "~/.cache/conductor/sessions/<session_id>.ndjson."
+    ),
+)
+@click.option(
     "--json",
     "as_json",
     is_flag=True,
@@ -1121,6 +1252,7 @@ def exec_cmd(
     task: str | None,
     task_file: str | None,
     model: str | None,
+    log_file: str | None,
     as_json: bool,
     verbose_route: bool,
     silent_route: bool,
@@ -1169,6 +1301,7 @@ def exec_cmd(
     effort_value = _parse_effort(effort)
 
     decision: RouteDecision | None = None
+    session_log: SessionLog | None = None
     if auto:
         try:
             provider, decision = pick(
@@ -1183,6 +1316,11 @@ def exec_cmd(
         except (NoConfiguredProvider, InvalidRouterRequest, MutedProvidersError) as e:
             click.echo(f"conductor: {e}", err=True)
             sys.exit(2)
+        session_log = _start_exec_session_log(
+            log_file=log_file,
+            resume_session_id=resume_session_id,
+        )
+        _emit_session_route_decision(session_log, decision)
         print_caller_banner(decision.provider, silent=silent_route or as_json)
         _emit_route_log(decision, verbose=verbose_route, silent=silent_route or as_json)
 
@@ -1199,14 +1337,24 @@ def exec_cmd(
                 timeout_sec=timeout_sec,
                 max_stall_sec=max_stall_sec,
                 silent=silent_route or as_json,
+                resume_session_id=resume_session_id,
+                session_log=session_log,
             )
         except UnsupportedCapability as e:
+            if session_log is not None:
+                session_log.emit("provider_failed", {"error": str(e)})
+                session_log.mark_finished()
             click.echo(f"conductor: {e}", err=True)
             sys.exit(2)
         except ProviderConfigError as e:
+            if session_log is not None:
+                session_log.emit("provider_failed", {"error": str(e)})
+                session_log.mark_finished()
             click.echo(f"conductor: {e}", err=True)
             sys.exit(2)
         except ProviderError as e:
+            if session_log is not None:
+                session_log.mark_finished()
             click.echo(f"conductor: {e}", err=True)
             sys.exit(1)
     else:
@@ -1219,8 +1367,25 @@ def exec_cmd(
             provider = get_provider(provider_id)
         except KeyError as e:
             raise click.UsageError(str(e)) from e
+        session_log = _start_exec_session_log(
+            log_file=log_file,
+            resume_session_id=resume_session_id,
+        )
+        session_log.bind_provider(provider_id)
         print_caller_banner(provider_id, silent=silent_route or as_json)
         try:
+            session_log.emit(
+                "provider_started",
+                {
+                    "provider": provider_id,
+                    "mode": "exec",
+                    "model": model,
+                    "tools": sorted(tools_set),
+                    "sandbox": sandbox_value,
+                    "cwd": cwd,
+                    "resume_session_id": resume_session_id,
+                },
+            )
             if isinstance(provider, OpenRouterProvider):
                 response = provider.exec(
                     body,
@@ -1235,6 +1400,7 @@ def exec_cmd(
                     timeout_sec=timeout_sec,
                     max_stall_sec=max_stall_sec,
                     resume_session_id=resume_session_id,
+                    session_log=session_log,
                 )
             else:
                 response = provider.exec(
@@ -1247,20 +1413,40 @@ def exec_cmd(
                     timeout_sec=timeout_sec,
                     max_stall_sec=max_stall_sec,
                     resume_session_id=resume_session_id,
+                    session_log=session_log,
                 )
         except UnsupportedCapability as e:
+            session_log.emit("provider_failed", {"provider": provider_id, "error": str(e)})
+            session_log.mark_finished()
             click.echo(f"conductor: {e}", err=True)
             sys.exit(2)
         except ProviderConfigError as e:
+            session_log.emit("provider_failed", {"provider": provider_id, "error": str(e)})
+            session_log.mark_finished()
             click.echo(f"conductor: {e}", err=True)
             sys.exit(2)
         except ProviderError as e:
+            session_log.emit("provider_failed", {"provider": provider_id, "error": str(e)})
+            session_log.mark_finished()
             click.echo(f"conductor: {e}", err=True)
             _maybe_echo_explicit_network_hint(provider_id, e)
             sys.exit(1)
+        session_log.set_session_id(response.session_id)
+        session_log.emit(
+            "provider_finished",
+            {
+                "provider": response.provider,
+                "model": response.model,
+                "duration_ms": response.duration_ms,
+                "session_id": response.session_id,
+            },
+        )
 
     if auto and not as_json:
         _emit_usage_log(response, silent=silent_route)
+    _emit_session_usage(session_log, response)
+    if session_log is not None:
+        session_log.mark_finished()
     _emit_call(response, as_json=as_json, decision=decision)
 
 
@@ -2144,6 +2330,55 @@ def _run_unwire() -> int:
         for path, reason in report.skipped:
             click.echo(f"  {path}  — {reason}")
     return 0
+
+
+# --------------------------------------------------------------------------- #
+# sessions — inspect structured exec logs
+# --------------------------------------------------------------------------- #
+
+
+@main.group()
+def sessions() -> None:
+    """Inspect structured session logs for `conductor exec`."""
+
+
+@sessions.command("list")
+def sessions_list() -> None:
+    """List known session logs with their latest status."""
+    records = list_session_records()
+    if not records:
+        click.echo("(no session logs)")
+        return
+
+    click.echo(
+        "SESSION ID                           STATUS    UPDATED                      PROVIDER"
+    )
+    click.echo("--------------------------------------------------------------------------------------")
+    for record in reversed(records):
+        provider = record.provider or "-"
+        click.echo(
+            f"{record.session_id:<36}  "
+            f"{record.status:<8}  "
+            f"{record.updated_at:<27}  "
+            f"{provider}"
+        )
+
+
+@sessions.command("tail")
+@click.argument("session_id", required=False)
+def sessions_tail(session_id: str | None) -> None:
+    """Print a session log and follow it while the session is running."""
+    if session_id is None:
+        record = latest_active_session()
+        if record is None:
+            click.echo("no active session")
+            return
+    else:
+        record = find_session_record(session_id)
+        if record is None:
+            raise click.ClickException(f"unknown session {session_id!r}")
+
+    _tail_record(record)
 
 
 # --------------------------------------------------------------------------- #

--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -15,6 +15,7 @@ import json
 import shutil
 import subprocess
 import time
+from typing import TYPE_CHECKING
 
 from conductor.providers.interface import (
     CallResponse,
@@ -23,6 +24,9 @@ from conductor.providers.interface import (
     ProviderHTTPError,
     resolve_effort_tokens,
 )
+
+if TYPE_CHECKING:
+    from conductor.session_log import SessionLog
 
 CLAUDE_DEFAULT_MODEL = "sonnet"
 CLAUDE_REQUEST_TIMEOUT_SEC = 180.0
@@ -188,6 +192,7 @@ class ClaudeProvider:
         timeout_sec: int | None = None,
         max_stall_sec: int | None = None,
         resume_session_id: str | None = None,
+        session_log: SessionLog | None = None,
     ) -> CallResponse:
         # accepted for API parity; only codex implements stall-watchdog today
         # Claude's `--allowedTools` is fine-grained; passing an empty set

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -23,6 +23,7 @@ import sys
 import threading
 import time
 from pathlib import Path  # noqa: TC003 — runtime import so tests can patch Path.write_text
+from typing import TYPE_CHECKING
 
 from conductor import __version__ as _conductor_version
 from conductor.offline_mode import _cache_dir
@@ -34,6 +35,9 @@ from conductor.providers.interface import (
     ProviderStalledError,
     resolve_effort_tokens,
 )
+
+if TYPE_CHECKING:
+    from conductor.session_log import SessionLog
 
 CODEX_DEFAULT_MODEL = "gpt-5.4"
 CODEX_REQUEST_TIMEOUT_SEC = 180.0
@@ -195,6 +199,55 @@ class CodexProvider:
                 output_tokens = (output_tokens or 0) + (usage.get("output_tokens") or 0)
         return content, input_tokens, output_tokens, session_id
 
+    def _emit_stream_event(
+        self,
+        raw_line: str,
+        *,
+        session_log: SessionLog | None,
+    ) -> None:
+        if session_log is None:
+            return
+        try:
+            event = json.loads(raw_line)
+        except json.JSONDecodeError:
+            return
+
+        kind = event.get("type")
+        if kind == "session.created":
+            session_log.set_session_id(event.get("session_id") or event.get("id"))
+            return
+
+        item = event.get("item") or {}
+        item_type = item.get("type")
+        if kind == "item.completed" and item_type == "agent_message":
+            token_count = (
+                item.get("token_count")
+                or event.get("token_count")
+                or event.get("output_tokens")
+            )
+            session_log.emit(
+                "subagent_message",
+                {
+                    "provider": self.name,
+                    "token_count": token_count,
+                    "text": item.get("text", ""),
+                },
+            )
+            return
+
+        if item_type and (
+            "tool" in str(item_type) or str(item_type) in {"function_call", "tool_use"}
+        ):
+            session_log.emit(
+                "tool_call",
+                {
+                    "provider": self.name,
+                    "item_type": item_type,
+                    "name": item.get("name") or item.get("tool_name"),
+                    "args": item.get("arguments") or item.get("args"),
+                },
+            )
+
     def call(
         self,
         task: str,
@@ -224,6 +277,7 @@ class CodexProvider:
         max_stall_sec: int | None = None,
         liveness_interval_sec: float = 30.0,
         resume_session_id: str | None = None,
+        session_log: SessionLog | None = None,
     ) -> CallResponse:
         codex_sandbox = {
             "read-only": "read-only",
@@ -241,6 +295,7 @@ class CodexProvider:
             liveness_interval_sec=liveness_interval_sec,
             stream=True,
             resume_session_id=resume_session_id,
+            session_log=session_log,
         )
 
     def _run(
@@ -256,6 +311,7 @@ class CodexProvider:
         liveness_interval_sec: float = 30.0,
         stream: bool = False,
         resume_session_id: str | None = None,
+        session_log: SessionLog | None = None,
     ) -> CallResponse:
         # Cheap PATH check on the hot path; auth state surfaces as a CLI
         # exit failure below if needed. configured() (with auth probe) is
@@ -312,6 +368,7 @@ class CodexProvider:
                 timeout=timeout,
                 max_stall_sec=max_stall_sec,
                 liveness_interval_sec=liveness_interval_sec,
+                session_log=session_log,
             )
 
         start = time.monotonic()
@@ -388,6 +445,7 @@ class CodexProvider:
         timeout: float | None,
         max_stall_sec: int | None,
         liveness_interval_sec: float,
+        session_log: SessionLog | None,
     ) -> CallResponse:
         start = time.monotonic()
         process = subprocess.Popen(
@@ -475,6 +533,14 @@ class CodexProvider:
                 and now - last_output >= liveness_interval_sec
                 and now - last_liveness >= liveness_interval_sec
             ):
+                if session_log is not None:
+                    session_log.emit(
+                        "provider_silent",
+                        {
+                            "provider": self.name,
+                            "silent_sec": round(now - last_output, 1),
+                        },
+                    )
                 sys.stderr.write(
                     f"[conductor] no output from codex for {now - last_output:.0f}s...\n"
                 )
@@ -497,10 +563,13 @@ class CodexProvider:
             stdout_parts.append(item)
             last_output = time.monotonic()
             last_liveness = last_output
+            self._emit_stream_event(item, session_log=session_log)
 
             if not session_id_emitted:
                 sid = self._extract_session_id_fast(item)
                 if sid is not None:
+                    if session_log is not None:
+                        session_log.set_session_id(sid)
                     sys.stderr.write(f"[conductor] codex session_id={sid}\n")
                     sys.stderr.flush()
                     session_id_emitted = True
@@ -519,6 +588,8 @@ class CodexProvider:
             )
 
         content, input_tokens, output_tokens, session_id = self._parse_ndjson(stdout)
+        if session_log is not None:
+            session_log.set_session_id(session_id)
         if not content:
             raise ProviderHTTPError(
                 f"codex NDJSON stream had no agent_message: {stdout[:500]!r}"

--- a/src/conductor/providers/gemini.py
+++ b/src/conductor/providers/gemini.py
@@ -18,6 +18,7 @@ import shutil
 import subprocess
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from conductor.providers.interface import (
     CallResponse,
@@ -26,6 +27,9 @@ from conductor.providers.interface import (
     ProviderHTTPError,
     resolve_effort_tokens,
 )
+
+if TYPE_CHECKING:
+    from conductor.session_log import SessionLog
 
 GEMINI_DEFAULT_MODEL = "gemini-2.5-pro"
 GEMINI_REQUEST_TIMEOUT_SEC = 180.0
@@ -213,6 +217,7 @@ class GeminiProvider:
         timeout_sec: int | None = None,
         max_stall_sec: int | None = None,
         resume_session_id: str | None = None,
+        session_log: SessionLog | None = None,
     ) -> CallResponse:
         # accepted for API parity; only codex implements stall-watchdog today
         # Gemini's --approval-mode: "plan" (read-only) vs "yolo" (all writes

--- a/src/conductor/providers/interface.py
+++ b/src/conductor/providers/interface.py
@@ -29,7 +29,10 @@ supported_sandboxes against the caller's request, then scores by `prefer`.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import ClassVar, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, ClassVar, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from conductor.session_log import SessionLog
 
 # --------------------------------------------------------------------------- #
 # Effort levels — symbolic dial for "how hard should this provider think".
@@ -184,6 +187,7 @@ class Provider(Protocol):
         timeout_sec: int | None = None,
         max_stall_sec: int | None = None,
         resume_session_id: str | None = None,
+        session_log: SessionLog | None = None,
     ) -> CallResponse:
         """Multi-turn agent session with tool access.
 

--- a/src/conductor/providers/ollama.py
+++ b/src/conductor/providers/ollama.py
@@ -15,6 +15,7 @@ import json
 import os
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import httpx
 
@@ -24,6 +25,9 @@ from conductor.providers.interface import (
     ProviderHTTPError,
     UnsupportedCapability,
 )
+
+if TYPE_CHECKING:
+    from conductor.session_log import SessionLog
 from conductor.tools import (
     ToolExecutionError,
     ToolExecutor,
@@ -301,6 +305,7 @@ class OllamaProvider:
         timeout_sec: int | None = None,
         max_stall_sec: int | None = None,
         resume_session_id: str | None = None,
+        session_log: SessionLog | None = None,
     ) -> CallResponse:
         # accepted for API parity; only codex implements stall-watchdog today
         if resume_session_id:
@@ -463,6 +468,19 @@ class OllamaProvider:
                         result = executor.run(name, args)
                     except ToolExecutionError as e:
                         result = f"error: {e}"
+                if session_log is not None:
+                    session_log.emit(
+                        "tool_call",
+                        {
+                            "provider": self.name,
+                            "iteration": iteration,
+                            "name": name,
+                            "args": args,
+                            "result_preview": (
+                                result[:200] if isinstance(result, str) else result
+                            ),
+                        },
+                    )
 
                 # Ollama does not always emit `id`; fall back to a synthesized one.
                 tool_msg: dict = {

--- a/src/conductor/providers/openrouter.py
+++ b/src/conductor/providers/openrouter.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import sys
 import time
+from typing import TYPE_CHECKING
 
 import httpx
 
@@ -22,6 +23,9 @@ from conductor.providers.interface import (
     UnsupportedCapability,
     resolve_effort_tokens,
 )
+
+if TYPE_CHECKING:
+    from conductor.session_log import SessionLog
 
 from . import openrouter_catalog
 
@@ -247,6 +251,7 @@ class OpenRouterProvider:
         timeout_sec: int | None = None,
         max_stall_sec: int | None = None,
         resume_session_id: str | None = None,
+        session_log: SessionLog | None = None,
     ) -> CallResponse:
         if resume_session_id:
             raise UnsupportedCapability(

--- a/src/conductor/providers/shell.py
+++ b/src/conductor/providers/shell.py
@@ -37,7 +37,7 @@ import shutil
 import subprocess
 import time
 from dataclasses import dataclass
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from conductor.providers.interface import (
     CallResponse,
@@ -46,6 +46,9 @@ from conductor.providers.interface import (
     ProviderHTTPError,
     UnsupportedCapability,
 )
+
+if TYPE_CHECKING:
+    from conductor.session_log import SessionLog
 
 SHELL_PROVIDER_TIMEOUT_SEC = 180.0
 
@@ -194,6 +197,7 @@ class ShellProvider:
         timeout_sec: int | None = None,
         max_stall_sec: int | None = None,
         resume_session_id: str | None = None,
+        session_log: SessionLog | None = None,
     ) -> CallResponse:
         # accepted for API parity; only codex implements stall-watchdog today
         if tools:

--- a/src/conductor/session_log.py
+++ b/src/conductor/session_log.py
@@ -1,0 +1,219 @@
+"""Structured session logs for `conductor exec`.
+
+Each session log is NDJSON: one JSON object per line, append-only.
+Metadata lives alongside the logs in the conductor cache so `sessions list`
+and `sessions tail` can discover active and completed runs without parsing
+the full event stream every time.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from conductor.offline_mode import _cache_dir
+
+
+class SessionLogError(RuntimeError):
+    """Raised when conductor cannot create or update a session log."""
+
+
+def _iso8601_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def sessions_dir() -> Path:
+    primary = _cache_dir() / "sessions"
+    try:
+        primary.mkdir(parents=True, exist_ok=True)
+        return primary
+    except OSError:
+        fallback = Path(tempfile.gettempdir()) / "conductor" / "sessions"
+        fallback.mkdir(parents=True, exist_ok=True)
+        return fallback
+
+
+def _meta_path(run_id: str) -> Path:
+    return sessions_dir() / f"{run_id}.meta.json"
+
+
+@dataclass(frozen=True)
+class SessionRecord:
+    run_id: str
+    session_id: str
+    log_path: Path
+    status: str
+    started_at: str
+    updated_at: str
+    finished_at: str | None
+    provider: str | None
+    explicit_log_path: bool
+
+
+class SessionLog:
+    """Append-only NDJSON event writer plus lightweight session metadata."""
+
+    def __init__(
+        self,
+        *,
+        path: Path | None = None,
+        session_id: str | None = None,
+    ) -> None:
+        self.run_id = str(uuid.uuid4())
+        self.session_id = session_id or self.run_id
+        self.provider: str | None = None
+        self.explicit_log_path = path is not None
+        self.started_at = _iso8601_now()
+        self.updated_at = self.started_at
+        self.finished_at: str | None = None
+        self.status = "running"
+
+        if path is None:
+            self.log_path = sessions_dir() / f"{self.session_id}.ndjson"
+        else:
+            self.log_path = path.expanduser()
+
+        self._ensure_parent_dirs()
+        self._write_meta()
+
+    def _ensure_parent_dirs(self) -> None:
+        try:
+            sessions_dir().mkdir(parents=True, exist_ok=True)
+            self.log_path.parent.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            raise SessionLogError(
+                f"could not create session log directories: {e.strerror or e}"
+            ) from e
+
+    def bind_provider(self, provider: str) -> None:
+        self.provider = provider
+        self._touch_meta()
+
+    def emit(self, event: str, data: dict | None = None) -> None:
+        payload = {
+            "ts": _iso8601_now(),
+            "event": event,
+            "data": data or {},
+        }
+        try:
+            with self.log_path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(payload, default=str))
+                fh.write("\n")
+        except OSError as e:
+            raise SessionLogError(
+                f"could not append session log {self.log_path}: {e.strerror or e}"
+            ) from e
+        self._touch_meta()
+
+    def set_session_id(self, session_id: str | None) -> None:
+        if not session_id or session_id == self.session_id:
+            return
+
+        old_path = self.log_path
+        self.session_id = session_id
+        if not self.explicit_log_path:
+            target = sessions_dir() / f"{session_id}.ndjson"
+            self._move_or_merge_log(old_path, target)
+            self.log_path = target
+        self._touch_meta()
+
+    def mark_finished(self) -> None:
+        self.status = "finished"
+        self.finished_at = _iso8601_now()
+        self._touch_meta()
+
+    def _move_or_merge_log(self, source: Path, target: Path) -> None:
+        if source == target or not source.exists():
+            return
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if target.exists():
+                with source.open("r", encoding="utf-8") as src, target.open(
+                    "a", encoding="utf-8"
+                ) as dst:
+                    shutil.copyfileobj(src, dst)
+                source.unlink()
+            else:
+                os.replace(source, target)
+        except OSError as e:
+            raise SessionLogError(
+                f"could not move session log into canonical path {target}: "
+                f"{e.strerror or e}"
+            ) from e
+
+    def _touch_meta(self) -> None:
+        self.updated_at = _iso8601_now()
+        self._write_meta()
+
+    def _write_meta(self) -> None:
+        payload = {
+            "run_id": self.run_id,
+            "session_id": self.session_id,
+            "log_path": str(self.log_path),
+            "status": self.status,
+            "started_at": self.started_at,
+            "updated_at": self.updated_at,
+            "finished_at": self.finished_at,
+            "provider": self.provider,
+            "explicit_log_path": self.explicit_log_path,
+        }
+        path = _meta_path(self.run_id)
+        tmp = path.with_suffix(".tmp")
+        try:
+            sessions_dir().mkdir(parents=True, exist_ok=True)
+            tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            os.replace(tmp, path)
+        except OSError as e:
+            raise SessionLogError(
+                f"could not update session metadata {path}: {e.strerror or e}"
+            ) from e
+
+
+def list_session_records() -> list[SessionRecord]:
+    records: list[SessionRecord] = []
+    root = sessions_dir()
+    if not root.exists():
+        return []
+    for meta in sorted(root.glob("*.meta.json")):
+        try:
+            data = json.loads(meta.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        session_id = str(data.get("session_id") or "")
+        log_path_raw = data.get("log_path")
+        if not session_id or not log_path_raw:
+            continue
+        records.append(
+            SessionRecord(
+                run_id=str(data.get("run_id") or meta.stem.removesuffix(".meta")),
+                session_id=session_id,
+                log_path=Path(str(log_path_raw)).expanduser(),
+                status=str(data.get("status") or "running"),
+                started_at=str(data.get("started_at") or ""),
+                updated_at=str(data.get("updated_at") or ""),
+                finished_at=data.get("finished_at"),
+                provider=data.get("provider"),
+                explicit_log_path=bool(data.get("explicit_log_path")),
+            )
+        )
+    return sorted(records, key=lambda record: (record.updated_at, record.started_at))
+
+
+def find_session_record(session_id: str) -> SessionRecord | None:
+    for record in reversed(list_session_records()):
+        if record.session_id == session_id or record.run_id == session_id:
+            return record
+    return None
+
+
+def latest_active_session() -> SessionRecord | None:
+    for record in reversed(list_session_records()):
+        if record.status == "running":
+            return record
+    return None

--- a/tests/test_cli_log_file.py
+++ b/tests/test_cli_log_file.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from click.testing import CliRunner
+
+from conductor.cli import main
+from conductor.providers import (
+    CallResponse,
+    ClaudeProvider,
+    CodexProvider,
+    DeepSeekChatProvider,
+    DeepSeekReasonerProvider,
+    GeminiProvider,
+    KimiProvider,
+    OllamaProvider,
+    OpenRouterProvider,
+)
+from conductor.router import reset_health
+from conductor.session_log import SessionLog
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _stub_all_configured(mocker, configured_names: set[str]) -> None:
+    classes = {
+        "kimi": KimiProvider,
+        "claude": ClaudeProvider,
+        "codex": CodexProvider,
+        "deepseek-chat": DeepSeekChatProvider,
+        "deepseek-reasoner": DeepSeekReasonerProvider,
+        "gemini": GeminiProvider,
+        "ollama": OllamaProvider,
+        "openrouter": OpenRouterProvider,
+    }
+    for name, cls in classes.items():
+        ok = name in configured_names
+        mocker.patch.object(
+            cls,
+            "configured",
+            lambda self, _ok=ok, _name=name: (
+                _ok,
+                None if _ok else f"{_name} stub not configured",
+            ),
+        )
+
+
+def _read_events(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_exec_log_file_writes_structured_ndjson_for_auto_route(
+    mocker,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    reset_health()
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    _stub_all_configured(mocker, {"claude"})
+
+    def _fake_exec(self, task, model=None, **kwargs):
+        session_log = kwargs["session_log"]
+        session_log.set_session_id("sess-auto-1")
+        session_log.emit(
+            "tool_call",
+            {"provider": "claude", "name": "Read", "args": {"path": "README.md"}},
+        )
+        session_log.emit(
+            "subagent_message",
+            {"provider": "claude", "token_count": 23, "text": "working"},
+        )
+        return CallResponse(
+            text="done",
+            provider="claude",
+            model="sonnet",
+            duration_ms=321,
+            usage={"input_tokens": 12, "output_tokens": 4, "thinking_tokens": 7},
+            cost_usd=0.02,
+            session_id="sess-auto-1",
+            raw={},
+        )
+
+    mocker.patch.object(ClaudeProvider, "exec", _fake_exec)
+    log_path = tmp_path / "session.ndjson"
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--auto",
+            "--prefer",
+            "best",
+            "--tools",
+            "Read",
+            "--sandbox",
+            "read-only",
+            "--task",
+            "review the diff",
+            "--log-file",
+            str(log_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    events = _read_events(log_path)
+    assert all({"ts", "event", "data"} <= set(event) for event in events)
+    kinds = [event["event"] for event in events]
+    assert "route_decision" in kinds
+    assert "provider_started" in kinds
+    assert "tool_call" in kinds
+    assert "subagent_message" in kinds
+    assert "provider_finished" in kinds
+    assert "usage" in kinds
+    route_event = next(event for event in events if event["event"] == "route_decision")
+    assert route_event["data"]["provider"] == "claude"
+    usage_event = next(event for event in events if event["event"] == "usage")
+    assert usage_event["data"]["usage"]["output_tokens"] == 4
+
+
+def test_exec_default_log_file_uses_provider_session_id(
+    mocker,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    reset_health()
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    _stub_all_configured(mocker, {"claude"})
+
+    def _fake_exec(self, task, model=None, **kwargs):
+        session_log = kwargs["session_log"]
+        session_log.set_session_id("sess-default-1")
+        session_log.emit(
+            "subagent_message",
+            {"provider": "claude", "token_count": 11, "text": "done"},
+        )
+        return CallResponse(
+            text="done",
+            provider="claude",
+            model="sonnet",
+            duration_ms=210,
+            usage={"input_tokens": 8, "output_tokens": 2},
+            cost_usd=0.01,
+            session_id="sess-default-1",
+            raw={},
+        )
+
+    mocker.patch.object(ClaudeProvider, "exec", _fake_exec)
+
+    result = CliRunner().invoke(
+        main,
+        ["exec", "--with", "claude", "--task", "write the patch"],
+    )
+
+    assert result.exit_code == 0, result.output
+    sessions_root = tmp_path / "conductor" / "sessions"
+    log_path = sessions_root / "sess-default-1.ndjson"
+    assert log_path.exists()
+    events = _read_events(log_path)
+    assert events[-1]["event"] == "usage"
+    assert {path.name for path in sessions_root.glob("*.ndjson")} == {"sess-default-1.ndjson"}
+
+
+def test_sessions_list_and_tail_use_cached_metadata(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+
+    finished = SessionLog(session_id="sess-finished-1")
+    finished.bind_provider("claude")
+    finished.emit("provider_started", {"provider": "claude"})
+    finished.mark_finished()
+
+    running = SessionLog(session_id="sess-running-1")
+    running.bind_provider("codex")
+    running.emit("provider_started", {"provider": "codex"})
+
+    list_result = CliRunner().invoke(main, ["sessions", "list"])
+
+    assert list_result.exit_code == 0, list_result.output
+    assert "sess-finished-1" in list_result.output
+    assert "finished" in list_result.output
+    assert "sess-running-1" in list_result.output
+    assert "running" in list_result.output
+
+    tail_result = CliRunner().invoke(main, ["sessions", "tail", "sess-finished-1"])
+
+    assert tail_result.exit_code == 0, tail_result.output
+    tailed = [json.loads(line) for line in tail_result.output.splitlines()]
+    assert tailed[0]["event"] == "provider_started"
+
+
+def test_sessions_tail_without_active_session_prints_message(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+
+    result = CliRunner().invoke(main, ["sessions", "tail"])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == "no active session"


### PR DESCRIPTION
Today a 10-minute exec is hard to monitor. `tee | tail -f` has
buffering issues; finding the running PID requires `ps aux | grep`.
Add structured progress logging that doesn't depend on stdout
buffering, plus a `conductor sessions` command for live-tail and
inventory.

What ships:

- src/conductor/session_log.py — new module. NDJSON event logger
  that providers and the CLI can both write to. Append-only, one
  JSON object per line, emits to file regardless of stdout
  destination.

- src/conductor/cli.py:
  - `--log-file <path>` option on `conductor exec`. When passed,
    writes events to <path>; otherwise, writes to
    `~/.cache/conductor/sessions/<session_id>.ndjson`.
  - `conductor sessions list` — known sessions with timestamps +
    status (running/finished).
  - `conductor sessions tail [<session_id>]` — `tail -f`-style
    follow on the latest session's NDJSON (or named one).
  - Emits `route_decision`, `provider_started`, `provider_finished`,
    `usage` events at the CLI layer regardless of provider.

- src/conductor/providers/{codex,ollama,claude,gemini,openrouter,
  shell}.py + interface.py: providers accept an optional
  SessionLog kwarg in exec(). Codex's streaming path emits
  `subagent_message` and `provider_silent` (the existing
  heartbeats now feed the log). Ollama's tool loop emits
  `tool_call` per Edit/Bash/etc. invocation. Public API
  unchanged — kwarg is optional.

- tests/test_cli_log_file.py — covers `--log-file` shape, default
  cache path, `sessions list`, `sessions tail` smoke. All HTTP
  mocked.

Closes #45.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
