### PR TITLE
fix(codex): pipe prompt via stdin (`codex exec -`), not argv

### DIFF
--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -401,15 +401,22 @@ class CodexProvider:
             _EFFORT_TO_CODEX_FLAG.get(effort) if isinstance(effort, str) else None
         )
 
-        # Codex resume uses a subcommand: `codex exec resume <id> "<prompt>"`.
-        # Build argv accordingly when we have a session to resume.
+        # Codex resume uses a subcommand: `codex exec resume <id> -`.
+        # Build argv accordingly when we have a session to resume. The task
+        # itself is passed via stdin (`exec -` / `exec resume <id> -`), not
+        # argv — see PR openai/codex#15917 (codex 0.122.0+) for the
+        # documented "primary prompt is stdin" path. argv-as-prompt has
+        # three real costs: it leaks 4KB+ briefs into `ps aux`, hits
+        # Windows command-line ceilings, and on long prompts is the path
+        # most prone to upstream regressions in the codex CLI's argv
+        # parser. Stdin is the supported path.
         if resume_session_id:
             args = [
                 self._cli,
                 "exec",
                 "resume",
                 resume_session_id,
-                task,
+                "-",
                 "--json",
                 "--sandbox",
                 sandbox,
@@ -418,7 +425,7 @@ class CodexProvider:
             args = [
                 self._cli,
                 "exec",
-                task,
+                "-",
                 "--json",
                 "--ephemeral",
                 "--sandbox",
@@ -436,6 +443,7 @@ class CodexProvider:
         if stream:
             return self._run_streaming(
                 args,
+                task=task,
                 model=model,
                 effort=effort,
                 thinking_budget=thinking_budget,
@@ -450,6 +458,7 @@ class CodexProvider:
         try:
             result = subprocess.run(
                 args,
+                input=task,
                 capture_output=True,
                 text=True,
                 timeout=timeout,
@@ -475,6 +484,7 @@ class CodexProvider:
                     cwd=cwd,
                     captured_stdout=partial_stdout,
                     captured_stderr=partial_stderr,
+                    prompt=task,
                 )
             ) from e
         duration_ms = int((time.monotonic() - start) * 1000)
@@ -513,6 +523,7 @@ class CodexProvider:
         self,
         args: list[str],
         *,
+        task: str,
         model: str,
         effort: str | int,
         thinking_budget: int,
@@ -525,11 +536,22 @@ class CodexProvider:
         start = time.monotonic()
         process = subprocess.Popen(
             args,
+            stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
             cwd=cwd,
         )
+        # Pipe the prompt via stdin and close — codex exec reads until EOF.
+        # If write blocks (huge prompt + slow consumer), we'd hang here, but
+        # codex's own ingestion is fast and the prompt fits in the pipe
+        # buffer for any realistic brief size. An os.set_blocking()-based
+        # async write is overkill until we see a brief that exceeds 64KB.
+        assert process.stdin is not None
+        try:
+            process.stdin.write(task)
+        finally:
+            process.stdin.close()
 
         stream_q: queue.Queue[tuple[str, str | None]] = queue.Queue()
         stdout_parts: list[str] = []
@@ -589,6 +611,7 @@ class CodexProvider:
                         cwd=cwd,
                         captured_stdout=stdout,
                         captured_stderr=stderr,
+                        prompt=task,
                     )
                 )
 
@@ -610,6 +633,7 @@ class CodexProvider:
                         cwd=cwd,
                         captured_stdout=stdout,
                         captured_stderr=stderr,
+                        prompt=task,
                     )
                 )
 
@@ -771,6 +795,7 @@ class CodexProvider:
         cwd: str | None,
         captured_stdout: str,
         captured_stderr: str,
+        prompt: str | None = None,
     ) -> str:
         """Build a user-facing failure message + write the forensic envelope.
 
@@ -790,6 +815,7 @@ class CodexProvider:
             cwd=cwd,
             captured_stdout=captured_stdout,
             captured_stderr=captured_stderr,
+            prompt=prompt,
         )
         parts = [prefix]
         if partial_session_id:
@@ -816,6 +842,7 @@ class CodexProvider:
         cwd: str | None,
         captured_stdout: str,
         captured_stderr: str,
+        prompt: str | None = None,
     ) -> Path | None:
         """Persist a structured failure envelope to the cache dir.
 
@@ -833,6 +860,10 @@ class CodexProvider:
             "conductor_version": _conductor_version,
             "codex_path": shutil.which(self._cli),
             "command": command,
+            # The prompt now arrives via stdin (codex exec -), so it isn't
+            # in `command`. Surface it separately so an operator inspecting
+            # the envelope can still correlate the wedge with the request.
+            "prompt": prompt,
             "cwd": cwd,
             "captured_stdout": captured_stdout,
             "captured_stderr": captured_stderr,

--- a/src/conductor/wizard.py
+++ b/src/conductor/wizard.py
@@ -104,7 +104,9 @@ _INFO: dict[str, _ProviderInfo] = {
         ],
         troubleshoot_tips=[
             "`codex login` requires a ChatGPT Plus/Team/Enterprise subscription.",
-            "Verify with `codex --version` (need >= 0.20) and `codex exec --help`.",
+            "Verify with `codex --version` (need >= 0.125) and `codex exec --help`. "
+            "0.122+ is required for stdin-piped prompts (which conductor uses); "
+            "0.125 fixed exec-server output retention. Older versions hang silently.",
             "Browser fails to open? try `codex login --no-browser` and follow URL.",
             "Session expired? `codex logout && codex login` forces a fresh auth.",
         ],

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -6,6 +6,7 @@ All three call external CLIs. We stub ``subprocess.run`` and
 
 from __future__ import annotations
 
+import io
 import os
 import shutil
 import subprocess
@@ -320,6 +321,9 @@ class _FakePopen:
             terminated=self._terminated_event,
             on_eof=None,
         )
+        # codex now reads the prompt from stdin (`codex exec -`); mock a
+        # writable pipe so the provider's write+close path doesn't blow up.
+        self.stdin = io.StringIO()
 
     def _finish_success(self) -> None:
         if self.returncode is None:
@@ -449,10 +453,13 @@ def test_codex_call_with_resume_uses_resume_subcommand(mocker):
     )
     CodexProvider().call("follow-up", resume_session_id="sess-codex-1")
     args = captured.call_args.args[0]
-    # `codex exec resume <id> "<prompt>"` is the documented shape
+    # `codex exec resume <id> -` is the documented shape (stdin-as-prompt
+    # via PR openai/codex#15917; argv-as-prompt is no longer used).
     assert args[1] == "exec" and args[2] == "resume"
     assert args[3] == "sess-codex-1"
-    assert args[4] == "follow-up"
+    assert args[4] == "-"
+    # The actual prompt arrives via stdin (the `input=` kwarg).
+    assert captured.call_args.kwargs.get("input") == "follow-up"
     # When resuming, --ephemeral does not apply (resume implies persistence).
     assert "--ephemeral" not in args
 
@@ -944,9 +951,13 @@ def test_codex_exec_writes_envelope_when_codex_emits_zero_bytes(
     envelope = _json.loads(log_files[0].read_text())
     assert envelope["kind"] == "stall"
     assert envelope["captured_stdout"] == ""
-    # The prompt body must be in the captured command (last positional after
-    # `codex exec`), so an operator can correlate the wedge with the request.
-    assert "test prompt body" in envelope["command"]
+    # The prompt body now arrives via stdin (`codex exec -`), not argv, so
+    # the envelope surfaces it as a separate `prompt` field. An operator
+    # can still correlate the wedge with the request — just not by reading
+    # `command`. argv contains only the flags + sandbox + effort overrides.
+    assert envelope["prompt"] == "test prompt body"
+    assert "-" in envelope["command"]  # stdin sentinel
+    assert "test prompt body" not in envelope["command"]
 
 
 def test_codex_exec_forensic_envelope_disk_failure_does_not_mask_real_error(

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -13,6 +13,7 @@ mocks; no real CLIs or HTTP endpoints are invoked.
 
 from __future__ import annotations
 
+import io
 import json
 
 import httpx
@@ -105,6 +106,9 @@ class _FakePopen:
         self._configured_returncode = returncode
         self.stdout = _FakeScheduledPipe(stdout_lines, on_eof=self._finish)
         self.stderr = _FakeScheduledPipe(stderr_lines or [])
+        # codex now reads the prompt from stdin (`codex exec -`); mock a
+        # writable pipe so the provider's write+close path works.
+        self.stdin = io.StringIO()
 
     def _finish(self) -> None:
         if self.returncode is None:


### PR DESCRIPTION
Conductor was passing the task as a positional argv argument to codex:

    args = [self._cli, "exec", task, "--json", "--ephemeral", ...]

Even when the user piped the brief on stdin to conductor, conductor
turned around and stuffed the brief into codex's argv. Three concrete
costs:

1. **The whole brief leaks into `ps aux`.** Issue #44 fixed this for
   conductor's own argv but conductor undid the protection one layer
   down by re-stuffing the brief into codex's argv.

2. **Windows hits "command line too long" outright.** A real codex
   review runner (peteromallet/desloppify#541) reproduced this when
   wrapping `codex exec` from `cmd /c`.

3. **argv-as-prompt is the path most prone to upstream regressions
   in codex's CLI parser.** The OpenAI codex repo has multiple open
   issues describing silent hangs on long-prompt runs (#17003,
   #14048, #14470, #15870) — the symptom shape (open HTTPS sockets,
   0% CPU, no output, no stderr, indefinite wait) matches what we've
   been observing this session.

OpenAI shipped piped-stdin support for `codex exec` in 0.122.0 via
PR openai/codex#15917 ("Support piped stdin in exec process API").
The documented "primary prompt is stdin" path is `codex exec -`.

Switch conductor to that path:

- `args` builds `["codex", "exec", "-", ...]` (or `["codex", "exec",
  "resume", <id>, "-", ...]` for resume).
- The non-streaming path adds `input=task` to subprocess.run.
- The streaming path opens stdin=PIPE, writes the prompt, closes it.
  codex reads until EOF.

Forensic envelope gains a `prompt` field so an operator inspecting
a wedge envelope can still correlate the failure with the request
text — argv now contains only flags + sandbox + effort overrides.

Wizard's troubleshoot tip bumps the codex version pin from
"need >= 0.20" to "need >= 0.125":
- 0.122 added piped-stdin (we now require it)
- 0.123 fixed root-flag inheritance to `exec`
- 0.124 fixed "stuck Working" via input queuing
- 0.125 fixed exec-server output retention on stream close

All 0.20-0.124 versions either lack the stdin path or carry
regressions of the exact shape we've been hitting. Pin forward.

Test surface change: the fake Popen helpers in
tests/test_adapters_subprocess.py and tests/test_cli_v02.py grew a
`stdin = io.StringIO()` attribute so the provider's write+close
path doesn't crash. The forensic-envelope test now asserts the
prompt is in `envelope["prompt"]` (new field), not
`envelope["command"]` (which is now flags-only).

564 passed, 15 skipped. ruff clean.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
