### PR TITLE
fix(ci): skip no-commit-to-branch hook on main-push validate runs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,6 +32,12 @@ jobs:
         run: uv sync --group dev
 
       - name: Run pre-commit hygiene
+        # `no-commit-to-branch` always fails on main pushes by definition —
+        # it's the local-developer guard against direct commits, not a CI
+        # check. PRs run on feature branches so the hook is silent there;
+        # only post-merge main pushes hit it. Skip explicitly in CI.
+        env:
+          SKIP: no-commit-to-branch
         run: |
           pipx install pre-commit
           pre-commit run --all-files --hook-stage pre-commit --show-diff-on-failure


### PR DESCRIPTION
Counterpart to #69 (un-tracked _version.py). Every main push runs
`pre-commit run --all-files --hook-stage pre-commit`, which executes
the no-commit-to-branch hook. That hook always fails on main by
definition — it's the local-developer guard against direct commits,
not a CI check. PRs run on feature branches so it's silent there;
only post-merge main pushes hit it.

Set `SKIP=no-commit-to-branch` on the workflow step so the hook stays
out of CI while remaining active for local commits and pre-push
checks.

After this lands, the email "[autumngarage/conductor] validate
workflow run" failures stop arriving.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
