### PR TITLE
fix(codex-review): tolerate footers after sentinel emission

### DIFF
--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -84,6 +84,29 @@
 #
 set -euo pipefail
 
+extract_review_sentinel() {
+  awk '
+    /^[[:space:]]*CODEX_REVIEW_(CLEAN|FIXED|BLOCKED)[[:space:]]*$/ {
+      line = $0
+      gsub(/\r/, "", line)
+      sub(/^[[:space:]]+/, "", line)
+      sub(/[[:space:]]+$/, "", line)
+      sentinel = line
+      count++
+    }
+    END {
+      if (count == 1) {
+        print sentinel
+      }
+    }
+  '
+}
+
+if [ "${CODEX_REVIEW_TEST_SENTINEL:-0}" = "1" ]; then
+  extract_review_sentinel
+  exit 0
+fi
+
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 CONFIG_FILE="$REPO_ROOT/.codex-review.toml"
 cd "$REPO_ROOT"
@@ -2088,8 +2111,8 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
     fi
   fi
 
-  LAST_LINE="$(printf '%s\n' "$OUTPUT" | tail -1 | tr -d '\r ')"
-  case "$LAST_LINE" in
+  LAST_SENTINEL="$(printf '%s\n' "$OUTPUT" | extract_review_sentinel)"
+  case "$LAST_SENTINEL" in
     CODEX_REVIEW_CLEAN)
       phase "done — clean"
       clean_subtitle="${REVIEWER_LABEL} · ${DIFF_LINE_COUNT} lines · push approved"
@@ -2166,8 +2189,14 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
       ;;
 
     *)
+      LAST_LINE="$(printf '%s\n' "$OUTPUT" | awk 'NF { line = $0 } END { print line }' | tr -d '\r')"
       echo "==> $REVIEWER_LABEL output did not match the expected sentinel contract."
-      echo "    Last line was: '$LAST_LINE'"
+      if [ -n "$LAST_SENTINEL" ]; then
+        echo "    Last matching sentinel line was: '$LAST_SENTINEL'"
+      else
+        echo "    No unique standalone sentinel line was found."
+      fi
+      echo "    Last non-blank line was: '$LAST_LINE'"
       echo "    Raw output (first 20 lines):"
       printf '%s\n' "$OUTPUT" | head -20 | sed 's/^/    /'
       REVIEW_EXIT_REASON="malformed-sentinel"

--- a/tests/test_codex_review_sentinel.py
+++ b/tests/test_codex_review_sentinel.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+def test_codex_review_sentinel_shell_regression() -> None:
+    repo = Path(__file__).resolve().parent.parent
+    test_script = repo / "tests" / "test_codex_review_sentinel.sh"
+    subprocess.run(["bash", str(test_script)], cwd=repo, check=True)
+
+
+def test_codex_review_wrapper_accepts_footer_after_sentinel(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@t",
+    }
+
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, env=env, check=True)
+    subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=repo, env=env, check=True)
+    (repo / "README").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README"], cwd=repo, env=env, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "base"], cwd=repo, env=env, check=True)
+    (repo / "README").write_text("base\nfeature\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README"], cwd=repo, env=env, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "feature"], cwd=repo, env=env, check=True)
+
+    (repo / ".codex-review.toml").write_text(
+        textwrap.dedent(
+            """
+            [codex_review]
+            max_iterations = 1
+            max_diff_lines = 5000
+            cache_clean_reviews = false
+            safe_by_default = true
+            mode = "review-only"
+            on_error = "fail-open"
+            unsafe_paths = []
+
+            [review]
+            enabled = true
+            reviewer = "conductor"
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "add", ".codex-review.toml"], cwd=repo, env=env, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "config"], cwd=repo, env=env, check=True)
+
+    fakes = tmp_path / "fakes"
+    fakes.mkdir()
+    conductor = fakes / "conductor"
+    conductor.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            case "$1" in
+              doctor)
+                printf '{"configured": true}\\n'
+                ;;
+              exec)
+                cat >/dev/null
+                printf 'LGTM\\nCODEX_REVIEW_CLEAN\\n---\\nreview complete\\n'
+                ;;
+              *)
+                exit 1
+                ;;
+            esac
+            """
+        ),
+        encoding="utf-8",
+    )
+    conductor.chmod(0o755)
+
+    script = Path(__file__).resolve().parent.parent / "scripts" / "codex-review.sh"
+    result = subprocess.run(
+        ["bash", str(script)],
+        cwd=repo,
+        env={
+            **env,
+            "PATH": f"{fakes}:{os.environ.get('PATH', '')}",
+            "CODEX_REVIEW_BASE": "HEAD~1",
+            "CODEX_REVIEW_MODE": "review-only",
+            "CODEX_REVIEW_DISABLE_CACHE": "1",
+            "CODEX_REVIEW_TIMEOUT": "5",
+            "NO_COLOR": "1",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ALL CLEAR" in result.stdout
+    assert "malformed sentinel" not in result.stdout

--- a/tests/test_codex_review_sentinel.sh
+++ b/tests/test_codex_review_sentinel.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/codex-review.sh"
+
+run_detector() {
+  local input="$1"
+  printf '%s' "$input" | CODEX_REVIEW_TEST_SENTINEL=1 bash "$SCRIPT"
+}
+
+assert_detector() {
+  local name="$1"
+  local input="$2"
+  local expected="$3"
+  local actual
+
+  actual="$(run_detector "$input")"
+  if [ "$actual" != "$expected" ]; then
+    printf 'FAIL: %s\nexpected: [%s]\nactual:   [%s]\n' "$name" "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+assert_detector \
+  "exact sentinel" \
+  $'Summary\nCODEX_REVIEW_CLEAN\n' \
+  "CODEX_REVIEW_CLEAN"
+
+assert_detector \
+  "trailing whitespace" \
+  $'Summary\nCODEX_REVIEW_CLEAN   \n\n' \
+  "CODEX_REVIEW_CLEAN"
+
+assert_detector \
+  "footer after sentinel" \
+  $'LGTM\nCODEX_REVIEW_CLEAN\n---\nreview complete\n' \
+  "CODEX_REVIEW_CLEAN"
+
+assert_detector \
+  "indented sentinel" \
+  $'Summary\n  CODEX_REVIEW_FIXED\t\nextra note\n' \
+  "CODEX_REVIEW_FIXED"
+
+assert_detector \
+  "inline sentinel rejected" \
+  $'Summary: CODEX_REVIEW_CLEAN\n' \
+  ""
+
+assert_detector \
+  "multiple sentinel lines rejected" \
+  $'CODEX_REVIEW_CLEAN\nCODEX_REVIEW_BLOCKED\n' \
+  ""
+
+printf 'ok\n'


### PR DESCRIPTION
Several recent PRs (#61, #64, #68, #70) triggered "malformed sentinel"
errors from the merge-review wrapper despite reviewer findings of 0.
Root cause: scripts/codex-review.sh inspected ONLY the final physical
line via `tail -1 | tr -d '\\r '` and `case`'d on that exact value.
Any footer after the sentinel — a stray markdown rule, a closing
fence, an LLM's habitual "Hope this helps." line — pushed the real
sentinel off the last position and the wrapper reported it as
malformed.

The reviewer was emitting CODEX_REVIEW_CLEAN correctly; the wrapper
was just looking in the wrong place.

Replace the tail-based check with a new extract_review_sentinel()
helper that finds exactly one standalone sentinel line anywhere in
the output, with surrounding whitespace tolerated. The malformed
path now reports "no unique standalone sentinel" rather than echoing
just the last line, so future regressions surface the real shape.

Adds tests/test_codex_review_sentinel.{sh,py} covering: sentinel
followed by trailing prose, sentinel mid-output with no extra
sentinels, multiple-sentinel ambiguity (still rejected), and the
clean baseline.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
