### PR TITLE
feat(exec): pre-flight provider health probe (#54)

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -330,6 +330,26 @@ def _stderr_is_tty() -> bool:
         return False
 
 
+def _provider_for_preflight(provider_or_name):
+    if hasattr(provider_or_name, "health_probe"):
+        return provider_or_name
+    return get_provider(str(provider_or_name))
+
+
+def _run_exec_preflight(provider_or_name) -> tuple[bool, str | None]:
+    provider = _provider_for_preflight(provider_or_name)
+    return provider.health_probe()
+
+
+def _echo_preflight_failure(provider_or_name, reason: str | None) -> None:
+    provider = _provider_for_preflight(provider_or_name)
+    detail = reason or "provider health probe failed"
+    click.echo(f"[conductor] preflight failed for {provider.name}: {detail}", err=True)
+    fix = getattr(provider, "fix_command", None)
+    if fix:
+        click.echo(f"[conductor] try: {fix}", err=True)
+
+
 def _echo_offline_hint(failed_name: str, *, silent: bool) -> None:
     """Print a hint pointing at ollama when we couldn't prompt."""
     if silent:
@@ -1292,6 +1312,12 @@ def call(
     help="--offline: force local (ollama) routing and set the sticky offline "
     "flag. --no-offline: clear the sticky flag before running.",
 )
+@click.option(
+    "--preflight/--no-preflight",
+    "preflight",
+    default=True,
+    help="Run a provider health probe before forwarding the task.",
+)
 def exec_cmd(
     provider_id: str | None,
     profile: str | None,
@@ -1314,6 +1340,7 @@ def exec_cmd(
     silent_route: bool,
     resume_session_id: str | None,
     offline: bool | None,
+    preflight: bool,
 ) -> None:
     """Run a task as an agent session with tool access (exec mode)."""
     profile_spec = _load_named_profile(profile)
@@ -1379,6 +1406,18 @@ def exec_cmd(
         _emit_session_route_decision(session_log, decision)
         print_caller_banner(decision.provider, silent=silent_route or as_json)
         _emit_route_log(decision, verbose=verbose_route, silent=silent_route or as_json)
+        if preflight:
+            ok, reason = _run_exec_preflight(provider)
+            if not ok:
+                if session_log is not None:
+                    session_log.bind_provider(provider.name)
+                    session_log.emit(
+                        "provider_failed",
+                        {"provider": provider.name, "error": reason or "preflight failed"},
+                    )
+                    session_log.mark_finished()
+                _echo_preflight_failure(provider, reason)
+                sys.exit(2)
 
         try:
             response, _fallbacks = _invoke_with_fallback(
@@ -1429,6 +1468,16 @@ def exec_cmd(
         )
         session_log.bind_provider(provider_id)
         print_caller_banner(provider_id, silent=silent_route or as_json)
+        if preflight:
+            ok, reason = _run_exec_preflight(provider)
+            if not ok:
+                session_log.emit(
+                    "provider_failed",
+                    {"provider": provider_id, "error": reason or "preflight failed"},
+                )
+                session_log.mark_finished()
+                _echo_preflight_failure(provider, reason)
+                sys.exit(2)
         try:
             session_log.emit(
                 "provider_started",

--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -164,6 +164,28 @@ class ClaudeProvider:
             )
         return True, None
 
+    def health_probe(self, *, timeout_sec: float = 30.0) -> tuple[bool, str | None]:
+        ok, reason = self._check_cli_path()
+        if not ok:
+            return False, reason
+        try:
+            result = subprocess.run(
+                [self._cli, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=timeout_sec,
+            )
+        except subprocess.TimeoutExpired:
+            return False, f"`{self._cli} --version` timed out after {timeout_sec:.0f}s"
+        except OSError as e:
+            return False, f"could not run `{self._cli} --version`: {e}"
+        if result.returncode != 0:
+            return False, (
+                f"`{self._cli} --version` exited {result.returncode}: "
+                f"{(result.stderr or result.stdout).strip()[:200]}"
+            )
+        return True, None
+
     def call(
         self,
         task: str,

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -172,6 +172,28 @@ class CodexProvider:
             )
         return True, None
 
+    def health_probe(self, *, timeout_sec: float = 30.0) -> tuple[bool, str | None]:
+        ok, reason = self._check_cli_path()
+        if not ok:
+            return False, reason
+        try:
+            result = subprocess.run(
+                [self._cli, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=timeout_sec,
+            )
+        except subprocess.TimeoutExpired:
+            return False, f"`{self._cli} --version` timed out after {timeout_sec:.0f}s"
+        except OSError as e:
+            return False, f"could not run `{self._cli} --version`: {e}"
+        if result.returncode != 0:
+            return False, (
+                f"`{self._cli} --version` exited {result.returncode}: "
+                f"{(result.stderr or result.stdout).strip()[:200]}"
+            )
+        return True, None
+
     def _parse_ndjson(
         self, stdout: str
     ) -> tuple[str, int | None, int | None, str | None]:

--- a/src/conductor/providers/gemini.py
+++ b/src/conductor/providers/gemini.py
@@ -190,6 +190,28 @@ class GeminiProvider:
             )
         return True, None
 
+    def health_probe(self, *, timeout_sec: float = 30.0) -> tuple[bool, str | None]:
+        ok, reason = self._check_cli_path()
+        if not ok:
+            return False, reason
+        try:
+            result = subprocess.run(
+                [self._cli, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=timeout_sec,
+            )
+        except subprocess.TimeoutExpired:
+            return False, f"`{self._cli} --version` timed out after {timeout_sec:.0f}s"
+        except OSError as e:
+            return False, f"could not run `{self._cli} --version`: {e}"
+        if result.returncode != 0:
+            return False, (
+                f"`{self._cli} --version` exited {result.returncode}: "
+                f"{(result.stderr or result.stdout).strip()[:200]}"
+            )
+        return True, None
+
     def call(
         self,
         task: str,

--- a/src/conductor/providers/interface.py
+++ b/src/conductor/providers/interface.py
@@ -156,6 +156,16 @@ class Provider(Protocol):
     def smoke(self) -> tuple[bool, str | None]:
         """Cheapest possible round-trip that proves auth + endpoint work."""
 
+    def health_probe(self, *, timeout_sec: float = 30.0) -> tuple[bool, str | None]:
+        """Cheapest possible end-to-end check that the provider can be invoked
+        right now.
+
+        Distinct from configured() (cheap, static config check) and smoke()
+        (full round-trip). Providers override this with a fast probe suited to
+        their transport.
+        """
+        raise NotImplementedError
+
     def call(
         self,
         task: str,

--- a/src/conductor/providers/ollama.py
+++ b/src/conductor/providers/ollama.py
@@ -196,6 +196,26 @@ class OllamaProvider:
     def smoke(self) -> tuple[bool, str | None]:
         return self.configured()
 
+    def health_probe(self, *, timeout_sec: float = 10.0) -> tuple[bool, str | None]:
+        url = f"{self._base_url()}/api/tags"
+        try:
+            with httpx.Client(timeout=timeout_sec) as client:
+                resp = client.get(url)
+        except httpx.TimeoutException:
+            return False, f"`GET {url}` timed out after {timeout_sec:.0f}s"
+        except httpx.HTTPError as e:
+            return False, (
+                f"cannot reach Ollama at {self._base_url()}: {e}. "
+                "Install with `brew install ollama`, run `ollama serve`, "
+                f"and `ollama pull {self.default_model}`."
+            )
+        if resp.status_code != 200:
+            return False, (
+                f"Ollama at {self._base_url()} returned {resp.status_code} — "
+                "is the server healthy?"
+            )
+        return True, None
+
     def default_model_available(self) -> tuple[bool, str | None]:
         """Check whether ``default_model`` is pulled on the running daemon.
 

--- a/src/conductor/providers/openrouter.py
+++ b/src/conductor/providers/openrouter.py
@@ -33,6 +33,7 @@ OPENROUTER_API_KEY_ENV = "OPENROUTER_API_KEY"
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 OPENROUTER_DEFAULT_MODEL = "openrouter/auto"
 OPENROUTER_REQUEST_TIMEOUT_SEC = 120.0
+OPENROUTER_HEALTH_PROBE_TIMEOUT_SEC = 10.0
 OPENROUTER_HTTP_REFERER = "https://github.com/autumngarage/conductor"
 OPENROUTER_X_TITLE = "conductor"
 
@@ -131,6 +132,27 @@ class OpenRouterProvider:
             return False, str(e)
         if "choices" not in response:
             return False, f"unexpected response shape: {sorted(response)[:5]}"
+        return True, None
+
+    def health_probe(
+        self, *, timeout_sec: float = OPENROUTER_HEALTH_PROBE_TIMEOUT_SEC
+    ) -> tuple[bool, str | None]:
+        try:
+            headers = self._headers()
+        except ProviderConfigError as e:
+            return False, str(e)
+
+        url = f"{self._base_url}/models"
+        try:
+            with httpx.Client(timeout=timeout_sec) as client:
+                resp = client.get(url, headers=headers)
+        except httpx.TimeoutException:
+            return False, f"`GET {url}` timed out after {timeout_sec:.0f}s"
+        except httpx.HTTPError as e:
+            return False, f"network error calling OpenRouter: {e}"
+
+        if resp.status_code != 200:
+            return False, f"OpenRouter returned HTTP {resp.status_code}: {resp.text[:200]}"
         return True, None
 
     def _post_chat(self, payload: dict) -> dict:

--- a/src/conductor/providers/shell.py
+++ b/src/conductor/providers/shell.py
@@ -160,6 +160,10 @@ class ShellProvider:
         # `conductor call --with <name> --task "ping"` for that.
         return self.configured()
 
+    def health_probe(self, *, timeout_sec: float = 30.0) -> tuple[bool, str | None]:
+        del timeout_sec
+        return self.configured()
+
     def _binary(self) -> str:
         parts = shlex.split(self._spec.shell)
         return parts[0] if parts else ""

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -127,6 +127,65 @@ def test_claude_configured_false_when_auth_probe_returns_non_json(mocker):
     assert "not JSON" in reason
 
 
+@pytest.mark.parametrize("provider_cls,module_path,cli_name", [
+    (ClaudeProvider, "conductor.providers.claude", "claude"),
+    (CodexProvider, "conductor.providers.codex", "codex"),
+    (GeminiProvider, "conductor.providers.gemini", "gemini"),
+])
+def test_cli_health_probe_success(mocker, provider_cls, module_path, cli_name):
+    mocker.patch(f"{module_path}.shutil.which", return_value=f"/usr/bin/{cli_name}")
+    mocker.patch(
+        f"{module_path}.subprocess.run",
+        return_value=_fake_completed(stdout=f"{cli_name} 1.2.3"),
+    )
+    ok, reason = provider_cls().health_probe(timeout_sec=7)
+    assert ok is True and reason is None
+
+
+@pytest.mark.parametrize("provider_cls,module_path,cli_name", [
+    (ClaudeProvider, "conductor.providers.claude", "claude"),
+    (CodexProvider, "conductor.providers.codex", "codex"),
+    (GeminiProvider, "conductor.providers.gemini", "gemini"),
+])
+def test_cli_health_probe_timeout(mocker, provider_cls, module_path, cli_name):
+    mocker.patch(f"{module_path}.shutil.which", return_value=f"/usr/bin/{cli_name}")
+    mocker.patch(
+        f"{module_path}.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd=cli_name, timeout=7),
+    )
+    ok, reason = provider_cls().health_probe(timeout_sec=7)
+    assert ok is False
+    assert "timed out" in reason
+
+
+@pytest.mark.parametrize("provider_cls,module_path,cli_name", [
+    (ClaudeProvider, "conductor.providers.claude", "claude"),
+    (CodexProvider, "conductor.providers.codex", "codex"),
+    (GeminiProvider, "conductor.providers.gemini", "gemini"),
+])
+def test_cli_health_probe_nonzero_exit(mocker, provider_cls, module_path, cli_name):
+    mocker.patch(f"{module_path}.shutil.which", return_value=f"/usr/bin/{cli_name}")
+    mocker.patch(
+        f"{module_path}.subprocess.run",
+        return_value=_fake_completed(stderr="broken", returncode=2),
+    )
+    ok, reason = provider_cls().health_probe()
+    assert ok is False
+    assert "exited 2" in reason
+
+
+@pytest.mark.parametrize("provider_cls,module_path", [
+    (ClaudeProvider, "conductor.providers.claude"),
+    (CodexProvider, "conductor.providers.codex"),
+    (GeminiProvider, "conductor.providers.gemini"),
+])
+def test_cli_health_probe_missing_binary(mocker, provider_cls, module_path):
+    mocker.patch(f"{module_path}.shutil.which", return_value=None)
+    ok, reason = provider_cls().health_probe()
+    assert ok is False
+    assert "not found on PATH" in reason
+
+
 def test_claude_call_returns_normalized_response(mocker):
     mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
     mocker.patch(

--- a/tests/test_cli_log_file.py
+++ b/tests/test_cli_log_file.py
@@ -45,6 +45,14 @@ def _stub_all_configured(mocker, configured_names: set[str]) -> None:
                 None if _ok else f"{_name} stub not configured",
             ),
         )
+        mocker.patch.object(
+            cls,
+            "health_probe",
+            lambda self, timeout_sec=30.0, _ok=ok, _name=name: (
+                _ok,
+                None if _ok else f"{_name} preflight failed",
+            ),
+        )
 
 
 def _read_events(path: Path) -> list[dict]:

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -63,6 +63,14 @@ def _stub_all_configured(mocker, configured_names: set[str]) -> None:
             "configured",
             lambda self, _ok=ok, _n=name: (_ok, None if _ok else f"{_n} stub not configured"),
         )
+        mocker.patch.object(
+            cls,
+            "health_probe",
+            lambda self, timeout_sec=30.0, _ok=ok, _n=name: (
+                _ok,
+                None if _ok else f"{_n} preflight failed",
+            ),
+        )
 
 
 def _fake_response(provider: str = "claude", model: str = "sonnet") -> CallResponse:
@@ -513,6 +521,49 @@ def test_exec_cli_no_max_stall_seconds_defaults_none(mocker):
     assert exec_mock.call_args.kwargs["max_stall_sec"] is None
 
 
+def test_exec_cli_preflight_blocks_exec_and_surfaces_fix_hint(mocker):
+    _stub_all_configured(mocker, {"codex"})
+    mocker.patch.object(
+        CodexProvider,
+        "health_probe",
+        return_value=(False, "network is unreachable"),
+    )
+    exec_mock = mocker.patch.object(
+        CodexProvider, "exec", return_value=_fake_response("codex")
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["exec", "--with", "codex", "--task", "do it"],
+    )
+
+    assert result.exit_code == 2
+    assert not exec_mock.called
+    assert "[conductor] preflight failed for codex: network is unreachable" in result.stderr
+    assert "[conductor] try: brew install codex && codex login" in result.stderr
+
+
+def test_exec_cli_no_preflight_skips_probe(mocker):
+    _stub_all_configured(mocker, {"codex"})
+    probe_mock = mocker.patch.object(
+        CodexProvider,
+        "health_probe",
+        return_value=(False, "network is unreachable"),
+    )
+    exec_mock = mocker.patch.object(
+        CodexProvider, "exec", return_value=_fake_response("codex")
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["exec", "--with", "codex", "--no-preflight", "--task", "do it"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert not probe_mock.called
+    assert exec_mock.called
+
+
 def test_exec_json_surfaces_codex_auth_prompt_and_records_auth_prompts(
     mocker, monkeypatch, tmp_path
 ):
@@ -536,7 +587,7 @@ def test_exec_json_surfaces_codex_auth_prompt_and_records_auth_prompts(
 
     result = CliRunner().invoke(
         main,
-        ["exec", "--with", "codex", "--task", "hi", "--json"],
+        ["exec", "--with", "codex", "--no-preflight", "--task", "hi", "--json"],
     )
 
     assert result.exit_code == 0, result.output
@@ -570,7 +621,7 @@ def test_exec_json_omits_auth_prompts_when_no_notice(mocker, monkeypatch, tmp_pa
 
     result = CliRunner().invoke(
         main,
-        ["exec", "--with", "codex", "--task", "hi", "--json"],
+        ["exec", "--with", "codex", "--no-preflight", "--task", "hi", "--json"],
     )
 
     assert result.exit_code == 0, result.output
@@ -600,7 +651,7 @@ def test_exec_non_json_still_surfaces_codex_auth_prompt(mocker, monkeypatch, tmp
 
     result = CliRunner().invoke(
         main,
-        ["exec", "--with", "codex", "--task", "hi"],
+        ["exec", "--with", "codex", "--no-preflight", "--task", "hi"],
     )
 
     assert result.exit_code == 0, result.output

--- a/tests/test_custom_providers.py
+++ b/tests/test_custom_providers.py
@@ -51,6 +51,12 @@ def test_shell_provider_configured_false_when_binary_missing():
     assert "PATH" in reason
 
 
+def test_shell_provider_health_probe_only_checks_binary_presence():
+    spec = ShellProviderSpec(name="demo", shell="/bin/cat")
+    ok, reason = ShellProvider(spec).health_probe()
+    assert ok is True and reason is None
+
+
 def test_shell_provider_call_stdin_round_trips():
     # /bin/cat on stdin echoes its input — perfect stub.
     spec = ShellProviderSpec(name="echo", shell="/bin/cat", accepts="stdin")

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -95,6 +95,43 @@ def test_configured_honors_env_override(monkeypatch):
     assert ok is True
 
 
+def test_health_probe_success():
+    with respx.mock() as router:
+        router.get(TAGS_URL).mock(
+            return_value=httpx.Response(200, json={"models": []})
+        )
+        ok, reason = OllamaProvider().health_probe()
+    assert ok is True and reason is None
+
+
+def test_health_probe_timeout():
+    with respx.mock() as router:
+        router.get(TAGS_URL).mock(
+            side_effect=httpx.ReadTimeout(
+                "timed out", request=httpx.Request("GET", TAGS_URL)
+            )
+        )
+        ok, reason = OllamaProvider().health_probe(timeout_sec=9)
+    assert ok is False
+    assert "timed out" in reason
+
+
+def test_health_probe_non_200():
+    with respx.mock() as router:
+        router.get(TAGS_URL).mock(return_value=httpx.Response(503, text="down"))
+        ok, reason = OllamaProvider().health_probe()
+    assert ok is False
+    assert "returned 503" in reason
+
+
+def test_health_probe_network_error():
+    with respx.mock() as router:
+        router.get(TAGS_URL).mock(side_effect=httpx.ConnectError("refused"))
+        ok, reason = OllamaProvider().health_probe()
+    assert ok is False
+    assert "cannot reach Ollama" in reason
+
+
 def test_call_returns_normalized_response():
     body = {
         "model": OLLAMA_DEFAULT_MODEL,

--- a/tests/test_openrouter.py
+++ b/tests/test_openrouter.py
@@ -8,11 +8,13 @@ import httpx
 import pytest
 import respx
 
+from conductor.providers.deepseek import DeepSeekChatProvider, DeepSeekReasonerProvider
 from conductor.providers.interface import (
     CallResponse,
     ProviderConfigError,
     UnsupportedCapability,
 )
+from conductor.providers.kimi import KimiProvider
 from conductor.providers.openrouter import (
     OPENROUTER_API_KEY_ENV,
     OPENROUTER_DEFAULT_MODEL,
@@ -111,6 +113,77 @@ def test_smoke_returns_true_on_well_formed_response(configured):
         ok, reason = OpenRouterProvider().smoke()
     assert ok is True
     assert reason is None
+
+
+@pytest.mark.parametrize(
+    "provider_cls,model_url",
+    [
+        (OpenRouterProvider, "https://openrouter.ai/api/v1/models"),
+        (KimiProvider, "https://openrouter.ai/api/v1/models"),
+        (DeepSeekChatProvider, "https://openrouter.ai/api/v1/models"),
+        (DeepSeekReasonerProvider, "https://openrouter.ai/api/v1/models"),
+    ],
+)
+def test_openrouter_family_health_probe_success(configured, provider_cls, model_url):
+    with respx.mock() as router:
+        router.get(model_url).mock(return_value=httpx.Response(200, json={"data": []}))
+        ok, reason = provider_cls().health_probe()
+    assert ok is True and reason is None
+
+
+@pytest.mark.parametrize(
+    "provider_cls,model_url",
+    [
+        (OpenRouterProvider, "https://openrouter.ai/api/v1/models"),
+        (KimiProvider, "https://openrouter.ai/api/v1/models"),
+        (DeepSeekChatProvider, "https://openrouter.ai/api/v1/models"),
+        (DeepSeekReasonerProvider, "https://openrouter.ai/api/v1/models"),
+    ],
+)
+def test_openrouter_family_health_probe_timeout(configured, provider_cls, model_url):
+    with respx.mock() as router:
+        router.get(model_url).mock(
+            side_effect=httpx.ReadTimeout("timed out", request=httpx.Request("GET", model_url))
+        )
+        ok, reason = provider_cls().health_probe(timeout_sec=9)
+    assert ok is False
+    assert "timed out" in reason
+
+
+@pytest.mark.parametrize(
+    "provider_cls,model_url",
+    [
+        (OpenRouterProvider, "https://openrouter.ai/api/v1/models"),
+        (KimiProvider, "https://openrouter.ai/api/v1/models"),
+        (DeepSeekChatProvider, "https://openrouter.ai/api/v1/models"),
+        (DeepSeekReasonerProvider, "https://openrouter.ai/api/v1/models"),
+    ],
+)
+def test_openrouter_family_health_probe_4xx(configured, provider_cls, model_url):
+    with respx.mock() as router:
+        router.get(model_url).mock(return_value=httpx.Response(401, text="bad key"))
+        ok, reason = provider_cls().health_probe()
+    assert ok is False
+    assert "HTTP 401" in reason
+
+
+@pytest.mark.parametrize(
+    "provider_cls,model_url",
+    [
+        (OpenRouterProvider, "https://openrouter.ai/api/v1/models"),
+        (KimiProvider, "https://openrouter.ai/api/v1/models"),
+        (DeepSeekChatProvider, "https://openrouter.ai/api/v1/models"),
+        (DeepSeekReasonerProvider, "https://openrouter.ai/api/v1/models"),
+    ],
+)
+def test_openrouter_family_health_probe_network_error(
+    configured, provider_cls, model_url
+):
+    with respx.mock() as router:
+        router.get(model_url).mock(side_effect=httpx.ConnectError("refused"))
+        ok, reason = provider_cls().health_probe()
+    assert ok is False
+    assert "network error" in reason
 
 
 def test_call_sends_reasoning_effort_and_openrouter_headers(configured):


### PR DESCRIPTION
When a provider's CLI was in a bad state — auth expired, sandbox
broken, network unreachable — `conductor exec --with <provider>`
would forward the full task and let the provider hang. By the time
we knew something was wrong, the user's prompt had already been
burned into a doomed invocation.

Add a fast pre-flight check before forwarding.

What ships:

- src/conductor/providers/interface.py — new `health_probe()`
  method on the Provider Protocol. Distinct from `configured()`
  (cheap, no API call) and `smoke()` (full round-trip): the
  cheapest possible "is this provider reachable RIGHT NOW" check.
  Default raises NotImplementedError; concrete providers
  override.

- Per-provider implementations:
  - claude/codex/gemini → `<cli> --version` with tight timeout
  - openrouter/kimi/deepseek-chat/deepseek-reasoner →
    `GET /models` (public endpoint, proves auth + network)
  - ollama → `GET /api/tags`
  - shell → `which <binary>` only (custom commands aren't safe to probe)

- src/conductor/cli.py:
  - `conductor exec` runs `provider.health_probe()` before
    forwarding. On failure: print `[conductor] preflight failed
    for <provider>: <reason>`, surface the provider's
    `fix_command` if set, exit 2 without invoking exec.
  - New `--no-preflight` flag for users who want to skip the
    probe (escape hatch).
  - `conductor call` is unchanged: single-turn HTTP is fast
    enough that probe overhead would dominate.

- Tests cover happy + failure paths per provider, the CLI gate
  that blocks exec on probe failure, and the --no-preflight
  bypass.

608 passed, 15 skipped (was 573 pre-PR). ruff clean.

Closes #54.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
