### PR TITLE
feat(codex): enrich exec heartbeats with progress data (#56)

### DIFF
--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -61,6 +61,15 @@ _EFFORT_TO_CODEX_FLAG = {
 }
 
 
+def _format_compact_count(value: int) -> str:
+    """Format integer counts for operator-facing heartbeat output."""
+    if value < 1_000:
+        return str(value)
+    if value < 10_000:
+        return f"{value / 1_000:.1f}k"
+    return f"{value // 1_000}k"
+
+
 class CodexProvider:
     name = "codex"
     tags = ["strong-reasoning", "code-review", "tool-use"]
@@ -247,6 +256,71 @@ class CodexProvider:
                     "args": item.get("arguments") or item.get("args"),
                 },
             )
+
+    def _read_session_log_progress(
+        self,
+        *,
+        session_log: SessionLog,
+        offset: int,
+    ) -> tuple[str | None, int]:
+        """Summarize tool/message progress from complete NDJSON lines.
+
+        Heartbeats report deltas since the previous heartbeat, not cumulative
+        totals since process start. We therefore advance the read offset only
+        after consuming complete newline-terminated records.
+        """
+        try:
+            with session_log.log_path.open("r", encoding="utf-8") as fh:
+                fh.seek(offset)
+                chunk = fh.read()
+                end_offset = fh.tell()
+        except OSError:
+            return None, offset
+
+        if not chunk:
+            return (
+                "[conductor] no output from codex for {silent_sec:.0f}s...",
+                offset,
+            )
+
+        lines = chunk.splitlines(keepends=True)
+        if lines and not lines[-1].endswith("\n"):
+            incomplete = lines.pop()
+            end_offset -= len(incomplete)
+
+        tool_calls = 0
+        tokens_received = 0
+        for line in lines:
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            if event.get("event") == "tool_call":
+                tool_calls += 1
+                continue
+
+            if event.get("event") != "subagent_message":
+                continue
+
+            token_count = (event.get("data") or {}).get("token_count")
+            if isinstance(token_count, int):
+                tokens_received += token_count
+
+        if tool_calls == 0 and tokens_received == 0:
+            return (
+                "[conductor] no output from codex for {silent_sec:.0f}s"
+                " · 0 tool calls, 0 tokens — possibly stalled",
+                end_offset,
+            )
+
+        tool_label = "tool call" if tool_calls == 1 else "tool calls"
+        return (
+            "[conductor] no output from codex for {silent_sec:.0f}s"
+            f" · {tool_calls} {tool_label}"
+            f" · {_format_compact_count(tokens_received)} tokens received since last heartbeat",
+            end_offset,
+        )
 
     def call(
         self,
@@ -487,6 +561,7 @@ class CodexProvider:
         stdout_done = False
         last_output = start
         last_liveness = start
+        heartbeat_log_offset = 0
         session_id_emitted = False
         while True:
             now = time.monotonic()
@@ -541,8 +616,20 @@ class CodexProvider:
                             "silent_sec": round(now - last_output, 1),
                         },
                     )
+                heartbeat_template: str | None = None
+                if session_log is not None:
+                    heartbeat_template, heartbeat_log_offset = (
+                        self._read_session_log_progress(
+                            session_log=session_log,
+                            offset=heartbeat_log_offset,
+                        )
+                    )
+                if heartbeat_template is None:
+                    heartbeat_template = (
+                        "[conductor] no output from codex for {silent_sec:.0f}s..."
+                    )
                 sys.stderr.write(
-                    f"[conductor] no output from codex for {now - last_output:.0f}s...\n"
+                    heartbeat_template.format(silent_sec=now - last_output) + "\n"
                 )
                 sys.stderr.flush()
                 last_liveness = now

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -23,6 +23,7 @@ from conductor.providers.interface import (
     ProviderHTTPError,
     ProviderStalledError,
 )
+from conductor.session_log import SessionLog
 
 
 def _strip_gemini_auth_env(monkeypatch) -> None:
@@ -620,6 +621,112 @@ def test_codex_exec_emits_liveness_signal_to_stderr(mocker, capsys):
         CodexProvider().exec("hi", max_stall_sec=0.25, liveness_interval_sec=0.1)
 
     assert "[conductor] no output from codex for " in capsys.readouterr().err
+
+
+def test_codex_exec_heartbeat_reports_tool_calls_from_session_log(
+    mocker, capsys, tmp_path, monkeypatch
+):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    lines = [
+        '{"type":"session.created","session_id":"sess-heartbeat-tools"}\n',
+        (
+            '{"type":"item.completed","item":{"type":"function_call","name":"Read",'
+            '"arguments":{"path":"README.md"}}}\n'
+        ),
+    ]
+    fake = _FakePopen(
+        stdout_schedule=[(0, line) for line in lines],
+        hang_after_stdout=True,
+    )
+    _patch_codex_popen(mocker, fake)
+    session_log = SessionLog(path=tmp_path / "heartbeat-tools.ndjson")
+
+    with pytest.raises(ProviderStalledError):
+        CodexProvider().exec(
+            "hi",
+            max_stall_sec=0.25,
+            liveness_interval_sec=0.1,
+            session_log=session_log,
+        )
+
+    err = capsys.readouterr().err
+    assert "1 tool call" in err
+
+
+def test_codex_exec_heartbeat_reports_subagent_tokens_from_session_log(
+    mocker, capsys, tmp_path, monkeypatch
+):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    lines = [
+        '{"type":"session.created","session_id":"sess-heartbeat-tokens"}\n',
+        (
+            '{"type":"item.completed","item":{"type":"agent_message",'
+            '"text":"working","token_count":1200}}\n'
+        ),
+    ]
+    fake = _FakePopen(
+        stdout_schedule=[(0, line) for line in lines],
+        hang_after_stdout=True,
+    )
+    _patch_codex_popen(mocker, fake)
+    session_log = SessionLog(path=tmp_path / "heartbeat-tokens.ndjson")
+
+    with pytest.raises(ProviderStalledError):
+        CodexProvider().exec(
+            "hi",
+            max_stall_sec=0.25,
+            liveness_interval_sec=0.1,
+            session_log=session_log,
+        )
+
+    err = capsys.readouterr().err
+    assert "1.2k tokens received since last heartbeat" in err
+
+
+def test_codex_exec_heartbeat_marks_zero_progress_as_possibly_stalled(
+    mocker, capsys, tmp_path, monkeypatch
+):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    partial = '{"type":"session.created","session_id":"sess-heartbeat-stalled"}\n'
+    fake = _FakePopen(
+        stdout_schedule=[(0, partial)],
+        hang_after_stdout=True,
+    )
+    _patch_codex_popen(mocker, fake)
+    session_log = SessionLog(path=tmp_path / "heartbeat-stalled.ndjson")
+
+    with pytest.raises(ProviderStalledError):
+        CodexProvider().exec(
+            "hi",
+            max_stall_sec=0.25,
+            liveness_interval_sec=0.1,
+            session_log=session_log,
+        )
+
+    err = capsys.readouterr().err
+    assert "0 tool calls, 0 tokens — possibly stalled" in err
+
+
+def test_codex_exec_heartbeat_falls_back_when_session_log_missing(mocker, capsys):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    partial = '{"type":"session.created","session_id":"sess-heartbeat-fallback"}\n'
+    fake = _FakePopen(
+        stdout_schedule=[(0, partial)],
+        hang_after_stdout=True,
+    )
+    _patch_codex_popen(mocker, fake)
+
+    with pytest.raises(ProviderStalledError):
+        CodexProvider().exec("hi", max_stall_sec=0.25, liveness_interval_sec=0.1)
+
+    err = capsys.readouterr().err
+    assert "[conductor] no output from codex for " in err
+    assert "tool call" not in err
+    assert "tokens received" not in err
+    assert "possibly stalled" not in err
 
 
 def test_codex_call_unaffected_by_streaming_changes(mocker):


### PR DESCRIPTION
Today's heartbeats from streaming codex exec are pure liveness:

  [conductor] no output from codex for 31s...
  [conductor] no output from codex for 61s...

This says "conductor is alive" but says nothing about whether the
provider is doing useful work. In #43 (now closed-as-monitoring),
every one of these printed for 21 minutes while codex was at 0% CPU
doing nothing — operationally misleading.

PR #75 (#45) added a SessionLog event stream that captures tool_call
and subagent_message events. The heartbeat now reads recent events
from the log and includes them:

  [conductor] no output from codex for 90s · 3 tool calls · 1.2k
                                              tokens since last
                                              heartbeat

When zero events have fired since the start of the run (the original
#43 case), the heartbeat says so explicitly:

  [conductor] no output from codex for 90s · 0 tool calls, 0 tokens
                                              — possibly stalled

That's the actually-informative signal that distinguishes "thinking
hard" from "wedged."

Falls back to elapsed-only when session_log is None (regression
guard for legacy callers without the SessionLog wiring).

Closes #56.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
