### PR TITLE
fix(branch-guard): worktree-aware via `git -C <path>` parsing

### DIFF
--- a/scripts/branch-guard.sh
+++ b/scripts/branch-guard.sh
@@ -28,9 +28,9 @@ set -euo pipefail
 input="$(cat)"
 
 # Fast path — bail on non-git-commit calls without the jq/git overhead.
-# Matches "git commit" with optional whitespace; explicitly NOT matching
-# "git commit-tree" or other unrelated subcommands.
-if ! printf '%s' "$input" | grep -qE '"command"[[:space:]]*:[[:space:]]*"[^"]*\bgit[[:space:]]+commit\b'; then
+# Matches `git commit` with optional `-c key=value` / `-C <path>` flags
+# ahead of the subcommand; explicitly NOT matching `commit-tree`.
+if ! printf '%s' "$input" | grep -qE '"command"[[:space:]]*:[[:space:]]*"[^"]*\bgit([[:space:]]+-c[[:space:]]+[^[:space:]]+|[[:space:]]+-C[[:space:]]+[^[:space:]]+)*[[:space:]]+commit([[:space:]]|$)'; then
   exit 0
 fi
 
@@ -49,8 +49,19 @@ cwd="$(printf '%s' "$input" | jq -r '.cwd // ""')"
 # class is explicit — `\b` would match `commit-tree` because `-` is a
 # non-word char; we want `commit` followed by whitespace or end-of-string
 # only, so plumbing subcommands like `git commit-tree` pass through.
-if ! printf '%s' "$command" | grep -qE '\bgit[[:space:]]+commit([[:space:]]|$)'; then
+if ! printf '%s' "$command" | grep -qE '\bgit([[:space:]]+-c[[:space:]]+[^[:space:]]+|[[:space:]]+-C[[:space:]]+[^[:space:]]+)*[[:space:]]+commit([[:space:]]|$)'; then
   exit 0
+fi
+
+# Worktree-aware: when commit targets a different repo via `-C <path>`,
+# check that branch instead.
+target_cwd="$(printf '%s' "$command" | grep -oE '\-C[[:space:]]+[^[:space:]]+' | sed -E 's/^-C[[:space:]]+//' | tail -1 || true)"
+if [ -n "$target_cwd" ]; then
+  if [ -n "$cwd" ] && [ -d "$cwd/$target_cwd" ]; then
+    cwd="$cwd/$target_cwd"
+  elif [ -d "$target_cwd" ]; then
+    cwd="$target_cwd"
+  fi
 fi
 
 # Determine current branch in the project Claude is operating in.

--- a/tests/test_branch_guard.py
+++ b/tests/test_branch_guard.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "branch-guard.sh"
+
+pytestmark = [
+    pytest.mark.skipif(shutil.which("git") is None, reason="git not installed"),
+    pytest.mark.skipif(shutil.which("jq") is None, reason="jq not installed"),
+]
+
+
+def _git(repo: Path, *args: str) -> None:
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "Test User",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "Test User",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+    subprocess.run(["git", *args], cwd=repo, env=env, check=True, capture_output=True, text=True)
+
+
+def _init_repo(repo: Path) -> None:
+    _git(repo, "init", "-q", "-b", "main")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-q", "-m", "base")
+
+
+def _run_hook(command: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "cwd": str(cwd),
+    }
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_blocks_git_commit_on_main_branch(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+
+    result = _run_hook('git commit -m "test"', repo)
+
+    assert result.returncode == 2
+    assert "Blocked by Touchstone branch-guard" in result.stderr
+    assert "on 'main'" in result.stderr
+
+
+def test_allows_git_commit_on_feature_branch(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    _git(repo, "checkout", "-q", "-b", "feat/test")
+
+    result = _run_hook('git commit -m "test"', repo)
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
+def test_allows_git_commit_with_dash_capital_c_feature_worktree(tmp_path: Path) -> None:
+    parent = tmp_path / "repo"
+    worktree = tmp_path / "repo-feat"
+    parent.mkdir()
+    _init_repo(parent)
+    _git(parent, "branch", "feat/test")
+    _git(parent, "worktree", "add", str(worktree), "feat/test")
+
+    result = _run_hook(f'git -C {worktree} commit -m "test"', parent)
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
+def test_lowercase_dash_c_does_not_override_cwd(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+
+    result = _run_hook('git -c core.editor=foo commit -m "test"', repo)
+
+    assert result.returncode == 2
+    assert "Blocked by Touchstone branch-guard" in result.stderr
+    assert "on 'main'" in result.stderr


### PR DESCRIPTION
The PreToolUse hook reads `cwd` from the tool-call JSON and runs
`git -C "$cwd" branch --show-current` to decide whether to block a
commit. This is wrong when the parent agent is on `main` but the
commit targets a feature-branch worktree via `git -C <worktree>
commit ...` — the hook sees `main` and blocks, even though the
actual commit is fine.

Hit this 8+ times in a recent parallel-worktree session; the
workaround was to use `git -C <path>` form (which evades the regex
`'git[[:space:]]+commit'` because of the `-C path` between them).
That's an exploit, not a fix.

Update the hook to parse `-C <path>` from the command and use that
path for branch detection. Lowercase `-c` (config flag) doesn't
trigger the override — only `-C` (change-directory).

Also adds tests/test_branch_guard.py covering: main blocked,
feature allowed, `git -C <worktree>` from main-parent allowed
(the bug fix), and lowercase `-c` does not bypass the guard
(case-sensitivity regression guard).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
