### PR TITLE
fix(exec): surface OAuth prompts even when --json is set (#55)

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -639,14 +639,49 @@ def _emit_call(
     *,
     as_json: bool,
     decision: RouteDecision | None = None,
+    auth_prompts: list[dict] | None = None,
 ) -> None:
     if as_json:
         payload = asdict(response)
+        effective_auth_prompts = auth_prompts or response.auth_prompts
+        if effective_auth_prompts:
+            payload["auth_prompts"] = effective_auth_prompts
+        else:
+            payload.pop("auth_prompts", None)
         if decision is not None:
             payload["route"] = asdict(decision)
         click.echo(json.dumps(payload, default=str, indent=2))
     else:
         click.echo(response.text)
+
+
+def _collect_session_auth_prompts(session_log: SessionLog | None) -> list[dict] | None:
+    if session_log is None:
+        return None
+    try:
+        lines = session_log.log_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return None
+
+    prompts: list[dict] = []
+    seen: set[tuple[str, str | None]] = set()
+    for line in lines:
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if event.get("event") != "auth_prompt":
+            continue
+        data = event.get("data") or {}
+        provider = data.get("provider")
+        if not isinstance(provider, str) or not provider:
+            continue
+        key = (provider, data.get("url"))
+        if key in seen:
+            continue
+        seen.add(key)
+        prompts.append(data)
+    return prompts or None
 
 
 def _format_route_log_line(decision: RouteDecision) -> str:
@@ -1447,7 +1482,12 @@ def exec_cmd(
     _emit_session_usage(session_log, response)
     if session_log is not None:
         session_log.mark_finished()
-    _emit_call(response, as_json=as_json, decision=decision)
+    _emit_call(
+        response,
+        as_json=as_json,
+        decision=decision,
+        auth_prompts=_collect_session_auth_prompts(session_log),
+    )
 
 
 # --------------------------------------------------------------------------- #

--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -17,6 +17,7 @@ import subprocess
 import time
 from typing import TYPE_CHECKING
 
+from conductor.providers.cli_auth import AuthPromptTracker, run_subprocess_with_live_stderr
 from conductor.providers.interface import (
     CallResponse,
     ProviderConfigError,
@@ -216,6 +217,8 @@ class ClaudeProvider:
             cwd=cwd,
             timeout_sec_override=timeout_sec,
             resume_session_id=resume_session_id,
+            live_auth_capture=True,
+            session_log=session_log,
         )
 
     def _run(
@@ -229,6 +232,8 @@ class ClaudeProvider:
         cwd: str | None = None,
         timeout_sec_override: float | None | object = _USE_DEFAULT,
         resume_session_id: str | None = None,
+        live_auth_capture: bool = False,
+        session_log: SessionLog | None = None,
     ) -> CallResponse:
         # Cheap PATH check only on the hot path — auth state surfaces as a
         # CLI exit failure below if the user installed but didn't log in.
@@ -269,23 +274,38 @@ class ClaudeProvider:
         else:
             timeout = timeout_sec_override  # type: ignore[assignment]
         start = time.monotonic()
+        tracker = AuthPromptTracker(self.name, session_log=session_log)
         try:
             import os as _os
             proc_env = {**_os.environ, **env_overrides} if env_overrides else None
-            result = subprocess.run(
-                args,
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-                cwd=cwd,
-                env=proc_env,
-            )
+            if live_auth_capture:
+                result = run_subprocess_with_live_stderr(
+                    args=args,
+                    cwd=cwd,
+                    env=proc_env,
+                    timeout=timeout,
+                    tracker=tracker,
+                    popen_factory=subprocess.Popen,
+                )
+            else:
+                result = subprocess.run(
+                    args,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                    cwd=cwd,
+                    env=proc_env,
+                )
         except subprocess.TimeoutExpired as e:
             elapsed = time.monotonic() - start
             raise ProviderError(
                 f"claude CLI timed out after {elapsed:.0f}s"
             ) from e
-        duration_ms = int((time.monotonic() - start) * 1000)
+        duration_ms = (
+            result.duration_ms
+            if live_auth_capture
+            else int((time.monotonic() - start) * 1000)
+        )
 
         if result.returncode != 0:
             raise ProviderHTTPError(
@@ -322,4 +342,5 @@ class ClaudeProvider:
             cost_usd=data.get("total_cost_usd"),
             session_id=data.get("session_id"),
             raw=data,
+            auth_prompts=tracker.prompts or None,
         )

--- a/src/conductor/providers/cli_auth.py
+++ b/src/conductor/providers/cli_auth.py
@@ -1,0 +1,286 @@
+"""Helpers for surfacing interactive CLI auth prompts during exec runs."""
+
+from __future__ import annotations
+
+import json
+import queue
+import re
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from conductor.session_log import SessionLog
+
+_AUTH_URL_RE = re.compile(r"https://[^\s'\"<>]+")
+_AUTH_FALLBACK_PROVIDER = {
+    "codex": "claude",
+    "claude": "codex",
+    "gemini": "claude",
+}
+_AUTH_TEXT_SIGNALS = (
+    "please visit",
+    "open this url",
+    "open the following url",
+    "complete authentication in your browser",
+    "complete the login in your browser",
+    "waiting for oauth",
+    "login --with-api-key",
+)
+
+
+@dataclass(frozen=True)
+class CapturedProcessResult:
+    returncode: int
+    stdout: str
+    stderr: str
+    duration_ms: int
+
+
+def _extract_url(text: str) -> str | None:
+    match = _AUTH_URL_RE.search(text)
+    if match is None:
+        return None
+    return match.group(0).rstrip(".,)")
+
+
+def _iter_scalar_strings(obj: Any) -> list[str]:
+    found: list[str] = []
+    if isinstance(obj, str):
+        return [obj]
+    if isinstance(obj, dict):
+        for value in obj.values():
+            found.extend(_iter_scalar_strings(value))
+    elif isinstance(obj, list):
+        for value in obj:
+            found.extend(_iter_scalar_strings(value))
+    return found
+
+
+def _extract_event_url(event: dict[str, Any]) -> str | None:
+    for key in (
+        "url",
+        "auth_url",
+        "oauth_url",
+        "verification_uri",
+        "verification_url",
+        "login_url",
+    ):
+        value = event.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    for value in _iter_scalar_strings(event):
+        url = _extract_url(value)
+        if url is not None:
+            return url
+    return None
+
+
+class AuthPromptTracker:
+    """Detect provider-auth prompts, mirror them to stderr, and remember them."""
+
+    def __init__(
+        self,
+        provider: str,
+        *,
+        session_log: SessionLog | None = None,
+    ) -> None:
+        self._provider = provider
+        self._session_log = session_log
+        self._seen: set[tuple[str, str | None]] = set()
+        self.prompts: list[dict] = []
+
+    def observe_text(self, text: str, *, source: str) -> None:
+        notice = self._detect_from_text(text, source=source)
+        if notice is not None:
+            self._record(notice)
+
+    def observe_json_line(self, line: str, *, source: str) -> None:
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            return
+        if not isinstance(event, dict):
+            return
+        notice = self._detect_from_event(event, source=source)
+        if notice is not None:
+            self._record(notice)
+
+    def _detect_from_text(self, text: str, *, source: str) -> dict | None:
+        raw = text.strip()
+        if not raw:
+            return None
+        lowered = raw.lower()
+        url = _extract_url(raw)
+        if url is not None and "/oauth" in url.lower():
+            return self._build_notice(url=url, source=source)
+        if url is not None and any(signal in lowered for signal in _AUTH_TEXT_SIGNALS):
+            return self._build_notice(url=url, source=source)
+        if "login --with-api-key" in lowered:
+            return self._build_notice(url=url, source=source)
+        return None
+
+    def _detect_from_event(self, event: dict[str, Any], *, source: str) -> dict | None:
+        if str(event.get("type") or "") != "auth_required":
+            return None
+        return self._build_notice(url=_extract_event_url(event), source=source)
+
+    def _build_notice(self, *, url: str | None, source: str) -> dict:
+        notice = {
+            "provider": self._provider,
+            "message": "provider is waiting for OAuth completion",
+            "source": source,
+        }
+        if url is not None:
+            notice["url"] = url
+        return notice
+
+    def _record(self, notice: dict) -> None:
+        key = (notice["provider"], notice.get("url"))
+        if key in self._seen:
+            return
+        self._seen.add(key)
+        self.prompts.append(notice)
+        self._emit_stderr(notice)
+        if self._session_log is not None:
+            self._session_log.emit("auth_prompt", notice)
+
+    def _emit_stderr(self, notice: dict) -> None:
+        provider = notice["provider"]
+        fallback = _AUTH_FALLBACK_PROVIDER.get(provider, "claude")
+        sys.stderr.write(
+            f"[conductor] auth required for {provider} — "
+            "provider is waiting for OAuth completion\n"
+        )
+        url = notice.get("url")
+        if url:
+            sys.stderr.write(f"[conductor] complete the flow at: {url}\n")
+        else:
+            sys.stderr.write(
+                "[conductor] complete the flow in the provider auth prompt "
+                "(no URL captured)\n"
+            )
+        sys.stderr.write(
+            "[conductor] rerun this exec after auth, or use "
+            f"`--with {fallback}` for now\n"
+        )
+        sys.stderr.flush()
+
+
+def run_subprocess_with_live_stderr(
+    *,
+    args: list[str],
+    cwd: str | None,
+    env: dict[str, str] | None,
+    timeout: float | None,
+    tracker: AuthPromptTracker,
+    popen_factory,
+) -> CapturedProcessResult:
+    """Run a subprocess while inspecting stderr for auth prompts live."""
+
+    start = time.monotonic()
+    process = popen_factory(
+        args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=cwd,
+        env=env,
+    )
+
+    parts: dict[str, list[str]] = {"stdout": [], "stderr": []}
+    stream_done = {"stdout": False, "stderr": False}
+    stream_q: queue.Queue[tuple[str, str | None]] = queue.Queue()
+
+    def read_stream(name: str, pipe) -> None:
+        try:
+            while True:
+                line = pipe.readline()
+                if line == "":
+                    break
+                stream_q.put((name, line))
+        finally:
+            stream_q.put((name, None))
+
+    stdout_thread = threading.Thread(
+        target=read_stream, args=("stdout", process.stdout), daemon=True
+    )
+    stderr_thread = threading.Thread(
+        target=read_stream, args=("stderr", process.stderr), daemon=True
+    )
+    stdout_thread.start()
+    stderr_thread.start()
+
+    while True:
+        now = time.monotonic()
+        if timeout is not None and now - start > timeout:
+            _terminate_process(process)
+            stdout_thread.join(timeout=1)
+            stderr_thread.join(timeout=1)
+            _drain_stream_queue(stream_q, parts, tracker)
+            raise subprocess.TimeoutExpired(
+                cmd=args,
+                timeout=timeout,
+                output="".join(parts["stdout"]),
+                stderr="".join(parts["stderr"]),
+            )
+
+        try:
+            stream_name, item = stream_q.get(timeout=0.05)
+        except queue.Empty:
+            if all(stream_done.values()) and process.poll() is not None:
+                break
+            continue
+
+        if item is None:
+            stream_done[stream_name] = True
+            if all(stream_done.values()) and process.poll() is not None:
+                break
+            continue
+
+        parts[stream_name].append(item)
+        if stream_name == "stderr":
+            tracker.observe_text(item, source="stderr")
+
+    returncode = process.wait()
+    stdout_thread.join(timeout=1)
+    stderr_thread.join(timeout=1)
+    _drain_stream_queue(stream_q, parts, tracker)
+    return CapturedProcessResult(
+        returncode=returncode,
+        stdout="".join(parts["stdout"]),
+        stderr="".join(parts["stderr"]),
+        duration_ms=int((time.monotonic() - start) * 1000),
+    )
+
+
+def _drain_stream_queue(
+    stream_q: queue.Queue[tuple[str, str | None]],
+    parts: dict[str, list[str]],
+    tracker: AuthPromptTracker,
+) -> None:
+    while True:
+        try:
+            stream_name, item = stream_q.get_nowait()
+        except queue.Empty:
+            return
+        if item is None:
+            continue
+        parts[stream_name].append(item)
+        if stream_name == "stderr":
+            tracker.observe_text(item, source="stderr")
+
+
+def _terminate_process(process: subprocess.Popen[str]) -> None:
+    if process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        if process.poll() is None:
+            process.kill()
+            process.wait()

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING
 
 from conductor import __version__ as _conductor_version
 from conductor.offline_mode import _cache_dir
+from conductor.providers.cli_auth import AuthPromptTracker
 from conductor.providers.interface import (
     CallResponse,
     ProviderConfigError,
@@ -530,9 +531,10 @@ class CodexProvider:
             cwd=cwd,
         )
 
-        stdout_q: queue.Queue[str | None] = queue.Queue()
+        stream_q: queue.Queue[tuple[str, str | None]] = queue.Queue()
         stdout_parts: list[str] = []
         stderr_parts: list[str] = []
+        auth_tracker = AuthPromptTracker(self.name, session_log=session_log)
 
         def read_stdout() -> None:
             assert process.stdout is not None
@@ -541,17 +543,20 @@ class CodexProvider:
                     line = process.stdout.readline()
                     if line == "":
                         break
-                    stdout_q.put(line)
+                    stream_q.put(("stdout", line))
             finally:
-                stdout_q.put(None)
+                stream_q.put(("stdout", None))
 
         def read_stderr() -> None:
             assert process.stderr is not None
-            while True:
-                chunk = process.stderr.readline()
-                if chunk == "":
-                    break
-                stderr_parts.append(chunk)
+            try:
+                while True:
+                    chunk = process.stderr.readline()
+                    if chunk == "":
+                        break
+                    stream_q.put(("stderr", chunk))
+            finally:
+                stream_q.put(("stderr", None))
 
         stdout_thread = threading.Thread(target=read_stdout, daemon=True)
         stderr_thread = threading.Thread(target=read_stderr, daemon=True)
@@ -559,6 +564,7 @@ class CodexProvider:
         stderr_thread.start()
 
         stdout_done = False
+        stderr_done = False
         last_output = start
         last_liveness = start
         heartbeat_log_offset = 0
@@ -568,7 +574,9 @@ class CodexProvider:
             if timeout is not None and now - start > timeout:
                 self._terminate_process(process)
                 self._join_reader_threads(stdout_thread, stderr_thread)
-                self._drain_stdout_queue(stdout_q, stdout_parts)
+                self._drain_stream_queue(
+                    stream_q, stdout_parts, stderr_parts, auth_tracker
+                )
                 stdout = "".join(stdout_parts)
                 stderr = "".join(stderr_parts)
                 elapsed = time.monotonic() - start
@@ -587,7 +595,9 @@ class CodexProvider:
             if max_stall_sec is not None and now - last_output > max_stall_sec:
                 self._terminate_process(process)
                 self._join_reader_threads(stdout_thread, stderr_thread)
-                self._drain_stdout_queue(stdout_q, stdout_parts)
+                self._drain_stream_queue(
+                    stream_q, stdout_parts, stderr_parts, auth_tracker
+                )
                 stdout = "".join(stdout_parts)
                 stderr = "".join(stderr_parts)
                 elapsed = time.monotonic() - last_output
@@ -635,21 +645,32 @@ class CodexProvider:
                 last_liveness = now
 
             try:
-                item = stdout_q.get(timeout=0.05)
+                stream_name, item = stream_q.get(timeout=0.05)
             except queue.Empty:
-                if stdout_done and process.poll() is not None:
+                if stdout_done and stderr_done and process.poll() is not None:
                     break
                 continue
 
             if item is None:
-                stdout_done = True
-                if process.poll() is not None:
+                if stream_name == "stdout":
+                    stdout_done = True
+                else:
+                    stderr_done = True
+                if stdout_done and stderr_done and process.poll() is not None:
                     break
+                continue
+
+            if stream_name == "stderr":
+                stderr_parts.append(item)
+                last_output = time.monotonic()
+                last_liveness = last_output
+                auth_tracker.observe_text(item, source="stderr")
                 continue
 
             stdout_parts.append(item)
             last_output = time.monotonic()
             last_liveness = last_output
+            auth_tracker.observe_json_line(item, source="stdout")
             self._emit_stream_event(item, session_log=session_log)
 
             if not session_id_emitted:
@@ -663,7 +684,7 @@ class CodexProvider:
 
         returncode = process.wait()
         self._join_reader_threads(stdout_thread, stderr_thread)
-        self._drain_stdout_queue(stdout_q, stdout_parts)
+        self._drain_stream_queue(stream_q, stdout_parts, stderr_parts, auth_tracker)
         duration_ms = int((time.monotonic() - start) * 1000)
         stdout = "".join(stdout_parts)
         stderr = "".join(stderr_parts)
@@ -696,6 +717,7 @@ class CodexProvider:
             },
             session_id=session_id,
             raw={"stdout": stdout},
+            auth_prompts=auth_tracker.prompts or None,
         )
 
     def _terminate_process(self, process: subprocess.Popen[str]) -> None:
@@ -718,18 +740,26 @@ class CodexProvider:
         stdout_thread.join(timeout=1)
         stderr_thread.join(timeout=1)
 
-    def _drain_stdout_queue(
+    def _drain_stream_queue(
         self,
-        stdout_q: queue.Queue[str | None],
+        stream_q: queue.Queue[tuple[str, str | None]],
         stdout_parts: list[str],
+        stderr_parts: list[str],
+        auth_tracker: AuthPromptTracker,
     ) -> None:
         while True:
             try:
-                item = stdout_q.get_nowait()
+                stream_name, item = stream_q.get_nowait()
             except queue.Empty:
                 return
-            if item is not None:
+            if item is None:
+                continue
+            if stream_name == "stdout":
                 stdout_parts.append(item)
+                auth_tracker.observe_json_line(item, source="stdout")
+                continue
+            stderr_parts.append(item)
+            auth_tracker.observe_text(item, source="stderr")
 
     def _failure_message(
         self,

--- a/src/conductor/providers/gemini.py
+++ b/src/conductor/providers/gemini.py
@@ -20,6 +20,7 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from conductor.providers.cli_auth import AuthPromptTracker, run_subprocess_with_live_stderr
 from conductor.providers.interface import (
     CallResponse,
     ProviderConfigError,
@@ -235,6 +236,8 @@ class GeminiProvider:
             cwd=cwd,
             timeout_sec_override=timeout_sec,
             resume_session_id=resume_session_id,
+            live_auth_capture=True,
+            session_log=session_log,
         )
 
     def _run(
@@ -247,6 +250,8 @@ class GeminiProvider:
         cwd: str | None = None,
         timeout_sec_override: float | None | object = _USE_DEFAULT,
         resume_session_id: str | None = None,
+        live_auth_capture: bool = False,
+        session_log: SessionLog | None = None,
     ) -> CallResponse:
         # Cheap PATH check on the hot path; auth state surfaces as a CLI
         # exit failure below if needed. configured() (with auth probe) is
@@ -287,21 +292,36 @@ class GeminiProvider:
         else:
             timeout = timeout_sec_override  # type: ignore[assignment]
         start = time.monotonic()
+        tracker = AuthPromptTracker(self.name, session_log=session_log)
         try:
-            result = subprocess.run(
-                args,
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-                cwd=cwd,
-                env=proc_env,
-            )
+            if live_auth_capture:
+                result = run_subprocess_with_live_stderr(
+                    args=args,
+                    cwd=cwd,
+                    env=proc_env,
+                    timeout=timeout,
+                    tracker=tracker,
+                    popen_factory=subprocess.Popen,
+                )
+            else:
+                result = subprocess.run(
+                    args,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                    cwd=cwd,
+                    env=proc_env,
+                )
         except subprocess.TimeoutExpired as e:
             elapsed = time.monotonic() - start
             raise ProviderError(
                 f"gemini CLI timed out after {elapsed:.0f}s"
             ) from e
-        duration_ms = int((time.monotonic() - start) * 1000)
+        duration_ms = (
+            result.duration_ms
+            if live_auth_capture
+            else int((time.monotonic() - start) * 1000)
+        )
 
         if result.returncode != 0:
             raise ProviderHTTPError(
@@ -329,6 +349,7 @@ class GeminiProvider:
                     "thinking_budget": thinking_budget,
                 },
                 raw={"stdout": stdout},
+                auth_prompts=tracker.prompts or None,
             )
 
         input_tokens, output_tokens = self._sum_usage(data)
@@ -358,6 +379,7 @@ class GeminiProvider:
             },
             session_id=session_id,
             raw=data,
+            auth_prompts=tracker.prompts or None,
         )
 
     @staticmethod

--- a/src/conductor/providers/interface.py
+++ b/src/conductor/providers/interface.py
@@ -113,6 +113,7 @@ class CallResponse:
     cost_usd: float | None = None
     session_id: str | None = None
     raw: dict = field(default_factory=dict)
+    auth_prompts: list[dict] | None = None
 
 
 @runtime_checkable

--- a/src/conductor/session_log.py
+++ b/src/conductor/session_log.py
@@ -30,13 +30,18 @@ def _iso8601_now() -> str:
 
 def sessions_dir() -> Path:
     primary = _cache_dir() / "sessions"
-    try:
-        primary.mkdir(parents=True, exist_ok=True)
-        return primary
-    except OSError:
-        fallback = Path(tempfile.gettempdir()) / "conductor" / "sessions"
-        fallback.mkdir(parents=True, exist_ok=True)
-        return fallback
+    fallback = Path(tempfile.gettempdir()) / "conductor" / "sessions"
+    for candidate in (primary, fallback):
+        try:
+            candidate.mkdir(parents=True, exist_ok=True)
+            probe = candidate / f".write-probe-{uuid.uuid4().hex}"
+            probe.write_text("", encoding="utf-8")
+            probe.unlink()
+            return candidate
+        except OSError:
+            continue
+    fallback.mkdir(parents=True, exist_ok=True)
+    return fallback
 
 
 def _meta_path(run_id: str) -> Path:

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -223,6 +223,34 @@ def test_claude_timeout_maps_to_provider_error(mocker):
     assert "timed out" in str(exc.value)
 
 
+def test_claude_exec_surfaces_auth_prompt_and_records_notice(mocker, capsys):
+    mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
+    fake = _FakePopen(
+        stdout_schedule=[(0, CLAUDE_JSON)],
+        stderr_schedule=[
+            (0, "Please visit https://claude.ai/oauth/authorize to authenticate\n")
+        ],
+    )
+    mocker.patch(
+        "conductor.providers.claude.subprocess.Popen",
+        side_effect=lambda args, **kwargs: fake,
+    )
+
+    response = ClaudeProvider().exec("hi")
+
+    assert response.auth_prompts == [
+        {
+            "provider": "claude",
+            "message": "provider is waiting for OAuth completion",
+            "source": "stderr",
+            "url": "https://claude.ai/oauth/authorize",
+        }
+    ]
+    err = capsys.readouterr().err
+    assert "[conductor] auth required for claude" in err
+    assert "https://claude.ai/oauth/authorize" in err
+
+
 # ---------------------------------------------------------------------------
 # Codex
 # ---------------------------------------------------------------------------
@@ -788,6 +816,34 @@ def test_codex_exec_emits_session_id_only_once(mocker, capsys):
     assert "sess-second" not in err
 
 
+def test_codex_exec_surfaces_auth_prompt_and_records_notice(mocker, capsys):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    fake = _FakePopen(
+        stdout_schedule=[(0, line) for line in CODEX_NDJSON.splitlines(keepends=True)],
+        stderr_schedule=[
+            (
+                0,
+                "Please visit https://chatgpt.com/oauth/device to authenticate\n",
+            )
+        ],
+    )
+    _patch_codex_popen(mocker, fake)
+
+    response = CodexProvider().exec("hi", liveness_interval_sec=0)
+
+    assert response.auth_prompts == [
+        {
+            "provider": "codex",
+            "message": "provider is waiting for OAuth completion",
+            "source": "stderr",
+            "url": "https://chatgpt.com/oauth/device",
+        }
+    ]
+    err = capsys.readouterr().err
+    assert "[conductor] auth required for codex" in err
+    assert "https://chatgpt.com/oauth/device" in err
+
+
 def test_codex_exec_writes_forensic_envelope_on_stall(mocker, tmp_path, monkeypatch):
     """Envelope captures everything needed to attribute a stall:
     command, cwd, conductor version, partial stdout, partial stderr.
@@ -1078,6 +1134,37 @@ def test_gemini_call_raises_on_empty_stdout(mocker):
     )
     with pytest.raises(ProviderHTTPError):
         GeminiProvider().call("hi")
+
+
+def test_gemini_exec_surfaces_auth_prompt_and_records_notice(mocker, capsys):
+    mocker.patch("conductor.providers.gemini.shutil.which", return_value="/usr/bin/gemini")
+    fake = _FakePopen(
+        stdout_schedule=[(0, GEMINI_JSON)],
+        stderr_schedule=[
+            (
+                0,
+                "Please visit https://accounts.google.com/o/oauth2/auth to authenticate\n",
+            )
+        ],
+    )
+    mocker.patch(
+        "conductor.providers.gemini.subprocess.Popen",
+        side_effect=lambda args, **kwargs: fake,
+    )
+
+    response = GeminiProvider().exec("hi")
+
+    assert response.auth_prompts == [
+        {
+            "provider": "gemini",
+            "message": "provider is waiting for OAuth completion",
+            "source": "stderr",
+            "url": "https://accounts.google.com/o/oauth2/auth",
+        }
+    ]
+    err = capsys.readouterr().err
+    assert "[conductor] auth required for gemini" in err
+    assert "https://accounts.google.com/o/oauth2/auth" in err
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -36,8 +36,9 @@ from conductor.router import reset_health
 
 
 @pytest.fixture(autouse=True)
-def _clean_health():
+def _clean_health(monkeypatch, tmp_path):
     reset_health()
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
     yield
     reset_health()
 
@@ -78,6 +79,49 @@ def _fake_response(provider: str = "claude", model: str = "sonnet") -> CallRespo
         cost_usd=0.01,
         raw={},
     )
+
+
+class _FakeScheduledPipe:
+    def __init__(self, schedule, *, on_eof=None) -> None:
+        self._schedule = schedule
+        self._idx = 0
+        self._on_eof = on_eof
+
+    def readline(self) -> str:
+        if self._idx < len(self._schedule):
+            line = self._schedule[self._idx]
+            self._idx += 1
+            return line
+        if self._on_eof is not None:
+            self._on_eof()
+            self._on_eof = None
+        return ""
+
+
+class _FakePopen:
+    def __init__(self, *, stdout_lines, stderr_lines=None, returncode: int = 0) -> None:
+        self.args = None
+        self.returncode = None
+        self._configured_returncode = returncode
+        self.stdout = _FakeScheduledPipe(stdout_lines, on_eof=self._finish)
+        self.stderr = _FakeScheduledPipe(stderr_lines or [])
+
+    def _finish(self) -> None:
+        if self.returncode is None:
+            self.returncode = self._configured_returncode
+
+    def poll(self):
+        return self.returncode
+
+    def wait(self, timeout=None):
+        self._finish()
+        return self.returncode
+
+    def terminate(self):
+        self.returncode = -15
+
+    def kill(self):
+        self.returncode = -9
 
 
 # ---------------------------------------------------------------------------
@@ -463,6 +507,101 @@ def test_exec_cli_no_max_stall_seconds_defaults_none(mocker):
 
     assert result.exit_code == 0, result.output
     assert exec_mock.call_args.kwargs["max_stall_sec"] is None
+
+
+def test_exec_json_surfaces_codex_auth_prompt_and_records_auth_prompts(
+    mocker, monkeypatch, tmp_path
+):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    ndjson = [
+        '{"type":"session.created","session_id":"sess-auth-1"}\n',
+        '{"type":"item.completed","item":{"type":"agent_message","text":"hello from codex"}}\n',
+        '{"type":"turn.completed","usage":{"input_tokens":5,"output_tokens":2}}\n',
+    ]
+    fake = _FakePopen(
+        stdout_lines=ndjson,
+        stderr_lines=[
+            "Please visit https://chatgpt.com/oauth/device to authenticate\n"
+        ],
+    )
+    mocker.patch(
+        "conductor.providers.codex.subprocess.Popen",
+        side_effect=lambda args, **kwargs: fake,
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["exec", "--with", "codex", "--task", "hi", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["text"] == "hello from codex"
+    assert payload["auth_prompts"] == [
+        {
+            "provider": "codex",
+            "message": "provider is waiting for OAuth completion",
+            "source": "stderr",
+            "url": "https://chatgpt.com/oauth/device",
+        }
+    ]
+    assert "[conductor] auth required for codex" in result.stderr
+    assert "complete the flow at: https://chatgpt.com/oauth/device" in result.stderr
+
+
+def test_exec_json_omits_auth_prompts_when_no_notice(mocker, monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    ndjson = [
+        '{"type":"session.created","session_id":"sess-auth-2"}\n',
+        '{"type":"item.completed","item":{"type":"agent_message","text":"hello from codex"}}\n',
+        '{"type":"turn.completed","usage":{"input_tokens":5,"output_tokens":2}}\n',
+    ]
+    fake = _FakePopen(stdout_lines=ndjson)
+    mocker.patch(
+        "conductor.providers.codex.subprocess.Popen",
+        side_effect=lambda args, **kwargs: fake,
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["exec", "--with", "codex", "--task", "hi", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert "auth_prompts" not in payload
+    assert "[conductor] auth required for codex" not in result.stderr
+
+
+def test_exec_non_json_still_surfaces_codex_auth_prompt(mocker, monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    ndjson = [
+        '{"type":"session.created","session_id":"sess-auth-3"}\n',
+        '{"type":"item.completed","item":{"type":"agent_message","text":"hello from codex"}}\n',
+        '{"type":"turn.completed","usage":{"input_tokens":5,"output_tokens":2}}\n',
+    ]
+    fake = _FakePopen(
+        stdout_lines=ndjson,
+        stderr_lines=[
+            "Please visit https://chatgpt.com/oauth/device to authenticate\n"
+        ],
+    )
+    mocker.patch(
+        "conductor.providers.codex.subprocess.Popen",
+        side_effect=lambda args, **kwargs: fake,
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["exec", "--with", "codex", "--task", "hi"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.stdout.strip() == "hello from codex"
+    assert "[conductor] auth required for codex" in result.stderr
 
 
 def test_exec_with_kimi_tools_raises_unsupported(mocker, monkeypatch):


### PR DESCRIPTION
`conductor exec --with codex --json` (and the symmetric paths for
claude and gemini) was silently swallowing auth prompts. When the
provider's session expired, the CLI would print "Please visit
https://… to authenticate" but in --json mode the prompt either
never reached our stdout or got filtered out — the provider then
blocked indefinitely waiting for input no one could see. This was
the leading hypothesis for the #43 hang shape.

Fix: detect auth-prompt phrases in the provider's output and surface
them to **stderr regardless of --json mode**. --json constrains
stdout; stderr is unconstrained, so the user always sees what's
needed even when stdout is reserved for the JSON envelope.

What ships:

- src/conductor/providers/cli_auth.py — new shared module. One
  detector + one stderr formatter used by all three CLI providers.
  Recognizes documented OAuth-flow phrases ("Please visit",
  "https://" + "/oauth", "login --with-api-key", etc.) and codex's
  structured `auth_required` JSON event.

- providers/codex.py — the streaming exec loop now watches both
  stderr phrases and stdout NDJSON for auth signals.

- providers/claude.py + providers/gemini.py — switched their exec
  paths to live-capture stderr so OAuth prompts are visible before
  the subprocess exits (was buffered-on-exit before).

- cli.py — when --json is set and auth prompts fired during the
  run, the JSON envelope includes a top-level `auth_prompts` array
  so downstream parsers can tell "this exec was interrupted by auth,
  here's what was needed."

- session_log.py — small fix to fall back to a writable temp dir
  when the cache dir exists but is read-only (surfaced during this
  work, unrelated to the auth fix proper).

Tests in tests/test_adapters_subprocess.py + tests/test_cli_v02.py
cover detection for codex/claude/gemini, the stderr-fires-in-both-
modes invariant, and the JSON envelope shape.

Closes #55.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
