### PR TITLE
fix(exec): resolve provider before .name access in preflight failure path

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -1422,16 +1422,20 @@ def exec_cmd(
         print_caller_banner(decision.provider, silent=silent_route or as_json)
         _emit_route_log(decision, verbose=verbose_route, silent=silent_route or as_json)
         if preflight:
-            ok, reason = _run_exec_preflight(provider)
+            # `provider` may arrive as a Provider object (real `pick()` return)
+            # or as a string (test fixtures, and any caller passing the name).
+            # Resolve once via the helper so downstream `.name` access is safe.
+            provider_obj = _provider_for_preflight(provider)
+            ok, reason = provider_obj.health_probe()
             if not ok:
                 if session_log is not None:
-                    session_log.bind_provider(provider.name)
+                    session_log.bind_provider(provider_obj.name)
                     session_log.emit(
                         "provider_failed",
-                        {"provider": provider.name, "error": reason or "preflight failed"},
+                        {"provider": provider_obj.name, "error": reason or "preflight failed"},
                     )
                     session_log.mark_finished()
-                _echo_preflight_failure(provider, reason)
+                _echo_preflight_failure(provider_obj, reason)
                 sys.exit(2)
 
         try:

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -33,7 +33,7 @@ from conductor.providers import (
     OllamaProvider,
     OpenRouterProvider,
 )
-from conductor.router import reset_health
+from conductor.router import RouteDecision, reset_health
 
 
 @pytest.fixture(autouse=True)
@@ -556,6 +556,50 @@ def test_exec_cli_preflight_blocks_exec_and_surfaces_fix_hint(mocker):
     assert not exec_mock.called
     assert "[conductor] preflight failed for codex: network is unreachable" in result.stderr
     assert "[conductor] try: brew install codex && codex login" in result.stderr
+
+
+def test_exec_auto_preflight_failure_does_not_attribute_error_on_str_provider(mocker):
+    """Regression: auto-mode `pick()` may return the provider name as a string
+    (test fixtures, and some legacy callers); when preflight fails the cli used
+    to call `provider.name` on that string and AttributeError. This test pins
+    the failure mode by mocking `pick` to return ("codex", decision) and
+    health_probe to fail — the buggy code raised AttributeError; the fixed
+    code emits the standard preflight-failure message and exits 2.
+    """
+    _stub_all_configured(mocker, {"codex"})
+    mocker.patch.object(
+        CodexProvider,
+        "health_probe",
+        return_value=(False, "network is unreachable"),
+    )
+    fake_decision = RouteDecision(
+        provider="codex",
+        prefer="best",
+        effort="medium",
+        thinking_budget=8000,
+        tier="frontier",
+        task_tags=("coding",),
+        matched_tags=("coding",),
+        tools_requested=("Read",),
+        sandbox="workspace-write",
+        ranked=(),
+        candidates_skipped=(),
+        tag_default_applied={},
+    )
+    mocker.patch("conductor.cli.pick", return_value=("codex", fake_decision))
+    exec_mock = mocker.patch.object(
+        CodexProvider, "exec", return_value=_fake_response("codex")
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["exec", "--auto", "--tags", "coding", "--tools", "Read", "--task", "do it"],
+    )
+
+    assert result.exit_code == 2, result.output
+    assert not exec_mock.called
+    assert "AttributeError" not in result.output
+    assert "[conductor] preflight failed for codex: network is unreachable" in result.stderr
 
 
 def test_exec_cli_no_preflight_skips_probe(mocker):


### PR DESCRIPTION
PR #84 (preflight) added a block in `exec_cmd` that, on health_probe
failure, calls `provider.name` while logging and emitting session events.
But `provider` here can be either a Provider object or a string — the
helper `_provider_for_preflight` exists precisely to bridge that — and
when it's a string (the legacy contract some test fixtures still use,
and any caller that hands in a name), `.name` raises
AttributeError("'str' object has no attribute 'name'").

The bug only fires when health_probe returns False, so it doesn't
trigger on developer machines where the target CLI is installed but
fires on every CI runner that lacks the CLI. validate has been red on
main since #84 landed (4 test_profiles.py tests failing on every push).

Resolve `provider` once via `_provider_for_preflight` at the top of the
preflight block, then use the resolved object's `.name` everywhere
downstream. Add a regression test that mocks `pick` to return a string
provider and `health_probe` to fail, verifying the failure path emits
the standard preflight message and exits 2 instead of AttributeError.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
