### PR TITLE
[codex] Address open provider and CI issues

### DIFF
--- a/.github/workflows/nightly-smoke.yml
+++ b/.github/workflows/nightly-smoke.yml
@@ -1,7 +1,9 @@
-# Required repository secrets for this subprocess-adapter smoke:
+# Optional repository secrets for this subprocess-adapter smoke:
 # - ${{ secrets.ANTHROPIC_API_KEY }} for the `claude` CLI.
 # - ${{ secrets.OPENAI_API_KEY }} for the `codex` CLI.
 # - ${{ secrets.GEMINI_API_KEY }} for the `gemini` CLI.
+# If any are missing, the workflow skips live smoke rather than failing and
+# filing an issue. Forks and fresh repos often lack these secrets by design.
 # Cloudflare secrets are intentionally not referenced here: this workflow does
 # not exercise the Kimi/Cloudflare adapter, which is covered by validate.yml.
 name: nightly-smoke
@@ -65,15 +67,22 @@ jobs:
         run: |
           set +e
           {
-            missing=0
+            missing=()
             for name in ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY; do
               if [ -z "${!name}" ]; then
-                echo "::error::$name secret is required for live subprocess smoke"
-                missing=1
+                echo "::notice::$name secret is not configured; skipping live subprocess smoke"
+                missing+=("$name")
               fi
             done
-            if [ "$missing" -ne 0 ]; then
-              exit 1
+            if [ "${#missing[@]}" -ne 0 ]; then
+              {
+                echo "Live subprocess smoke skipped because required repository secrets are not configured:"
+                printf -- "- %s\n" "${missing[@]}"
+                echo
+                echo "Add these repository secrets, then re-run nightly-smoke manually or wait for the next schedule."
+              } >> "$GITHUB_STEP_SUMMARY"
+              touch live-smoke-skipped.txt
+              exit 0
             fi
 
             uv run pytest -k live tests/test_adapters_subprocess.py
@@ -114,12 +123,27 @@ jobs:
               --description "Nightly conductor live smoke failure" \
               --color B60205
           fi
-          gh issue create \
-            --title "Live subprocess smoke failed: $(date -u +%Y-%m-%d)" \
-            --label live-smoke-failure \
-            --body-file live-smoke-issue.md
+          existing_issue="$(
+            gh issue list \
+              --state open \
+              --label live-smoke-failure \
+              --json number \
+              --jq '.[0].number // empty'
+          )"
+          if [ -n "$existing_issue" ]; then
+            gh issue comment "$existing_issue" --body-file live-smoke-issue.md
+          else
+            gh issue create \
+              --title "Live subprocess smoke failed: $(date -u +%Y-%m-%d)" \
+              --label live-smoke-failure \
+              --body-file live-smoke-issue.md
+          fi
 
       - name: Log heartbeat
         if: success()
         run: |
-          echo "Live subprocess smoke passed at $(date -u --iso-8601=seconds)." >> "$GITHUB_STEP_SUMMARY"
+          if [ -f live-smoke-skipped.txt ]; then
+            echo "Live subprocess smoke skipped at $(date -u --iso-8601=seconds)." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Live subprocess smoke passed at $(date -u --iso-8601=seconds)." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Pick an LLM, give it a job. Manual or auto routing across providers.
 
 **Status:** shipping. Current tap release is v0.3.3 — built-in providers for `kimi`, `openrouter`, `deepseek-chat`, `deepseek-reasoner`, `claude`, `codex`, `gemini`, and `ollama`, manual + auto routing, single-turn `call` + multi-turn `exec` with tools and sandboxes, and the first slice of agent-wiring (`conductor init --wire-agents` for Claude Code — delegation guidance, slash command, `kimi-long-context` / `gemini-web-search` subagents, `--unwire`). Further slices on main not yet tagged: repo-scoped `AGENTS.md` with three more subagents (codex / ollama / conductor-auto), plus `GEMINI.md`, repo `CLAUDE.md`, and Cursor-rule patching — use the dev-install path below until the next tap bump.
 
-DeepSeek note: `deepseek-chat` and `deepseek-reasoner` now use OpenRouter credentials. Set `OPENROUTER_API_KEY`; `DEEPSEEK_API_KEY` is deprecated.
-Kimi note: `kimi` now routes through OpenRouter. Set `OPENROUTER_API_KEY`; legacy `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` are no longer used.
+DeepSeek note: `deepseek-chat` and `deepseek-reasoner` now use OpenRouter credentials. Set `OPENROUTER_API_KEY`; `DEEPSEEK_API_KEY` is deprecated. Conductor resolves the newest matching DeepSeek slug from the OpenRouter catalog and falls back to the pinned default if the catalog is unavailable.
+Kimi note: `kimi` now routes through OpenRouter. Set `OPENROUTER_API_KEY`; legacy `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` are no longer used. Conductor resolves the newest matching Kimi slug from the OpenRouter catalog and falls back to the pinned default if the catalog is unavailable.
 
 Conductor is the fourth peer in the [Autumn Garage](https://github.com/autumngarage/autumn-garage) tool family alongside [Touchstone](https://github.com/autumngarage/touchstone), [Cortex](https://github.com/autumngarage/cortex), and [Sentinel](https://github.com/autumngarage/sentinel). It owns the LLM provider adapters and the user-facing "pick an LLM, give it a job" surface so that Sentinel and Touchstone don't each have to.
 
@@ -37,6 +37,7 @@ Conductor's runtime resolution order stays `env -> key_command -> keychain`. The
 - Linux: if `secret-tool` is available, default to `libsecret` via `secret-tool store` plus a generated `key_command` lookup. That keeps the secret encrypted at rest without changing the runtime resolution order. If `secret-tool` is unavailable, the wizard falls back to an environment-variable export and tells you that path is not encrypted at rest.
 - 1Password: available when the `op` CLI is on `PATH`. The wizard stores an `op read op://...` command in `~/.config/conductor/credentials.toml`; the secret itself never lands on disk. For zero-friction reads, set `1Password -> Settings -> Security -> Auto-Lock` to `Never`.
 - CI: use environment variables from your runner or secret store, e.g. GitHub Actions repository or environment secrets mapped to `OPENROUTER_API_KEY`.
+- Live subprocess smoke in GitHub Actions needs `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, and `GEMINI_API_KEY`; the nightly workflow skips when they are absent.
 
 ### Alternatives
 

--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -12,6 +12,7 @@ that touch credentials directly.
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import time
@@ -31,6 +32,7 @@ if TYPE_CHECKING:
 
 CLAUDE_DEFAULT_MODEL = "sonnet"
 CLAUDE_REQUEST_TIMEOUT_SEC = 180.0
+CLAUDE_CLI_ENV = "CONDUCTOR_CLAUDE_CLI"
 
 # Sentinel: "caller didn't specify a timeout" vs "caller explicitly passed
 # None". The constructor default applies only in the first case.
@@ -74,10 +76,10 @@ class ClaudeProvider:
     def __init__(
         self,
         *,
-        cli_command: str = "claude",
+        cli_command: str | None = None,
         timeout_sec: float = CLAUDE_REQUEST_TIMEOUT_SEC,
     ) -> None:
-        self._cli = cli_command
+        self._cli = cli_command or os.environ.get(CLAUDE_CLI_ENV) or "claude"
         self._timeout_sec = timeout_sec
 
     def _check_cli_path(self) -> tuple[bool, str | None]:
@@ -85,9 +87,22 @@ class ClaudeProvider:
         for the defensive guard so the hot path doesn't take an auth-probe
         round-trip on every invocation."""
         if not shutil.which(self._cli):
+            configured_cli = os.environ.get(CLAUDE_CLI_ENV)
+            if configured_cli:
+                return False, (
+                    f"{CLAUDE_CLI_ENV}={configured_cli!r} does not point to an "
+                    "executable visible to this Conductor process. Set it to the "
+                    "absolute Claude CLI path, update PATH for the non-interactive "
+                    "agent environment, or install/auth with "
+                    f"`brew install claude && {self.auth_login_command}` "
+                    "(or set `ANTHROPIC_API_KEY` for non-interactive use)."
+                )
             return False, (
-                f"`{self._cli}` CLI not found on PATH. "
-                "Install with `brew install claude` and auth with "
+                f"`{self._cli}` CLI not found on PATH for this Conductor process. "
+                "If Claude works in your terminal, set "
+                f"`{CLAUDE_CLI_ENV}=/absolute/path/to/claude` or update PATH for "
+                "the non-interactive agent environment. Otherwise install with "
+                "`brew install claude` and auth with "
                 f"`{self.auth_login_command}` "
                 "(or set `ANTHROPIC_API_KEY` for non-interactive use)."
             )

--- a/src/conductor/providers/deepseek.py
+++ b/src/conductor/providers/deepseek.py
@@ -7,10 +7,26 @@ now share OpenRouter's credential + transport layer.
 
 from __future__ import annotations
 
+import conductor.providers.openrouter_catalog as openrouter_catalog
 from conductor.providers.openrouter import OpenRouterProvider
 
 DEEPSEEK_CHAT_MODEL = "deepseek/deepseek-chat"
 DEEPSEEK_REASONER_MODEL = "deepseek/deepseek-r1"
+
+
+def _is_deepseek_chat_model(model: openrouter_catalog.ModelEntry) -> bool:
+    model_id = model.id
+    if not model_id.startswith("deepseek/deepseek-"):
+        return False
+    if model_id.startswith("deepseek/deepseek-r"):
+        return False
+    if "reasoner" in model_id:
+        return False
+    return model_id == DEEPSEEK_CHAT_MODEL or "-chat" in model_id or "-v" in model_id
+
+
+def _is_deepseek_reasoner_model(model: openrouter_catalog.ModelEntry) -> bool:
+    return model.id.startswith("deepseek/deepseek-r")
 
 
 class DeepSeekChatProvider(OpenRouterProvider):
@@ -33,11 +49,18 @@ class DeepSeekChatProvider(OpenRouterProvider):
     def _reasoning_payload(self, effort: str | int) -> dict[str, str] | None:
         return None
 
-    def call(self, task: str, model: str | None = None, **kwargs):
-        return super().call(task, model=model or self.default_model, **kwargs)
+    def _catalog_model(self) -> str:
+        return openrouter_catalog.newest_matching_model_id(
+            _is_deepseek_chat_model,
+            fallback_model=self.default_model,
+            label=self.name,
+        )
 
-    def exec(self, task: str, model: str | None = None, **kwargs):
-        return super().exec(task, model=model or self.default_model, **kwargs)
+    def _preset_model(self) -> str | None:
+        return self._catalog_model()
+
+    def _smoke_model(self) -> str:
+        return self._catalog_model()
 
 
 class DeepSeekReasonerProvider(OpenRouterProvider):
@@ -63,8 +86,15 @@ class DeepSeekReasonerProvider(OpenRouterProvider):
     typical_p50_ms = 12_000
     max_context_tokens = 64_000
 
-    def call(self, task: str, model: str | None = None, **kwargs):
-        return super().call(task, model=model or self.default_model, **kwargs)
+    def _catalog_model(self) -> str:
+        return openrouter_catalog.newest_matching_model_id(
+            _is_deepseek_reasoner_model,
+            fallback_model=self.default_model,
+            label=self.name,
+        )
 
-    def exec(self, task: str, model: str | None = None, **kwargs):
-        return super().exec(task, model=model or self.default_model, **kwargs)
+    def _preset_model(self) -> str | None:
+        return self._catalog_model()
+
+    def _smoke_model(self) -> str:
+        return self._catalog_model()

--- a/src/conductor/providers/kimi.py
+++ b/src/conductor/providers/kimi.py
@@ -6,9 +6,14 @@ transport now flow through the shared OpenRouter adapter.
 
 from __future__ import annotations
 
+import conductor.providers.openrouter_catalog as openrouter_catalog
 from conductor.providers.openrouter import OpenRouterProvider
 
 KIMI_DEFAULT_MODEL = "moonshotai/kimi-k2.6"
+
+
+def _is_kimi_model(model: openrouter_catalog.ModelEntry) -> bool:
+    return model.id.startswith("moonshotai/kimi-")
 
 
 class KimiProvider(OpenRouterProvider):
@@ -34,8 +39,15 @@ class KimiProvider(OpenRouterProvider):
     typical_p50_ms = 3500
     max_context_tokens = 256_000
 
-    def call(self, task: str, model: str | None = None, **kwargs):
-        return super().call(task, model=model or self.default_model, **kwargs)
+    def _catalog_model(self) -> str:
+        return openrouter_catalog.newest_matching_model_id(
+            _is_kimi_model,
+            fallback_model=self.default_model,
+            label=self.name,
+        )
 
-    def exec(self, task: str, model: str | None = None, **kwargs):
-        return super().exec(task, model=model or self.default_model, **kwargs)
+    def _preset_model(self) -> str | None:
+        return self._catalog_model()
+
+    def _smoke_model(self) -> str:
+        return self._catalog_model()

--- a/src/conductor/providers/openrouter.py
+++ b/src/conductor/providers/openrouter.py
@@ -109,6 +109,12 @@ class OpenRouterProvider:
     def _reasoning_payload(self, effort: str | int) -> dict[str, str] | None:
         return _reasoning_payload(effort)
 
+    def _preset_model(self) -> str | None:
+        return None
+
+    def _smoke_model(self) -> str:
+        return self.default_model
+
     def configured(self) -> tuple[bool, str | None]:
         if self._api_key or credentials.get(OPENROUTER_API_KEY_ENV):
             return True, None
@@ -121,7 +127,7 @@ class OpenRouterProvider:
         try:
             response = self._post_chat(
                 {
-                    "model": self.default_model,
+                    "model": self._smoke_model(),
                     "messages": [{"role": "user", "content": "ping"}],
                     "max_tokens": 1,
                 }
@@ -202,7 +208,14 @@ class OpenRouterProvider:
             "messages": [{"role": "user", "content": task}],
         }
         selected_model = model
-        if selected_model is None:
+        preset_model = self._preset_model() if selected_model is None else None
+        if preset_model is not None:
+            selected_model = preset_model
+            payload["model"] = selected_model
+            reasoning = self._reasoning_payload(effort)
+            if reasoning is not None:
+                payload["reasoning"] = reasoning
+        elif selected_model is None:
             selector_payload = select_model_for_task(
                 task_tags=task_tags,
                 prefer=prefer,

--- a/src/conductor/providers/openrouter_catalog.py
+++ b/src/conductor/providers/openrouter_catalog.py
@@ -14,11 +14,14 @@ import time
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
 
 from conductor.providers.interface import ProviderHTTPError
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
 OPENROUTER_CATALOG_TIMEOUT_SEC = 30.0
@@ -133,6 +136,38 @@ def load_catalog_snapshot(force_refresh: bool = False) -> CatalogSnapshot:
             file=sys.stderr,
         )
         return cached
+
+
+def newest_matching_model_id(
+    predicate: Callable[[ModelEntry], bool],
+    *,
+    fallback_model: str,
+    label: str,
+) -> str:
+    """Return the newest catalog model matching ``predicate``.
+
+    Shim providers use this to keep stable Conductor provider IDs while letting
+    OpenRouter model slugs drift. The pinned ``fallback_model`` is only used
+    when the catalog cannot be loaded or no matching model exists.
+    """
+    try:
+        models = load_catalog()
+    except ProviderHTTPError as e:
+        print(
+            f"[conductor] {label}: OpenRouter catalog unavailable; "
+            f"using pinned fallback {fallback_model}: {e}",
+            file=sys.stderr,
+        )
+        return fallback_model
+    matches = [model for model in models if predicate(model)]
+    if not matches:
+        print(
+            f"[conductor] {label}: no matching model found in OpenRouter catalog; "
+            f"using pinned fallback {fallback_model}",
+            file=sys.stderr,
+        )
+        return fallback_model
+    return sorted(matches, key=lambda model: (-model.created, model.id))[0].id
 
 
 def _read_cached_catalog_for_load() -> CatalogSnapshot | None:

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -72,9 +72,43 @@ def test_claude_configured_false_when_cli_missing(mocker):
     ok, reason = ClaudeProvider().configured()
     assert ok is False
     assert "not found on PATH" in reason
+    assert "CONDUCTOR_CLAUDE_CLI" in reason
+    assert "non-interactive agent environment" in reason
     # Reason names the actionable login command + env-var fallback.
     assert "claude auth login" in reason
     assert "ANTHROPIC_API_KEY" in reason
+
+
+def test_claude_uses_configured_cli_env_for_path_and_auth_probe(mocker, monkeypatch):
+    monkeypatch.setenv("CONDUCTOR_CLAUDE_CLI", "/opt/claude/bin/claude")
+    mocker.patch(
+        "conductor.providers.claude.shutil.which",
+        side_effect=lambda cmd: cmd if cmd == "/opt/claude/bin/claude" else None,
+    )
+    run = mocker.patch(
+        "conductor.providers.claude.subprocess.run",
+        return_value=_fake_completed(stdout='{"loggedIn": true}'),
+    )
+
+    ok, reason = ClaudeProvider().configured()
+
+    assert ok is True and reason is None
+    assert run.call_args.args[0][0] == "/opt/claude/bin/claude"
+
+
+def test_claude_configured_false_when_configured_cli_env_missing(
+    mocker, monkeypatch
+):
+    monkeypatch.setenv("CONDUCTOR_CLAUDE_CLI", "/missing/claude")
+    mocker.patch("conductor.providers.claude.shutil.which", return_value=None)
+
+    ok, reason = ClaudeProvider().configured()
+
+    assert ok is False
+    assert "CONDUCTOR_CLAUDE_CLI" in reason
+    assert "/missing/claude" in reason
+    assert "does not point to an executable" in reason
+    assert "non-interactive agent environment" in reason
 
 
 def test_claude_configured_false_when_not_authed(mocker):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ import httpx
 import respx
 from click.testing import CliRunner
 
+import conductor.providers.openrouter_catalog as openrouter_catalog
 from conductor.cli import main
 from conductor.providers.kimi import KIMI_DEFAULT_MODEL
 from conductor.providers.openrouter import (
@@ -14,6 +15,27 @@ from conductor.providers.openrouter import (
 )
 
 _OPENROUTER_CHAT_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+
+def _stub_kimi_catalog(monkeypatch):
+    monkeypatch.setattr(
+        openrouter_catalog,
+        "load_catalog",
+        lambda: [
+            openrouter_catalog.ModelEntry(
+                id=KIMI_DEFAULT_MODEL,
+                name=KIMI_DEFAULT_MODEL,
+                created=1_700_000_000,
+                context_length=256_000,
+                pricing_prompt=0.001,
+                pricing_completion=0.002,
+                pricing_thinking=None,
+                supports_thinking=False,
+                supports_tools=False,
+                supports_vision=False,
+            )
+        ],
+    )
 
 
 def test_call_unknown_provider_shows_usage_error():
@@ -33,6 +55,7 @@ def test_call_missing_task_and_no_stdin_errors():
 
 def test_call_task_file_reads_file(monkeypatch, tmp_path):
     monkeypatch.setenv(OPENROUTER_API_KEY_ENV, "or-test-key")
+    _stub_kimi_catalog(monkeypatch)
     brief = tmp_path / "brief.md"
     brief.write_text("brief from file\n", encoding="utf-8")
 
@@ -58,6 +81,7 @@ def test_call_task_file_reads_file(monkeypatch, tmp_path):
 
 def test_call_kimi_happy_path(monkeypatch):
     monkeypatch.setenv(OPENROUTER_API_KEY_ENV, "or-test-key")
+    _stub_kimi_catalog(monkeypatch)
     with respx.mock() as router:
         router.post(_OPENROUTER_CHAT_URL).mock(
             return_value=httpx.Response(
@@ -115,6 +139,7 @@ def test_call_kimi_missing_openrouter_key_exits_2(monkeypatch, mocker):
 
 def test_call_json_output(monkeypatch):
     monkeypatch.setenv(OPENROUTER_API_KEY_ENV, "or-test-key")
+    _stub_kimi_catalog(monkeypatch)
     # The caller banner is silenced under --json (matches existing route-log
     # silencing), so stdout stays clean for json.loads().
     with respx.mock() as router:
@@ -145,6 +170,7 @@ def test_call_emits_caller_banner_when_claude_detected(monkeypatch):
     monkeypatch.setenv(OPENROUTER_API_KEY_ENV, "or-test-key")
     monkeypatch.setenv("CLAUDECODE", "1")
     monkeypatch.setenv("NO_COLOR", "1")  # plain ASCII for stable assertion
+    _stub_kimi_catalog(monkeypatch)
 
     with respx.mock() as router:
         router.post(_OPENROUTER_CHAT_URL).mock(
@@ -172,6 +198,7 @@ def test_call_silent_route_suppresses_caller_banner(monkeypatch):
     """--silent-route silences the caller banner (and the route log)."""
     monkeypatch.setenv(OPENROUTER_API_KEY_ENV, "or-test-key")
     monkeypatch.setenv("CLAUDECODE", "1")
+    _stub_kimi_catalog(monkeypatch)
 
     with respx.mock() as router:
         router.post(_OPENROUTER_CHAT_URL).mock(

--- a/tests/test_cli_auto.py
+++ b/tests/test_cli_auto.py
@@ -6,11 +6,33 @@ import httpx
 import respx
 from click.testing import CliRunner
 
+import conductor.providers.openrouter_catalog as openrouter_catalog
 from conductor.cli import main
 from conductor.providers.kimi import KIMI_DEFAULT_MODEL
 from conductor.providers.openrouter import OPENROUTER_API_KEY_ENV
 
 _OPENROUTER_CHAT_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+
+def _stub_kimi_catalog(monkeypatch):
+    monkeypatch.setattr(
+        openrouter_catalog,
+        "load_catalog",
+        lambda: [
+            openrouter_catalog.ModelEntry(
+                id=KIMI_DEFAULT_MODEL,
+                name=KIMI_DEFAULT_MODEL,
+                created=1_700_000_000,
+                context_length=256_000,
+                pricing_prompt=0.001,
+                pricing_completion=0.002,
+                pricing_thinking=None,
+                supports_thinking=False,
+                supports_tools=False,
+                supports_vision=False,
+            )
+        ],
+    )
 
 
 def _stub_only_kimi_configured(mocker):
@@ -52,6 +74,7 @@ def test_call_requires_with_or_auto(mocker):
 def test_call_auto_picks_configured_provider(monkeypatch, mocker):
     _stub_only_kimi_configured(mocker)
     monkeypatch.setenv(OPENROUTER_API_KEY_ENV, "or-test-key")
+    _stub_kimi_catalog(monkeypatch)
 
     with respx.mock() as router:
         router.post(_OPENROUTER_CHAT_URL).mock(
@@ -75,6 +98,7 @@ def test_call_auto_picks_configured_provider(monkeypatch, mocker):
 def test_call_auto_json_includes_route_decision(monkeypatch, mocker):
     _stub_only_kimi_configured(mocker)
     monkeypatch.setenv(OPENROUTER_API_KEY_ENV, "or-test-key")
+    _stub_kimi_catalog(monkeypatch)
 
     with respx.mock() as router:
         router.post(_OPENROUTER_CHAT_URL).mock(
@@ -159,6 +183,7 @@ def test_call_auto_emits_shadow_hint_when_unconfigured_outranks(monkeypatch, moc
     mocker.patch.object(OllamaProvider, "configured", lambda self: (False, "nope"))
     mocker.patch.object(OpenRouterProvider, "configured", lambda self: (False, "nope"))
     monkeypatch.setenv(OPENROUTER_API_KEY_ENV, "or-test-key")
+    _stub_kimi_catalog(monkeypatch)
 
     with respx.mock() as router:
         router.post(_OPENROUTER_CHAT_URL).mock(
@@ -312,6 +337,7 @@ def test_call_auto_silent_route_suppresses_shadow_hint(monkeypatch, mocker):
     mocker.patch.object(OllamaProvider, "configured", lambda self: (False, "nope"))
     mocker.patch.object(OpenRouterProvider, "configured", lambda self: (False, "nope"))
     monkeypatch.setenv(OPENROUTER_API_KEY_ENV, "or-test-key")
+    _stub_kimi_catalog(monkeypatch)
 
     with respx.mock() as router:
         router.post(_OPENROUTER_CHAT_URL).mock(

--- a/tests/test_deepseek_migration.py
+++ b/tests/test_deepseek_migration.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import json
+import time
 
 import httpx
 import pytest
 import respx
 from click.testing import CliRunner
 
+import conductor.providers.openrouter_catalog as openrouter_catalog
 from conductor.cli import main
 from conductor.providers.deepseek import (
     DEEPSEEK_CHAT_MODEL,
@@ -15,6 +17,44 @@ from conductor.providers.deepseek import (
     DeepSeekReasonerProvider,
 )
 from conductor.providers.openrouter import OpenRouterProvider
+
+
+def _model(model_id: str, *, created: int) -> openrouter_catalog.ModelEntry:
+    return openrouter_catalog.ModelEntry(
+        id=model_id,
+        name=model_id,
+        created=created,
+        context_length=128_000,
+        pricing_prompt=0.001,
+        pricing_completion=0.002,
+        pricing_thinking=None,
+        supports_thinking=False,
+        supports_tools=False,
+        supports_vision=False,
+    )
+
+
+def _write_catalog_cache(path, *, model_id: str, fetched_at: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "{\n"
+        f'  "fetched_at": {fetched_at},\n'
+        '  "models": [\n'
+        "    {\n"
+        f'      "id": "{model_id}",\n'
+        f'      "name": "{model_id}",\n'
+        '      "created": 1800000000,\n'
+        '      "context_length": 128000,\n'
+        '      "pricing_prompt": 0.001,\n'
+        '      "pricing_completion": 0.002,\n'
+        '      "pricing_thinking": null,\n'
+        '      "supports_thinking": false,\n'
+        '      "supports_tools": false,\n'
+        '      "supports_vision": false\n'
+        "    }\n"
+        "  ]\n"
+        "}\n"
+    )
 
 
 @pytest.mark.parametrize(
@@ -36,6 +76,11 @@ def test_deepseek_providers_subclass_openrouter_and_preset_model(
 
 def test_deepseek_chat_call_uses_preset_openrouter_model(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+    monkeypatch.setattr(
+        openrouter_catalog,
+        "load_catalog",
+        lambda: [_model(DEEPSEEK_CHAT_MODEL, created=1_700_000_000)],
+    )
     captured: dict[str, object] = {}
 
     def _record(request: httpx.Request) -> httpx.Response:
@@ -58,6 +103,90 @@ def test_deepseek_chat_call_uses_preset_openrouter_model(monkeypatch):
         "model": DEEPSEEK_CHAT_MODEL,
         "messages": [{"role": "user", "content": "hi"}],
     }
+
+
+@pytest.mark.parametrize(
+    ("provider_cls", "catalog_models", "expected_model"),
+    [
+        (
+            DeepSeekChatProvider,
+            [
+                _model("deepseek/deepseek-chat", created=1_700_000_000),
+                _model("deepseek/deepseek-v3.2-chat", created=1_800_000_000),
+                _model("deepseek/deepseek-r1", created=1_900_000_000),
+            ],
+            "deepseek/deepseek-v3.2-chat",
+        ),
+        (
+            DeepSeekReasonerProvider,
+            [
+                _model("deepseek/deepseek-r1", created=1_700_000_000),
+                _model("deepseek/deepseek-r2", created=1_800_000_000),
+                _model("deepseek/deepseek-v3.2-chat", created=1_900_000_000),
+            ],
+            "deepseek/deepseek-r2",
+        ),
+    ],
+)
+def test_deepseek_call_uses_newest_matching_catalog_slug(
+    monkeypatch, provider_cls, catalog_models, expected_model
+):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+    monkeypatch.setattr(openrouter_catalog, "load_catalog", lambda: catalog_models)
+    captured: dict[str, object] = {}
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        captured["payload"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "model": expected_model,
+                "choices": [{"message": {"content": "ok"}}],
+                "usage": {},
+            },
+        )
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.post("/chat/completions").mock(side_effect=_record)
+        response = provider_cls().call("hi")
+
+    assert response.model == expected_model
+    assert captured["payload"]["model"] == expected_model
+
+
+def test_deepseek_uses_stale_catalog_cache_when_refresh_fails(
+    monkeypatch, tmp_path, capsys
+):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+    cache_path = tmp_path / "openrouter-catalog.json"
+    monkeypatch.setattr(openrouter_catalog, "OPENROUTER_CATALOG_CACHE_PATH", cache_path)
+    cached_model = "deepseek/deepseek-v3.2-chat"
+    _write_catalog_cache(
+        cache_path,
+        model_id=cached_model,
+        fetched_at=int(time.time()) - (48 * 3600),
+    )
+    captured: dict[str, object] = {}
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        captured["payload"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "model": cached_model,
+                "choices": [{"message": {"content": "ok"}}],
+                "usage": {},
+            },
+        )
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.get("/models").mock(side_effect=httpx.ConnectError("network down"))
+        router.post("/chat/completions").mock(side_effect=_record)
+        response = DeepSeekChatProvider().call("hi")
+
+    assert response.model == cached_model
+    assert captured["payload"]["model"] == cached_model
+    assert "using stale cache" in capsys.readouterr().err
 
 
 def test_init_deepseek_chat_surfaces_migration_message(mocker, monkeypatch):

--- a/tests/test_kimi_migration.py
+++ b/tests/test_kimi_migration.py
@@ -1,14 +1,55 @@
 from __future__ import annotations
 
 import json
+import time
 
 import httpx
 import respx
 from click.testing import CliRunner
 
+import conductor.providers.openrouter_catalog as openrouter_catalog
 from conductor.cli import main
+from conductor.providers.interface import ProviderHTTPError
 from conductor.providers.kimi import KIMI_DEFAULT_MODEL, KimiProvider
 from conductor.providers.openrouter import OPENROUTER_API_KEY_ENV, OpenRouterProvider
+
+
+def _model(model_id: str, *, created: int) -> openrouter_catalog.ModelEntry:
+    return openrouter_catalog.ModelEntry(
+        id=model_id,
+        name=model_id,
+        created=created,
+        context_length=256_000,
+        pricing_prompt=0.001,
+        pricing_completion=0.002,
+        pricing_thinking=None,
+        supports_thinking=False,
+        supports_tools=False,
+        supports_vision=False,
+    )
+
+
+def _write_catalog_cache(path, *, model_id: str, fetched_at: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "{\n"
+        f'  "fetched_at": {fetched_at},\n'
+        '  "models": [\n'
+        "    {\n"
+        f'      "id": "{model_id}",\n'
+        f'      "name": "{model_id}",\n'
+        '      "created": 1800000000,\n'
+        '      "context_length": 256000,\n'
+        '      "pricing_prompt": 0.001,\n'
+        '      "pricing_completion": 0.002,\n'
+        '      "pricing_thinking": null,\n'
+        '      "supports_thinking": false,\n'
+        '      "supports_tools": false,\n'
+        '      "supports_vision": false\n'
+        "    }\n"
+        "  ]\n"
+        "}\n"
+    )
 
 
 def test_kimi_provider_subclasses_openrouter_and_presets_model():
@@ -20,6 +61,11 @@ def test_kimi_provider_subclasses_openrouter_and_presets_model():
 
 def test_kimi_call_uses_preset_openrouter_model(monkeypatch):
     monkeypatch.setenv(OPENROUTER_API_KEY_ENV, "or-test-key")
+    monkeypatch.setattr(
+        openrouter_catalog,
+        "load_catalog",
+        lambda: [_model(KIMI_DEFAULT_MODEL, created=1_700_000_000)],
+    )
     captured: dict[str, object] = {}
 
     def _record(request: httpx.Request) -> httpx.Response:
@@ -43,6 +89,96 @@ def test_kimi_call_uses_preset_openrouter_model(monkeypatch):
         "messages": [{"role": "user", "content": "hi"}],
         "reasoning": {"effort": "medium"},
     }
+
+
+def test_kimi_call_uses_newest_catalog_slug(monkeypatch):
+    monkeypatch.setenv(OPENROUTER_API_KEY_ENV, "or-test-key")
+    monkeypatch.setattr(
+        openrouter_catalog,
+        "load_catalog",
+        lambda: [
+            _model("moonshotai/kimi-k2.6", created=1_700_000_000),
+            _model("moonshotai/kimi-k3", created=1_800_000_000),
+        ],
+    )
+    captured: dict[str, object] = {}
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        captured["payload"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "model": "moonshotai/kimi-k3",
+                "choices": [{"message": {"content": "ok"}}],
+                "usage": {},
+            },
+        )
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.post("/chat/completions").mock(side_effect=_record)
+        response = KimiProvider().call("hi")
+
+    assert response.model == "moonshotai/kimi-k3"
+    assert captured["payload"]["model"] == "moonshotai/kimi-k3"
+
+
+def test_kimi_call_falls_back_to_pinned_slug_when_catalog_unavailable(
+    monkeypatch, capsys
+):
+    monkeypatch.setenv(OPENROUTER_API_KEY_ENV, "or-test-key")
+
+    def _raise_catalog_error():
+        raise ProviderHTTPError("network down")
+
+    monkeypatch.setattr(openrouter_catalog, "load_catalog", _raise_catalog_error)
+    captured: dict[str, object] = {}
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        captured["payload"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "model": KIMI_DEFAULT_MODEL,
+                "choices": [{"message": {"content": "ok"}}],
+                "usage": {},
+            },
+        )
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.post("/chat/completions").mock(side_effect=_record)
+        response = KimiProvider().call("hi")
+
+    assert response.model == KIMI_DEFAULT_MODEL
+    assert captured["payload"]["model"] == KIMI_DEFAULT_MODEL
+    assert "using pinned fallback" in capsys.readouterr().err
+
+
+def test_kimi_fresh_catalog_cache_hit_is_silent(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv(OPENROUTER_API_KEY_ENV, "or-test-key")
+    cache_path = tmp_path / "openrouter-catalog.json"
+    monkeypatch.setattr(openrouter_catalog, "OPENROUTER_CATALOG_CACHE_PATH", cache_path)
+    cached_model = "moonshotai/kimi-k3"
+    _write_catalog_cache(cache_path, model_id=cached_model, fetched_at=int(time.time()))
+    captured: dict[str, object] = {}
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        captured["payload"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "model": cached_model,
+                "choices": [{"message": {"content": "ok"}}],
+                "usage": {},
+            },
+        )
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.post("/chat/completions").mock(side_effect=_record)
+        response = KimiProvider().call("hi")
+
+    assert response.model == cached_model
+    assert captured["payload"]["model"] == cached_model
+    assert capsys.readouterr().err == ""
 
 
 def test_init_kimi_surfaces_legacy_cloudflare_migration_message(

--- a/tests/test_nightly_smoke_workflow.py
+++ b/tests/test_nightly_smoke_workflow.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/nightly-smoke.yml")
+
+
+def test_nightly_smoke_skips_missing_secrets_without_failure_issue():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "::error::$name secret is required for live subprocess smoke" not in text
+    assert "::notice::$name secret is not configured; skipping live subprocess smoke" in text
+    assert "touch live-smoke-skipped.txt" in text
+    assert re.search(
+        r'if \[ "\$\{#missing\[@\]\}" -ne 0 \]; then.*?exit 0',
+        text,
+        flags=re.S,
+    )
+
+
+def test_nightly_smoke_dedupes_failure_issues_by_label():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "gh issue list" in text
+    assert "--state open" in text
+    assert "--label live-smoke-failure" in text
+    assert ".[0].number // empty" in text
+    assert 'gh issue comment "$existing_issue" --body-file live-smoke-issue.md' in text
+    assert "gh issue create" in text

--- a/tests/test_offline_fallback.py
+++ b/tests/test_offline_fallback.py
@@ -23,6 +23,7 @@ import pytest
 import respx
 from click.testing import CliRunner
 
+import conductor.providers.openrouter_catalog as openrouter_catalog
 from conductor import offline_mode
 from conductor.cli import _is_retryable, main
 from conductor.providers.interface import ProviderHTTPError
@@ -55,6 +56,24 @@ def _isolate_offline_cache(tmp_path, monkeypatch):
 def _kimi_configured(monkeypatch):
     """Populate the env so KimiProvider.configured() returns True."""
     monkeypatch.setenv(OPENROUTER_API_KEY_ENV, "or-test-key")
+    monkeypatch.setattr(
+        openrouter_catalog,
+        "load_catalog",
+        lambda: [
+            openrouter_catalog.ModelEntry(
+                id=KIMI_DEFAULT_MODEL,
+                name=KIMI_DEFAULT_MODEL,
+                created=1_700_000_000,
+                context_length=256_000,
+                pricing_prompt=0.001,
+                pricing_completion=0.002,
+                pricing_thinking=None,
+                supports_thinking=False,
+                supports_tools=False,
+                supports_vision=False,
+            )
+        ],
+    )
 
 
 def _stub_other_providers_unconfigured(mocker, *, include_ollama: bool = False):


### PR DESCRIPTION
## Summary

Addresses the three open conductor issues reviewed in this session:

- Closes #77: live subprocess smoke now skips when required API-key secrets are absent, writes a clear workflow summary, and dedupes real failure reports by commenting on an existing `live-smoke-failure` issue instead of filing nightly duplicates.
- Closes #87: Claude provider preflight now supports `CONDUCTOR_CLAUDE_CLI` and distinguishes non-interactive PATH visibility from a missing/broken Claude install.
- Closes #85: Kimi and DeepSeek OpenRouter shims now resolve the newest matching catalog slug at call/smoke time, use the existing stale-cache path, and log loudly before falling back to pinned defaults.

## Root Causes

- The nightly smoke workflow treated intentionally missing repository secrets as job failures and opened a fresh issue each run.
- Claude executable discovery only used the process PATH, so non-interactive agent environments could not point Conductor at a known-good CLI path and received misleading setup guidance.
- Kimi/DeepSeek provider IDs kept hard-coded OpenRouter slugs even though the generic OpenRouter path already had catalog-driven model selection.

## Validation

- `uv run ruff check .`
- `uv run pytest` (`621 passed, 15 skipped`)
