### PR TITLE
[codex] fix provider stall watchdog

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -45,6 +45,7 @@ from conductor.providers import (
     ProviderConfigError,
     ProviderError,
     ProviderHTTPError,
+    ProviderStalledError,
     UnsupportedCapability,
     get_provider,
     known_providers,
@@ -298,12 +299,14 @@ def _is_retryable(err: Exception) -> tuple[bool, str]:
     mode prompt can fire on the real thing (DNS/TCP failure) rather than
     on a slow-but-reachable upstream.
     """
+    if isinstance(err, ProviderStalledError):
+        return True, "timeout"
     msg = str(err).lower()
     if "429" in msg or "rate limit" in msg or "ratelimit" in msg:
         return True, "rate-limit"
     if any(sig in msg for sig in _NETWORK_ERROR_SIGNALS):
         return True, "network"
-    if "timed out" in msg or "timeout" in msg:
+    if "timed out" in msg or "timeout" in msg or "stalled" in msg:
         return True, "timeout"
     # HTTP 5xx — check for " 5" preceded by "http" or a similar prefix so
     # we don't match arbitrary "5" digits. Cheap heuristic; acceptable.

--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -236,7 +236,6 @@ class ClaudeProvider:
         resume_session_id: str | None = None,
         session_log: SessionLog | None = None,
     ) -> CallResponse:
-        # accepted for API parity; only codex implements stall-watchdog today
         # Claude's `--allowedTools` is fine-grained; passing an empty set
         # is effectively "no tools permitted" (single-turn).
         allowed = ",".join(sorted(tools)) if tools else None
@@ -257,6 +256,7 @@ class ClaudeProvider:
             permission_mode=permission_mode,
             cwd=cwd,
             timeout_sec_override=timeout_sec,
+            max_stall_sec=max_stall_sec,
             resume_session_id=resume_session_id,
             live_auth_capture=True,
             session_log=session_log,
@@ -272,6 +272,7 @@ class ClaudeProvider:
         permission_mode: str | None,
         cwd: str | None = None,
         timeout_sec_override: float | None | object = _USE_DEFAULT,
+        max_stall_sec: int | None = None,
         resume_session_id: str | None = None,
         live_auth_capture: bool = False,
         session_log: SessionLog | None = None,
@@ -325,6 +326,9 @@ class ClaudeProvider:
                     cwd=cwd,
                     env=proc_env,
                     timeout=timeout,
+                    max_stall_sec=max_stall_sec,
+                    provider_name=self.name,
+                    session_log=session_log,
                     tracker=tracker,
                     popen_factory=subprocess.Popen,
                 )

--- a/src/conductor/providers/cli_auth.py
+++ b/src/conductor/providers/cli_auth.py
@@ -12,6 +12,8 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from conductor.providers.interface import ProviderStalledError
+
 if TYPE_CHECKING:
     from conductor.session_log import SessionLog
 
@@ -38,6 +40,12 @@ class CapturedProcessResult:
     stdout: str
     stderr: str
     duration_ms: int
+
+
+def _format_stall_seconds(value: float) -> str:
+    if float(value).is_integer():
+        return str(int(value))
+    return f"{value:g}"
 
 
 def _extract_url(text: str) -> str | None:
@@ -176,6 +184,9 @@ def run_subprocess_with_live_stderr(
     cwd: str | None,
     env: dict[str, str] | None,
     timeout: float | None,
+    max_stall_sec: float | None = None,
+    provider_name: str | None = None,
+    session_log: SessionLog | None = None,
     tracker: AuthPromptTracker,
     popen_factory,
 ) -> CapturedProcessResult:
@@ -214,6 +225,8 @@ def run_subprocess_with_live_stderr(
     stdout_thread.start()
     stderr_thread.start()
 
+    last_output = start
+    provider_label = provider_name or str(args[0])
     while True:
         now = time.monotonic()
         if timeout is not None and now - start > timeout:
@@ -226,6 +239,35 @@ def run_subprocess_with_live_stderr(
                 timeout=timeout,
                 output="".join(parts["stdout"]),
                 stderr="".join(parts["stderr"]),
+            )
+
+        if max_stall_sec is not None and now - last_output > max_stall_sec:
+            _terminate_process(process)
+            stdout_thread.join(timeout=1)
+            stderr_thread.join(timeout=1)
+            _drain_stream_queue(stream_q, parts, tracker)
+            elapsed = time.monotonic() - last_output
+            last_event = (
+                "provider_output"
+                if parts["stdout"] or parts["stderr"]
+                else "provider_started"
+            )
+            reason = (
+                "no_provider_response_within_"
+                f"{_format_stall_seconds(max_stall_sec)}s"
+            )
+            if session_log is not None:
+                session_log.emit(
+                    "error",
+                    {
+                        "provider": provider_label,
+                        "reason": reason,
+                        "last_event": last_event,
+                        "silent_sec": round(elapsed, 1),
+                    },
+                )
+            raise ProviderStalledError(
+                f"{provider_label} CLI stalled after {elapsed:.0f}s with no output"
             )
 
         try:
@@ -242,6 +284,7 @@ def run_subprocess_with_live_stderr(
             continue
 
         parts[stream_name].append(item)
+        last_output = time.monotonic()
         if stream_name == "stderr":
             tracker.observe_text(item, source="stderr")
 

--- a/src/conductor/providers/gemini.py
+++ b/src/conductor/providers/gemini.py
@@ -246,7 +246,6 @@ class GeminiProvider:
         resume_session_id: str | None = None,
         session_log: SessionLog | None = None,
     ) -> CallResponse:
-        # accepted for API parity; only codex implements stall-watchdog today
         # Gemini's --approval-mode: "plan" (read-only) vs "yolo" (all writes
         # auto-approved). No finer granularity; tools set is advisory.
         approval_mode = {
@@ -261,6 +260,7 @@ class GeminiProvider:
             approval_mode=approval_mode,
             cwd=cwd,
             timeout_sec_override=timeout_sec,
+            max_stall_sec=max_stall_sec,
             resume_session_id=resume_session_id,
             live_auth_capture=True,
             session_log=session_log,
@@ -275,6 +275,7 @@ class GeminiProvider:
         approval_mode: str,
         cwd: str | None = None,
         timeout_sec_override: float | None | object = _USE_DEFAULT,
+        max_stall_sec: int | None = None,
         resume_session_id: str | None = None,
         live_auth_capture: bool = False,
         session_log: SessionLog | None = None,
@@ -326,6 +327,9 @@ class GeminiProvider:
                     cwd=cwd,
                     env=proc_env,
                     timeout=timeout,
+                    max_stall_sec=max_stall_sec,
+                    provider_name=self.name,
+                    session_log=session_log,
                     tracker=tracker,
                     popen_factory=subprocess.Popen,
                 )

--- a/src/conductor/providers/interface.py
+++ b/src/conductor/providers/interface.py
@@ -203,8 +203,9 @@ class Provider(Protocol):
         """Multi-turn agent session with tool access.
 
         ``resume_session_id`` semantics match ``call()``.
-        ``max_stall_sec`` is an optional no-output watchdog; providers that
-        do not implement it accept and ignore the value for API parity.
+        ``max_stall_sec`` is an optional no-output watchdog. CLI-backed
+        providers should honor it; providers without a streaming subprocess
+        may accept and ignore the value for API parity.
 
         Raises UnsupportedCapability if the provider cannot drive the
         requested tools or sandbox, or cannot resume sessions when one

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -7,6 +7,7 @@ All three call external CLIs. We stub ``subprocess.run`` and
 from __future__ import annotations
 
 import io
+import json
 import os
 import shutil
 import subprocess
@@ -344,6 +345,38 @@ def test_claude_exec_surfaces_auth_prompt_and_records_notice(mocker, capsys):
     err = capsys.readouterr().err
     assert "[conductor] auth required for claude" in err
     assert "https://claude.ai/oauth/authorize" in err
+
+
+def test_claude_exec_stall_watchdog_kills_silent_provider_and_logs_error(
+    mocker,
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
+    fake = _FakePopen(stdout_schedule=[], hang_after_stdout=True)
+    mocker.patch(
+        "conductor.providers.claude.subprocess.Popen",
+        side_effect=lambda args, **kwargs: fake,
+    )
+    session_log = SessionLog(path=tmp_path / "claude-stall.ndjson")
+
+    with pytest.raises(ProviderStalledError) as exc:
+        ClaudeProvider().exec(
+            "hi",
+            max_stall_sec=0.05,
+            session_log=session_log,
+        )
+
+    assert fake.terminated is True
+    assert "claude CLI stalled" in str(exc.value)
+    events = [
+        json.loads(line)
+        for line in session_log.log_path.read_text(encoding="utf-8").splitlines()
+    ]
+    error_event = next(event for event in events if event["event"] == "error")
+    assert error_event["data"]["reason"] == "no_provider_response_within_0.05s"
+    assert error_event["data"]["last_event"] == "provider_started"
 
 
 # ---------------------------------------------------------------------------
@@ -1341,6 +1374,21 @@ def test_gemini_exec_surfaces_auth_prompt_and_records_notice(mocker, capsys):
     err = capsys.readouterr().err
     assert "[conductor] auth required for gemini" in err
     assert "https://accounts.google.com/o/oauth2/auth" in err
+
+
+def test_gemini_exec_stall_watchdog_kills_silent_provider(mocker):
+    mocker.patch("conductor.providers.gemini.shutil.which", return_value="/usr/bin/gemini")
+    fake = _FakePopen(stdout_schedule=[], hang_after_stdout=True)
+    mocker.patch(
+        "conductor.providers.gemini.subprocess.Popen",
+        side_effect=lambda args, **kwargs: fake,
+    )
+
+    with pytest.raises(ProviderStalledError) as exc:
+        GeminiProvider().exec("hi", max_stall_sec=0.05)
+
+    assert fake.terminated is True
+    assert "gemini CLI stalled" in str(exc.value)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_log_file.py
+++ b/tests/test_cli_log_file.py
@@ -16,6 +16,7 @@ from conductor.providers import (
     KimiProvider,
     OllamaProvider,
     OpenRouterProvider,
+    ProviderStalledError,
 )
 from conductor.router import reset_health
 from conductor.session_log import SessionLog
@@ -198,6 +199,59 @@ def test_sessions_list_and_tail_use_cached_metadata(
     assert tail_result.exit_code == 0, tail_result.output
     tailed = [json.loads(line) for line in tail_result.output.splitlines()]
     assert tailed[0]["event"] == "provider_started"
+
+
+def test_exec_provider_stall_records_terminal_session_metadata(
+    mocker,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    mocker.patch.object(ClaudeProvider, "health_probe", return_value=(True, None))
+
+    def _fake_exec(self, task, model=None, **kwargs):
+        session_log = kwargs["session_log"]
+        session_log.emit(
+            "error",
+            {
+                "provider": "claude",
+                "reason": "no_provider_response_within_1s",
+                "last_event": "provider_started",
+            },
+        )
+        raise ProviderStalledError("claude CLI stalled after 1s with no output")
+
+    mocker.patch.object(ClaudeProvider, "exec", _fake_exec)
+    log_path = tmp_path / "session.ndjson"
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--with",
+            "claude",
+            "--max-stall-seconds",
+            "1",
+            "--task",
+            "review the diff",
+            "--log-file",
+            str(log_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    events = _read_events(log_path)
+    kinds = [event["event"] for event in events]
+    assert "provider_started" in kinds
+    assert "error" in kinds
+    assert "provider_failed" in kinds
+
+    sessions_root = tmp_path / "conductor" / "sessions"
+    meta_paths = list(sessions_root.glob("*.meta.json"))
+    assert len(meta_paths) == 1
+    meta = json.loads(meta_paths[0].read_text(encoding="utf-8"))
+    assert meta["status"] != "running"
+    assert meta["finished_at"] is not None
 
 
 def test_sessions_tail_without_active_session_prints_message(

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -80,7 +80,17 @@ def test_exec_profile_applies_builtin_sandbox(mocker):
 
     result = CliRunner().invoke(
         main,
-        ["exec", "--auto", "--profile", "coding", "--tools", "Read", "--task", "hi"],
+        [
+            "exec",
+            "--auto",
+            "--profile",
+            "coding",
+            "--tools",
+            "Read",
+            "--no-preflight",
+            "--task",
+            "hi",
+        ],
     )
 
     assert result.exit_code == 0, result.output
@@ -110,7 +120,17 @@ def test_user_profile_overrides_builtin(mocker, monkeypatch, tmp_path):
 
     result = CliRunner().invoke(
         main,
-        ["exec", "--auto", "--profile", "coding", "--tools", "Read", "--task", "hi"],
+        [
+            "exec",
+            "--auto",
+            "--profile",
+            "coding",
+            "--tools",
+            "Read",
+            "--no-preflight",
+            "--task",
+            "hi",
+        ],
     )
 
     assert result.exit_code == 0, result.output
@@ -157,6 +177,7 @@ def test_explicit_flags_override_profile_defaults(mocker):
             "workspace-write",
             "--tools",
             "Read",
+            "--no-preflight",
             "--task",
             "hi",
         ],
@@ -197,6 +218,7 @@ def test_profile_env_cli_precedence(mocker, monkeypatch):
             "coding,tool-use",
             "--tools",
             "Read",
+            "--no-preflight",
             "--task",
             "hi",
         ],


### PR DESCRIPTION
## Summary

Adds a shared no-output watchdog for live CLI subprocess execution and wires it through Claude and Gemini exec runs.

## Root Cause

`conductor exec --max-stall-seconds` was only enforced by the Codex streaming path. Claude and Gemini accepted the argument for API parity but ignored it, so a provider subprocess that stopped producing stdout/stderr after `provider_started` could leave session metadata stuck at `status: running` indefinitely.

## Changes

- Enforce `max_stall_sec` in `run_subprocess_with_live_stderr`.
- Emit a structured session `error` event with `reason`, `last_event`, and `silent_sec` before raising `ProviderStalledError`.
- Wire the shared watchdog through Claude and Gemini exec paths.
- Treat `ProviderStalledError` as timeout-like for auto fallback classification.
- Add regression coverage for silent Claude/Gemini provider hangs and terminal session metadata.

Closes #91

## Validation

- `uv run ruff check src/conductor/providers/cli_auth.py src/conductor/providers/claude.py src/conductor/providers/gemini.py src/conductor/providers/interface.py src/conductor/cli.py tests/test_adapters_subprocess.py tests/test_cli_log_file.py`
- `uv run pytest tests/test_adapters_subprocess.py tests/test_cli_log_file.py tests/test_cli_v02.py`
- `uv run pytest` (625 passed, 15 skipped)