### PR TITLE
[codex] add explicit delegation briefs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,8 +84,13 @@ Primary channel is the Homebrew tap `autumngarage/homebrew-conductor` (install: 
 
 Conductor exposes two modes:
 
-- **Manual:** `conductor call --with <provider> --task "..."` — caller picks the provider explicitly.
-- **Auto:** `conductor call --auto --task "..." --tags <a,b,c>` — Conductor's router picks based on task tags + provider capability tags.
+- **Manual:** `conductor call --with <provider> --brief "..."` — caller picks the provider explicitly.
+- **Auto:** `conductor call --auto --brief "..." --tags <a,b,c>` — Conductor's router picks based on task tags + provider capability tags.
+
+For agent delegation, prefer `--brief-file` and include enough context for
+the receiving model to work without this conversation: goal, context, scope,
+constraints, expected output, and validation. `--task` / `--task-file`
+remain supported for compatibility, but `--brief` is the clearer contract.
 
 Both modes return the same `CallResponse` shape on stdout (text or JSON via `--json`). Consumers (Sentinel, Touchstone) shell out and read stdout; they never import Conductor as a library. This preserves Sentinel's "no Python coupling between trio tools" invariant and lets Conductor release on its own cadence.
 

--- a/README.md
+++ b/README.md
@@ -60,31 +60,38 @@ pip install git+https://github.com/autumngarage/conductor
 export OPENROUTER_API_KEY=sk-or-v1-...
 
 # Manual mode: pick a specific provider
-conductor call --with kimi --task "What is 2+2?"
+conductor call --with kimi --brief "What is 2+2?"
 
-# Pipe content as the task
-cat README.md | conductor call --with kimi --task "Summarize this in one sentence."
+# Pipe content as the brief
+cat README.md | conductor call --with kimi --brief "Summarize this in one sentence."
 
 # Override the default model (default: moonshotai/kimi-k2.6)
-conductor call --with kimi --model moonshotai/kimi-k2 --task "..."
+conductor call --with kimi --model moonshotai/kimi-k2 --brief "..."
 
 # Get the full response as JSON (for scripting)
-conductor call --with kimi --task "ping" --json
+conductor call --with kimi --brief "ping" --json
 ```
+
+For delegation from Claude, Codex, or another agent, prefer
+`--brief-file PATH` and include the goal, context, scope, constraints,
+expected output, and validation. Conductor only sees the brief you pass
+plus any files the delegated provider can inspect; it does not inherit
+the caller's conversation context. Existing `--task` / `--task-file`
+flags remain supported as compatibility aliases.
 
 ## v0.1 scope
 
 Shipped:
 
 - Built-in providers: `kimi` (OpenRouter-backed HTTP preset), `openrouter`, `deepseek-chat`, `deepseek-reasoner`, `claude`, `codex`, `gemini`, and `ollama`.
-- `conductor call --with <id> --task "..."` — manual mode for any provider.
-- `conductor call --auto [--tags a,b,c] --task "..."` — rule-based router picks the best configured provider for the task's tags.
+- `conductor call --with <id> --brief "..."` — manual mode for any provider.
+- `conductor call --auto [--tags a,b,c] --brief "..."` — rule-based router picks the best configured provider for the task's tags.
 - `conductor list [--json]` — shows every provider with ready/not-ready status, default model, and capability tags.
 - `conductor smoke <id>` / `conductor smoke --all [--json]` — proves a provider's auth + endpoint work (cheapest round-trip that exercises the full path).
 - `conductor doctor [--json]` — diagnostic report: which providers are configured, which env vars are set, what's in the macOS Keychain.
 - `conductor init [-y]` — interactive first-run wizard (TTY-detected, `--yes` for non-TTY). For providers needing credentials (`openrouter`, plus OpenRouter-backed `kimi` / `deepseek-*`), prompts, recommends macOS Keychain or Linux `secret-tool` when available, keeps 1Password available via `op read`, runs a setup verification smoke test, and prints the manual env-var fallback when no encrypted store is available.
 - Credentials resolver (`conductor.credentials`): env var first, then `key_command`, then macOS Keychain under service `conductor`.
-- Offline-mode fallback: on a real connectivity failure (DNS, TCP reset, unreachable host) during `--auto` routing, Conductor prompts once to switch to the local `ollama` provider and remembers that choice for a short window. `conductor call --offline --task "..."` is the non-interactive form — useful on a plane, in CI, or any time you want to force local. Clear the sticky flag with `--no-offline`.
+- Offline-mode fallback: on a real connectivity failure (DNS, TCP reset, unreachable host) during `--auto` routing, Conductor prompts once to switch to the local `ollama` provider and remembers that choice for a short window. `conductor call --offline --brief "..."` is the non-interactive form — useful on a plane, in CI, or any time you want to force local. Clear the sticky flag with `--no-offline`.
 
 Deferred (see `autumn-garage/.cortex/plans/conductor-bootstrap.md`):
 

--- a/src/conductor/_agent_templates.py
+++ b/src/conductor/_agent_templates.py
@@ -41,26 +41,32 @@ answer, present it to the user with attribution.
 
 ## How to delegate
 
+Conductor does **not** inherit your conversation context. Before every
+delegation, write a complete brief that includes the goal, relevant
+context, scope, constraints, expected output, and validation. For
+multi-turn `exec` work, prefer `--brief-file` so the handoff is durable
+and not squeezed through shell quoting.
+
 Single-turn call:
 
-    conductor call --with <provider> --task "..."
+    conductor call --with <provider> --brief "..."
 
 Let the router pick by tags:
 
-    conductor call --auto --tags long-context,cheap --task "..."
+    conductor call --auto --tags long-context,cheap --brief "..."
 
-Pipe content in as the task:
+Pipe content in as the brief:
 
-    cat long-file.md | conductor call --with kimi --task "Summarize."
+    cat long-file.md | conductor call --with kimi --brief "Summarize."
 
 Multi-turn agent session with tools (inside a sandbox):
 
     conductor exec --with <provider> --tools Read,Grep,Edit \\
-        --sandbox workspace-write --task "..."
+        --sandbox workspace-write --brief-file /tmp/conductor-brief.md
 
 Get JSON for scripting / piping into other tools:
 
-    conductor call --with kimi --task "..." --json
+    conductor call --with kimi --brief "..." --json
 
 ## Providers at a glance
 
@@ -107,23 +113,23 @@ $ARGUMENTS
 
 The first token is the target — a provider name (`kimi`, `claude`,
 `codex`, `gemini`, `ollama`) or the literal `auto` to let conductor's
-router pick. Everything after the first token is the task.
+router pick. Everything after the first token is the brief.
 
-Run the task through conductor using the Bash tool:
+Run the brief through conductor using the Bash tool:
 
 - If the first token is a provider name:
 
-      conductor call --with <provider> --task "<the rest>"
+      conductor call --with <provider> --brief "<the rest>"
 
 - If the first token is `auto`:
 
-      conductor call --auto --task "<the rest>"
+      conductor call --auto --brief "<the rest>"
 
 - If the task clearly needs file tools (editing, grep, long-running
-  agent work), prefer:
+  agent work), write a structured brief file first and prefer:
 
       conductor exec --with <provider> --tools Read,Grep,Edit \\
-          --sandbox workspace-write --task "<the rest>"
+          --sandbox workspace-write --brief-file /tmp/conductor-brief.md
 
 Capture the provider's response. Present it to the user with a brief
 "(from <provider>)" attribution. If conductor returns an error, show
@@ -144,17 +150,20 @@ answer — NOT to answer them yourself.
 
 When invoked:
 
-1. Take the user's task as given.
+1. Build a complete brief. Include the goal, relevant context, source
+   files or pasted content, expected output, and any constraints. Do not
+   assume Kimi can see your current conversation unless you put that
+   context in the brief.
 2. If the task references files, read them (use the Bash tool) and include
    the relevant contents in the prompt you pass to Kimi. Kimi supports
    1M-token contexts; you rarely need to truncate.
 3. Run:
 
-       conductor call --with kimi --task "<prompt>" --json
+       conductor call --with kimi --brief "<prompt>" --json
 
    Pipe content via stdin if the prompt is large:
 
-       cat <file> | conductor call --with kimi --task "Summarize." --json
+       cat <file> | conductor call --with kimi --brief "Summarize." --json
 
    For long-context work that also needs deeper reasoning, add
    `--effort high` or `--effort max`. For pure summarization or
@@ -200,10 +209,11 @@ should go through you.
 When invoked:
 
 1. Craft a prompt that explicitly asks Gemini to use web search and cite
-   its sources inline.
+   its sources inline. Include any conversation context Gemini needs;
+   conductor does not pass it implicitly.
 2. Run:
 
-       conductor call --with gemini --task "<prompt>" --json
+       conductor call --with gemini --brief "<prompt>" --json
 
 3. Parse the JSON, extract the `text` field, and return it verbatim
    prefixed with "From Gemini:". Preserve any URLs or citations Gemini
@@ -247,14 +257,15 @@ loop rather than answering single-shot.
 
 When invoked:
 
-1. Describe the task precisely — Codex will run its own loop and you
-   are giving it the initial prompt, not mid-conversation context.
+1. Write a structured brief file — Codex will run its own loop and you
+   are giving it the initial prompt, not mid-conversation context. Include:
+   Goal, Context, Scope, Constraints, Expected Output, and Validation.
 2. Run (always include the watchdog flags for unattended runs):
 
        conductor exec --with codex --tools Read,Grep,Glob,Edit,Write,Bash \\
            --sandbox workspace-write \\
            --max-stall-seconds 600 --timeout 1800 \\
-           --task "<prompt>" --json
+           --brief-file /tmp/conductor-brief.md --json
 
    `--max-stall-seconds 600` kills the run if codex produces no output
    for 10 minutes (the documented silent-hang failure mode — see
@@ -312,17 +323,19 @@ When invoked:
    than a hosted flagship. If the user's task clearly needs frontier
    reasoning and is NOT privacy-sensitive, say so and ask the parent
    to route elsewhere.
-2. Run with conductor's explicit offline flag:
+2. Build a complete brief. Include all sensitive context directly in the
+   brief because conductor does not inherit your conversation context.
+3. Run with conductor's explicit offline flag:
 
-       conductor call --offline --task "<prompt>" --json
+       conductor call --offline --brief "<prompt>" --json
 
    This forces the local Ollama provider and records conductor's
    short-lived offline preference. If the parent explicitly does not want
    that sticky offline preference, use the explicit provider path instead:
 
-       conductor call --with ollama --task "<prompt>" --json
+       conductor call --with ollama --brief "<prompt>" --json
 
-3. Parse the JSON, extract `text`, and return it prefixed with
+4. Parse the JSON, extract `text`, and return it prefixed with
    "From Ollama (local):".
 
 Verification reflex: If you diagnose a conductor-config-level cause for an
@@ -364,13 +377,17 @@ You can shell out to it instead of trying to do everything yourself.
 
 Quick reference:
 
-- `conductor call --with <provider> --task "..."` — single-turn call.
-- `conductor call --auto --tags <tag1>,<tag2> --task "..."` — let the
+- `conductor call --with <provider> --brief "..."` — single-turn call.
+- `conductor call --auto --tags <tag1>,<tag2> --brief "..."` — let the
   router pick a provider based on task tags.
 - `conductor exec --with <provider> --tools Read,Edit,Bash \\
-       --sandbox workspace-write --task "..."` — agent loop with file
+       --sandbox workspace-write --brief-file /tmp/conductor-brief.md` — agent loop with file
   tools, in a sandbox.
 - `conductor list` — show configured providers and their tags.
+
+Conductor does not inherit your conversation context. For delegation,
+write a complete brief with goal, context, scope, constraints, expected
+output, and validation; use `--brief-file` for nontrivial `exec` tasks.
 
 Providers commonly worth delegating to:
 
@@ -403,16 +420,20 @@ available — a CLI that dispatches work to other LLMs (Kimi, Gemini,
 Claude, Codex, Ollama) under a uniform interface.
 
 Use it when:
-- You want a cheap second opinion (`conductor call --with kimi --task "…"`).
-- You need fresh web information (`conductor call --with gemini --task "…"`).
-- You want to stay local / offline (`conductor call --with ollama --task "…"`).
+- You want a cheap second opinion (`conductor call --with kimi --brief "..."`).
+- You need fresh web information (`conductor call --with gemini --brief "..."`).
+- You want to stay local / offline (`conductor call --with ollama --brief "..."`).
 - You're not sure which provider fits — let the router pick:
-  `conductor call --auto --tags <tag1>,<tag2> --task "…"`.
+  `conductor call --auto --tags <tag1>,<tag2> --brief "..."`.
+
+Conductor does not inherit your conversation context. Write a complete
+brief before delegating; for `exec`, prefer `--brief-file` with goal,
+context, scope, constraints, expected output, and validation.
 
 For longer running tool-using sessions:
 
     conductor exec --with <provider> --tools Read,Edit,Bash \\
-        --sandbox workspace-write --task "…"
+        --sandbox workspace-write --brief-file /tmp/conductor-brief.md
 
 Discover configured providers: `conductor list`.
 
@@ -440,7 +461,7 @@ When invoked:
 2. For normal single-turn routing, run:
 
        conductor call --auto --tags <tag1>,<tag2> --prefer <mode> \\
-           --task "<prompt>" --json
+           --brief "<prompt>" --json
 
    For the prefer axis:
    - Default: `--prefer balanced` (what conductor does by default).
@@ -456,7 +477,7 @@ When invoked:
 
        conductor exec --auto --tags tool-use,<tag> \\
            --tools Read,Grep,Glob,Edit,Write,Bash \\
-           --sandbox <mode> --task "<prompt>" --json
+           --sandbox <mode> --brief-file /tmp/conductor-brief.md --json
 
    Sandbox modes are: `read-only` for inspection, `workspace-write` for
    edits in the workspace, `strict` for the strongest isolation supported

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -1,9 +1,9 @@
 """Conductor CLI — call, exec, list, smoke, doctor, init, route, config.
 
 v0.2 surface (call/exec):
-  conductor call --with <id> [--effort max] --task "..."
-  conductor call --auto [--tags a,b] [--prefer best] [--effort max] --task "..."
-  conductor exec --auto [--tools Read,Grep,Edit] [--sandbox read-only] --task "..."
+  conductor call --with <id> [--effort max] --brief "..."
+  conductor call --auto [--tags a,b] [--prefer best] [--effort max] --brief "..."
+  conductor exec --auto [--tools Read,Grep,Edit] [--sandbox read-only] --brief-file PATH
 
 v0.1 surface (unchanged):
   conductor list [--json]
@@ -22,7 +22,7 @@ import json
 import os
 import sys
 import time
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 import click
@@ -84,6 +84,13 @@ PROFILE_PRECEDENCE_TEXT = (
     "Resolution order: profile defaults < CONDUCTOR_* env vars < explicit CLI flags."
 )
 DEFAULT_EXEC_MAX_STALL_SEC = 360
+MIN_EXEC_BRIEF_CHARS = 300
+
+
+@dataclass(frozen=True)
+class BriefInput:
+    body: str
+    source: str
 
 
 # --------------------------------------------------------------------------- #
@@ -91,36 +98,79 @@ DEFAULT_EXEC_MAX_STALL_SEC = 360
 # --------------------------------------------------------------------------- #
 
 
-def _read_task(task: str | None, task_file: str | None) -> str:
-    if task is not None and task_file is not None:
+def _read_task(
+    task: str | None,
+    task_file: str | None,
+    *,
+    brief: str | None = None,
+    brief_file: str | None = None,
+) -> BriefInput:
+    explicit_sources = [
+        (name, value)
+        for name, value in (
+            ("--task", task),
+            ("--brief", brief),
+            ("--task-file", task_file),
+            ("--brief-file", brief_file),
+        )
+        if value is not None
+    ]
+    if len(explicit_sources) > 1:
+        got = ", ".join(name for name, _value in explicit_sources)
         raise click.UsageError(
-            "task source is ambiguous. Use exactly one of --task, --task-file, or stdin; "
-            "got --task, --task-file."
+            "brief source is ambiguous. Use exactly one of --brief, --brief-file, "
+            f"--task, --task-file, or stdin; got {got}."
         )
 
-    if task is not None:
+    source = "stdin"
+    if brief is not None:
+        body = brief
+        source = "--brief"
+    elif task is not None:
         body = task
-    elif task_file is not None:
-        if task_file == "-":
+        source = "--task"
+    elif brief_file is not None or task_file is not None:
+        file_source = brief_file if brief_file is not None else task_file
+        source = "--brief-file" if brief_file is not None else "--task-file"
+        assert file_source is not None
+        if file_source == "-":
             body = sys.stdin.read()
         else:
             try:
-                body = Path(task_file).read_text(encoding="utf-8")
+                body = Path(file_source).read_text(encoding="utf-8")
             except OSError as e:
                 raise click.UsageError(
-                    f"could not read --task-file {task_file!r}: {e.strerror or e}"
+                    f"could not read {source} {file_source!r}: {e.strerror or e}"
                 ) from e
     elif not sys.stdin.isatty():
         body = sys.stdin.read()
     else:
         raise click.UsageError(
-            "no task provided. Pass --task '...', --task-file PATH, or pipe content on stdin."
+            "no brief provided. Pass --brief '...', --brief-file PATH, "
+            "--task '...', --task-file PATH, or pipe content on stdin."
         )
 
     body = body.strip()
     if not body:
-        raise click.UsageError("task is empty after stripping whitespace.")
-    return body
+        raise click.UsageError("brief is empty after stripping whitespace.")
+    return BriefInput(body=body, source=source)
+
+
+def _warn_if_short_exec_brief(
+    brief_input: BriefInput,
+    *,
+    allow_short_brief: bool,
+) -> None:
+    if allow_short_brief or len(brief_input.body) >= MIN_EXEC_BRIEF_CHARS:
+        return
+    click.echo(
+        "[conductor] brief is short "
+        f"({len(brief_input.body)} chars). Delegated exec only sees this brief "
+        "plus files it can inspect; for Claude/Codex handoffs, prefer "
+        "--brief-file with goal, context, scope, constraints, expected output, "
+        "and validation. Pass --allow-short-brief to silence this warning.",
+        err=True,
+    )
 
 
 def _parse_csv(raw: str | None) -> list[str]:
@@ -373,7 +423,7 @@ def _echo_offline_hint(failed_name: str, *, silent: bool) -> None:
     click.echo(
         f"[conductor] {failed_name} is unreachable and no local fallback "
         "is available for automatic switching. If you are offline, run "
-        "`conductor call --with ollama --task '...'` (or pass --offline).",
+        "`conductor call --with ollama --brief '...'` (or pass --offline).",
         err=True,
     )
 
@@ -393,8 +443,8 @@ def _maybe_echo_explicit_network_hint(provider_id: str, err: Exception) -> None:
         return
     click.echo(
         f"[conductor] {provider_id} looks unreachable (network error). "
-        "If you are offline: `conductor call --offline --task '...'` "
-        "or `conductor call --with ollama --task '...'`.",
+        "If you are offline: `conductor call --offline --brief '...'` "
+        "or `conductor call --with ollama --brief '...'`.",
         err=True,
     )
 
@@ -1021,13 +1071,24 @@ def main() -> None:
     "--task",
     default=None,
     help="The task / prompt. Reads stdin if omitted.\n"
-    "For long briefs, prefer --task-file or stdin to keep the prompt\n"
+    "For delegation, prefer --brief or --brief-file.\n"
+    "For long briefs, prefer --brief-file or stdin to keep the prompt\n"
     "out of `ps aux`.",
 )
 @click.option(
     "--task-file",
     default=None,
-    help="Read the task / prompt from a UTF-8 file. Use '-' to read stdin.",
+    help="Read the task / prompt from a UTF-8 file. Alias: --brief-file.",
+)
+@click.option(
+    "--brief",
+    default=None,
+    help="Delegation brief / prompt. Alias for --task with clearer intent.",
+)
+@click.option(
+    "--brief-file",
+    default=None,
+    help="Read the delegation brief from a UTF-8 file. Use '-' to read stdin.",
 )
 @click.option(
     "--model",
@@ -1077,6 +1138,8 @@ def call(
     exclude: str | None,
     task: str | None,
     task_file: str | None,
+    brief: str | None,
+    brief_file: str | None,
     model: str | None,
     as_json: bool,
     verbose_route: bool,
@@ -1122,7 +1185,13 @@ def call(
             f"--with {provider_id} and --exclude {exclude} contradict each other."
         )
 
-    body = _read_task(task, task_file)
+    brief_input = _read_task(
+        task,
+        task_file,
+        brief=brief,
+        brief_file=brief_file,
+    )
+    body = brief_input.body
     effort_value = _parse_effort(effort)
 
     decision: RouteDecision | None = None
@@ -1290,13 +1359,24 @@ def call(
     "--task",
     default=None,
     help="The task / prompt. Reads stdin if omitted.\n"
-    "For long briefs, prefer --task-file or stdin to keep the prompt\n"
+    "For delegation, prefer --brief or --brief-file.\n"
+    "For long briefs, prefer --brief-file or stdin to keep the prompt\n"
     "out of `ps aux`.",
 )
 @click.option(
     "--task-file",
     default=None,
-    help="Read the task / prompt from a UTF-8 file. Use '-' to read stdin.",
+    help="Read the task / prompt from a UTF-8 file. Alias: --brief-file.",
+)
+@click.option(
+    "--brief",
+    default=None,
+    help="Delegation brief / prompt. Alias for --task with clearer intent.",
+)
+@click.option(
+    "--brief-file",
+    default=None,
+    help="Read the delegation brief from a UTF-8 file. Use '-' to read stdin.",
 )
 @click.option("--model", default=None, help="Override the provider's default model.")
 @click.option(
@@ -1335,6 +1415,15 @@ def call(
     default=True,
     help="Run a provider health probe before forwarding the task.",
 )
+@click.option(
+    "--allow-short-brief",
+    is_flag=True,
+    default=False,
+    help=(
+        "Suppress the short-brief warning for exec delegation. Use when the "
+        "brief is intentionally tiny or all context is supplied through files."
+    ),
+)
 def exec_cmd(
     provider_id: str | None,
     profile: str | None,
@@ -1350,6 +1439,8 @@ def exec_cmd(
     max_stall_sec: int | None,
     task: str | None,
     task_file: str | None,
+    brief: str | None,
+    brief_file: str | None,
     model: str | None,
     log_file: str | None,
     as_json: bool,
@@ -1358,6 +1449,7 @@ def exec_cmd(
     resume_session_id: str | None,
     offline: bool | None,
     preflight: bool,
+    allow_short_brief: bool,
 ) -> None:
     """Run a task as an agent session with tool access (exec mode)."""
     profile_spec = _load_named_profile(profile)
@@ -1395,7 +1487,17 @@ def exec_cmd(
             "--resume requires --with <provider> (sessions are provider-specific)."
         )
 
-    body = _read_task(task, task_file)
+    brief_input = _read_task(
+        task,
+        task_file,
+        brief=brief,
+        brief_file=brief_file,
+    )
+    _warn_if_short_exec_brief(
+        brief_input,
+        allow_short_brief=allow_short_brief,
+    )
+    body = brief_input.body
     tools_set = _validate_tools(tools)
     sandbox_value = _validate_sandbox(sandbox)
     effort_value = _parse_effort(effort)
@@ -2820,7 +2922,7 @@ def providers_add(
     click.echo(f"    file:    {path}")
     click.echo("")
     click.echo(f"Try it: conductor smoke {name}")
-    click.echo(f"Use it: conductor call --with {name} --task 'hello'")
+    click.echo(f"Use it: conductor call --with {name} --brief 'hello'")
 
 
 @providers.command("remove")

--- a/src/conductor/providers/shell.py
+++ b/src/conductor/providers/shell.py
@@ -157,7 +157,7 @@ class ShellProvider:
     def smoke(self) -> tuple[bool, str | None]:
         # Cheapest possible — just confirm the binary exists. A real
         # round-trip would cost tokens / time; the user can use
-        # `conductor call --with <name> --task "ping"` for that.
+        # `conductor call --with <name> --brief "ping"` for that.
         return self.configured()
 
     def health_probe(self, *, timeout_sec: float = 30.0) -> tuple[bool, str | None]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,11 +46,11 @@ def test_call_unknown_provider_shows_usage_error():
 
 def test_call_missing_task_and_no_stdin_errors():
     # CliRunner attaches an empty pipe as stdin (isatty=False), so we hit the
-    # empty-task branch rather than the no-task-no-stdin branch. Both signal
+    # empty-brief branch rather than the no-brief-no-stdin branch. Both signal
     # the same user error: nothing to send.
     result = CliRunner().invoke(main, ["call", "--with", "kimi"])
     assert result.exit_code != 0
-    assert "task" in result.output.lower() and "empty" in result.output.lower()
+    assert "brief" in result.output.lower() and "empty" in result.output.lower()
 
 
 def test_call_task_file_reads_file(monkeypatch, tmp_path):
@@ -77,6 +77,37 @@ def test_call_task_file_reads_file(monkeypatch, tmp_path):
     assert result.exit_code == 0, result.output
     assert "hello back" in result.output
     assert route.calls.last.request.content.decode("utf-8").count("brief from file") == 1
+
+
+def test_call_brief_file_reads_file(monkeypatch, tmp_path):
+    monkeypatch.setenv(OPENROUTER_API_KEY_ENV, "or-test-key")
+    _stub_kimi_catalog(monkeypatch)
+    brief = tmp_path / "brief.md"
+    brief.write_text("delegation brief from file\n", encoding="utf-8")
+
+    with respx.mock() as router:
+        route = router.post(_OPENROUTER_CHAT_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "model": KIMI_DEFAULT_MODEL,
+                    "choices": [{"message": {"content": "hello back"}}],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 2},
+                },
+            )
+        )
+        result = CliRunner().invoke(
+            main, ["call", "--with", "kimi", "--brief-file", str(brief)]
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "hello back" in result.output
+    assert (
+        route.calls.last.request.content.decode("utf-8").count(
+            "delegation brief from file"
+        )
+        == 1
+    )
 
 
 def test_call_kimi_happy_path(monkeypatch):

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -421,6 +421,53 @@ def test_exec_task_file_dash_reads_stdin(mocker):
     assert exec_mock.call_args.args[0] == "do the thing from stdin"
 
 
+def test_exec_brief_file_reads_file(mocker, tmp_path):
+    _stub_all_configured(mocker, {"codex"})
+    brief = tmp_path / "brief.md"
+    brief.write_text(
+        "# Goal\nRun the delegated change.\n\n# Context\nUse the repository files.",
+        encoding="utf-8",
+    )
+    exec_mock = mocker.patch.object(
+        CodexProvider, "exec", return_value=_fake_response("codex")
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["exec", "--with", "codex", "--brief-file", str(brief)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert exec_mock.call_args.args[0].startswith("# Goal")
+
+
+def test_exec_short_brief_warns_by_default(mocker):
+    _stub_all_configured(mocker, {"codex"})
+    mocker.patch.object(CodexProvider, "exec", return_value=_fake_response("codex"))
+
+    result = CliRunner().invoke(
+        main,
+        ["exec", "--with", "codex", "--brief", "do it"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "brief is short" in result.stderr
+    assert "--brief-file" in result.stderr
+
+
+def test_exec_allow_short_brief_suppresses_warning(mocker):
+    _stub_all_configured(mocker, {"codex"})
+    mocker.patch.object(CodexProvider, "exec", return_value=_fake_response("codex"))
+
+    result = CliRunner().invoke(
+        main,
+        ["exec", "--with", "codex", "--brief", "do it", "--allow-short-brief"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "brief is short" not in result.stderr
+
+
 def test_exec_rejects_task_and_task_file_together(mocker):
     _stub_all_configured(mocker, {"codex"})
 
@@ -430,7 +477,21 @@ def test_exec_rejects_task_and_task_file_together(mocker):
     )
 
     assert result.exit_code == 2
-    assert "exactly one of --task, --task-file, or stdin" in result.output
+    assert "exactly one of --brief, --brief-file, --task, --task-file, or stdin" in (
+        result.output
+    )
+
+
+def test_exec_rejects_task_and_brief_together(mocker):
+    _stub_all_configured(mocker, {"codex"})
+
+    result = CliRunner().invoke(
+        main,
+        ["exec", "--with", "codex", "--task", "hi", "--brief", "better brief"],
+    )
+
+    assert result.exit_code == 2
+    assert "got --task, --brief" in result.output
 
 
 def test_exec_missing_task_file_errors(mocker, tmp_path):


### PR DESCRIPTION
## Summary

Adds explicit delegation brief inputs to reduce context loss when Claude, Codex, and other agents call Conductor.

## Changes

- Adds `--brief` and `--brief-file` to `conductor call` and `conductor exec`.
- Keeps `--task` and `--task-file` as compatibility aliases.
- Warns on short `exec` briefs unless `--allow-short-brief` is passed.
- Updates managed agent templates and docs to state that Conductor does not inherit caller conversation context and to prefer structured `--brief-file` handoffs.
- Adds regression coverage for brief-file input, ambiguous source rejection, and short-brief warnings.

## Validation

- `uv run ruff check src/conductor/cli.py src/conductor/_agent_templates.py src/conductor/providers/shell.py tests/test_cli.py tests/test_cli_v02.py`
- `uv run pytest tests/test_cli.py tests/test_cli_v02.py tests/test_agent_template_drift.py`
- `uv run pytest` (630 passed, 15 skipped)