### PR TITLE
docs(plans): adopt conductor plans from autumn-garage

### DIFF
--- a/.cortex/plans/conductor-bootstrap.md
+++ b/.cortex/plans/conductor-bootstrap.md
@@ -1,0 +1,248 @@
+---
+Status: active
+Written: 2026-04-20
+Author: human
+Goal-hash: c0n8d1c70
+Updated-by:
+  - 2026-04-20T00:00 human (created; v0.1 bootstrap plan for Conductor — the fourth garage peer)
+Cites: doctrine/0004-conductor-as-fourth-peer, doctrine/0003-llm-providers-compose-by-contract, doctrine/0002-interactive-by-default, doctrine/0001-why-autumn-garage-exists, journal/2026-04-20-litellm-evaluated-rejected, journal/2026-04-20-conductor-decision, plans/llm-provider-additions, plans/sentinel-codex-identifier-rename, plans/local-llm-provider-alignment, integration/providers.md, https://platform.kimi.ai/docs/api/quickstart.md
+---
+
+# Conductor v0.1 — bootstrap the fourth garage peer with Kimi as first integration
+
+> Build Conductor: a small Python CLI that owns LLM provider adapters and exposes "pick an LLM, give it a job" with manual + auto modes. Ship v0.1 with five providers (claude, codex, gemini, ollama, kimi). Kimi is the v0.1 integration test case — the first provider that requires Conductor to handle an API key directly. Once v0.1 lands, Sentinel and Touchstone migrate from per-tool adapters to `conductor call` shell-outs in subsequent plans.
+
+## Why (grounding)
+
+Per Doctrine 0004 (today), the garage gains a fourth peer to consolidate provider adapters and the manual/auto routing surface. Three open plans (`llm-provider-additions`, `sentinel-codex-identifier-rename`, `local-llm-provider-alignment`) collapse into Conductor's v0.1 scope.
+
+Kimi is chosen as the v0.1 integration test case (instead of starting with the existing CLI-shellout providers) because it forces the hard cases up front:
+
+1. It's the first API-key-touching adapter — proves the auth pattern works cleanly.
+2. It's OpenAI-compatible HTTP — proves the httpx-based adapter shape (vs the shell-out adapter shape) works.
+3. The earlier research surfaced specific Moonshot quirks (temperature clamp, `tool_choice="required"` removal, streaming `usage`, reasoning_content preservation) that LiteLLM gets wrong. Implementing them ourselves means handling them correctly from day one.
+4. It's net-new functionality — no migration risk for existing Sentinel/Touchstone users; ship Conductor without breaking either.
+
+Build order within v0.1: scaffold + auto router + Kimi (httpx) FIRST, then claude/codex/gemini (shell-out) and ollama (httpx) AFTER the Kimi smoke test passes. This proves the design on the harder shape before backfilling the easier ones.
+
+Grounds-in: `.cortex/doctrine/0004-conductor-as-fourth-peer`.
+
+## Approach
+
+**Repo and structure.** New repo `autumngarage/conductor`. Bootstrap via Touchstone (`touchstone new conductor --type python`). Standard layout:
+
+```
+conductor/
+├── pyproject.toml
+├── README.md
+├── CLAUDE.md
+├── AGENTS.md
+├── .cortex/                      # per-Doctrine-0001 single-tool decisions live here
+├── src/conductor/
+│   ├── __init__.py
+│   ├── cli.py                    # argparse / typer; commands: call, list, smoke, init, doctor
+│   ├── config.py                 # ~/.config/conductor/config.toml schema
+│   ├── router.py                 # auto-mode rule-based router
+│   ├── providers/
+│   │   ├── __init__.py
+│   │   ├── interface.py          # Provider base class — call(task, model?) -> Response
+│   │   ├── kimi.py               # httpx, MOONSHOT_API_KEY, OpenAI-compatible
+│   │   ├── claude.py             # subprocess: claude -p
+│   │   ├── codex.py              # subprocess: codex exec
+│   │   ├── gemini.py             # subprocess: gemini -p
+│   │   └── ollama.py             # httpx, http://localhost:11434/api/chat
+│   └── wizard.py                 # init wizard (Doctrine 0002)
+├── tests/
+│   ├── test_cli.py
+│   ├── test_router.py
+│   ├── test_providers/
+│   │   ├── test_kimi.py          # mocked httpx
+│   │   ├── test_claude.py        # mocked subprocess
+│   │   └── ...
+│   └── test_smoke.py             # integration tests gated on env vars
+└── scripts/
+```
+
+**CLI shape (v0.1):**
+
+```bash
+# Manual
+conductor call --with kimi --task "summarize this README" < README.md
+conductor call --with codex --task "review this diff" --json
+
+# Auto
+conductor call --auto --task "summarize this README" --tags long-context,cheap < README.md
+conductor call --auto --task "review this diff" --tags code-review
+
+# Discovery
+conductor list                    # tabular: provider | configured? | smoke-passed? | default-model
+conductor list --json
+conductor smoke kimi              # runs the smoke test from integration/providers.md
+conductor doctor                  # what's installed, what env vars set, what missing
+
+# Setup
+conductor init                    # interactive wizard, Doctrine 0002 compliance
+```
+
+**Auto-mode router (v0.1, rule-based):**
+
+Each provider declares capability tags in its module: `kimi.tags = ["long-context", "cheap", "tool-use", "vision"]`. Each call carries task tags via `--tags a,b,c`. The router scores providers as `len(set(provider.tags) & set(task.tags))` and picks the highest scorer that's `configured == True` and `smoke-passed == True`. Ties broken by a configured priority list in `~/.config/conductor/config.toml`. Document the rule clearly in the docstring; don't pretend it's smart.
+
+**Provider interface:**
+
+```python
+# src/conductor/providers/interface.py
+from dataclasses import dataclass
+from typing import Optional, Protocol
+
+@dataclass
+class CallResponse:
+    text: str
+    provider: str
+    model: str
+    usage: dict           # {"input_tokens": N, "output_tokens": N, "cached_tokens": N}
+    duration_ms: int
+    cost_usd: Optional[float]   # None if pricing unknown
+    raw: dict             # full upstream response for debugging
+
+class Provider(Protocol):
+    name: str             # canonical identifier (claude, codex, kimi, ...)
+    tags: list[str]       # capability tags for auto-mode
+    default_model: str
+
+    def configured(self) -> tuple[bool, Optional[str]]:
+        """Return (is_configured, reason_if_not). Checks env vars / CLI presence."""
+    def smoke(self) -> tuple[bool, Optional[str]]:
+        """Run the provider's smoke test. Cheap call to /v1/models or equivalent."""
+    def call(self, task: str, model: Optional[str] = None) -> CallResponse:
+        """Make the actual call. Returns response or raises."""
+```
+
+**Kimi adapter (the v0.1 integration test):**
+
+- httpx-based, OpenAI-compatible. Endpoint: `https://api.moonshot.ai/v1/chat/completions`.
+- Reads `MOONSHOT_API_KEY` from env. No fallback to `OPENAI_API_KEY` (the research flagged that as a footgun).
+- Default model `kimi-k2.6`. Allow override via `--model`.
+- Handles the documented Moonshot quirks: temperature clamped to [0,1], no `tool_choice="required"`, streaming `usage` requires `stream_options={"include_usage": true}` (deferred — v0.1 is non-streaming).
+- For the multi-turn tool-call path: not in v0.1 scope (single-turn `chat.completions` only). Document that future tool-use support must echo `reasoning_content` back per LiteLLM #21672.
+- Smoke test: `GET https://api.moonshot.ai/v1/models` with auth header. Verify 200 + JSON.
+- Capability tags: `["long-context", "cheap", "tool-use", "vision"]`.
+
+**Setup UX (Doctrine 0002 compliance):**
+
+`conductor init` prompts:
+1. Which providers to configure now? (multi-select from claude, codex, gemini, ollama, kimi)
+2. For each selected: prompt for env var if not present; offer to write to `~/.zshrc` or print export line; run smoke test; print result.
+3. Auto-mode default tags? (skip in v0.1 — defer to user editing `~/.config/conductor/config.toml`)
+4. Print equivalent flag-form at end.
+5. Save `~/.config/conductor/config.toml` with the chosen defaults.
+
+**Distribution:**
+
+- Brew tap `autumngarage/homebrew-conductor`. Formula points at GitHub Releases.
+- Release flow modeled on Sentinel's (since both are Python CLIs).
+- v0.1.0 tagged when all Success Criteria below pass.
+
+## Success Criteria
+
+This plan is done when all of the following hold:
+
+1. **Repo exists.** `autumngarage/conductor` exists on GitHub. Bootstrapped via `touchstone new conductor --type python`. Brew tap exists.
+2. **CLI installs and runs.** `brew install autumngarage/conductor/conductor` works on macOS. `conductor --version` reports `v0.1.0`. `conductor --help` shows all commands documented.
+3. **Kimi adapter works end-to-end.** With `MOONSHOT_API_KEY` set: `conductor call --with kimi --task "What is 2+2?"` returns a response from `kimi-k2.6` on stdout. `conductor smoke kimi` reports OK. `conductor list` shows kimi as configured.
+4. **All five providers implemented.** claude, codex, gemini, ollama, kimi each have an adapter. Each has a smoke test. Each handles the "not configured" case gracefully (informative error, no traceback).
+5. **Auto-mode picks correctly.** `conductor call --auto --task "..." --tags long-context,cheap` picks kimi (or ollama if kimi not configured). `--tags code-review` picks codex (or claude). The router's logic is documented and tested.
+6. **`conductor init` wizard works.** Fresh user with no config can run `conductor init`, configure at least one provider, and successfully run `conductor call` against it. Doctrine 0002 compliance: TTY-detected, `--yes` flag, prints flag-form at end, reversible on Ctrl-C.
+7. **`conductor doctor` is useful.** Run on a partially-configured system, output lists every provider with: installed (yes/no), env var set (yes/no/with-name), smoke test (passed/failed/not-run), default model. Includes installation hints for missing pieces.
+8. **JSON output is stable.** `conductor call --json` returns the `CallResponse` shape documented in this plan. `conductor list --json` returns a list of provider records. Schema documented in README.
+9. **Tests pass.** `pytest` green. Includes: mocked httpx tests for kimi/ollama; mocked subprocess tests for claude/codex/gemini; router unit tests; CLI integration tests (no network); a smoke-test suite gated on env vars (only runs when `RUN_LIVE_SMOKE=1` and the relevant `*_API_KEY` is set).
+10. **Documentation.** README explains: what Conductor is (one paragraph), the manual/auto mode distinction, every command with one example, how to add a provider (for future contributors), and how Sentinel/Touchstone consume it (forward references — the integration plans land separately).
+11. **autumn-garage updated.** `integration/providers.md` notes that Conductor is now the canonical source for provider identifiers + capability tags. State.md reflects Conductor's existence.
+12. **Three sibling plans annotated.** `plans/llm-provider-additions.md`, `plans/sentinel-codex-identifier-rename.md`, and `plans/local-llm-provider-alignment.md` each get a status note: "Superseded by Conductor v0.1 — see plans/conductor-bootstrap.md."
+
+## Work items
+
+### Phase 1 — Repo + scaffolding
+
+- [ ] `touchstone new conductor --type python` — scaffold the repo locally.
+- [ ] Create the GitHub repo `autumngarage/conductor` (private or public — decide with user).
+- [ ] Initial push: scaffolding + `pyproject.toml` + `README.md` placeholder + `CLAUDE.md` (matching the trio's CLAUDE.md style) + `AGENTS.md` + `.cortex/` initialized via `cortex init`.
+- [ ] Set up brew tap `autumngarage/homebrew-conductor` (model on `homebrew-sentinel`).
+- [ ] CI: GitHub Actions for pytest on macOS + Linux.
+
+### Phase 2 — Kimi adapter (the integration test)
+
+- [ ] `src/conductor/providers/interface.py` — Provider protocol, CallResponse dataclass.
+- [ ] `src/conductor/providers/kimi.py` — httpx implementation, MOONSHOT_API_KEY auth, default model `kimi-k2.6`, smoke test, capability tags. Handles temperature clamping; no streaming in v0.1.
+- [ ] `src/conductor/cli.py` — `conductor call --with kimi --task "..."` end-to-end. argparse or typer.
+- [ ] `tests/test_providers/test_kimi.py` — mocked httpx, covers: success case, missing env var, smoke test, model override.
+- [ ] Manual end-to-end: with real `MOONSHOT_API_KEY`, run `conductor call --with kimi --task "ping"` and observe a real response. Journal the result.
+
+### Phase 3 — Remaining adapters
+
+- [ ] `claude.py` — shell out to `claude -p`. Mirror Sentinel's existing `claude.py` pattern.
+- [ ] `codex.py` — shell out to `codex exec`. (Note: NOT `openai.py` — Conductor uses canonical identifier `codex`. Doctrine 0003.)
+- [ ] `gemini.py` — shell out to `gemini -p`.
+- [ ] `ollama.py` — httpx against `http://localhost:11434/api/chat`. Allow base URL override via `OLLAMA_BASE_URL` env var.
+- [ ] Tests for each (mocked subprocess / httpx).
+- [ ] `conductor list` and `conductor doctor` show all five.
+
+### Phase 4 — Auto-mode router
+
+- [ ] `src/conductor/router.py` — rule-based router as described in Approach.
+- [ ] Each provider module declares its `tags` list.
+- [ ] `conductor call --auto --tags a,b,c --task "..."` works end-to-end.
+- [ ] `tests/test_router.py` — covers: tag matching, configured filter, smoke-passed filter, tie-break, no-match error.
+- [ ] Document the rule in `conductor --help` output AND the README.
+
+### Phase 5 — Setup wizard + smoke commands
+
+- [ ] `src/conductor/wizard.py` — interactive `conductor init` per Doctrine 0002.
+- [ ] `conductor smoke <id>` and `conductor smoke --all`.
+- [ ] `conductor doctor` rich output.
+- [ ] `~/.config/conductor/config.toml` schema + parser.
+- [ ] `tests/test_init_scenarios.py` — covers TTY/non-TTY, `--yes`, partial config, Ctrl-C cleanup.
+
+### Phase 6 — Distribution + docs
+
+- [ ] README: usage, examples, provider matrix, integration notes for Sentinel/Touchstone consumers.
+- [ ] CHANGELOG entry for v0.1.0.
+- [ ] Tag and release v0.1.0. Update brew formula. Verify `brew install` works.
+- [ ] Smoke-test the brew install on a clean macOS user.
+
+### Phase 7 — autumn-garage updates
+
+- [ ] Update `autumn-garage/README.md` install block to include Conductor.
+- [ ] Update `autumn-garage/.cortex/state.md` to reflect Conductor v0.1 shipping.
+- [ ] Update `integration/providers.md` to note Conductor is now the source of truth for identifiers; bump "Last update" date.
+- [ ] Annotate the three sibling plans (`llm-provider-additions`, `sentinel-codex-identifier-rename`, `local-llm-provider-alignment`) with "Superseded by Conductor v0.1" status notes.
+- [ ] Journal entry: Conductor v0.1 shipped, with link to the GitHub release and notes on what was easier/harder than expected.
+
+## Follow-ups (deferred)
+
+- **Sentinel migration plan.** Once Conductor v0.1 is live, open `plans/sentinel-conductor-migration.md` — replace `src/sentinel/providers/{claude,openai,gemini,local}.py` with a thin shell-out to `conductor call`. Default to `--auto`; user overrides per-role go to `--with <id>`. This is where the codex/openai rename and the local/ollama alignment actually land — when Sentinel stops implementing those adapters at all.
+- **Touchstone migration plan.** Once Sentinel migration is proven, open `plans/touchstone-conductor-migration.md` — extend the reviewer cascade to support `auto` as a valid entry that resolves via `conductor call --auto`. Existing `claude`/`codex`/`gemini` entries can also migrate to going through Conductor for consistency.
+- **Cortex Phase C synthesis** picks up Conductor as the synthesis backend choice instead of shelling directly to `claude -p`. Resolves to a future `plans/cortex-phase-c-conductor-wiring.md`.
+- **Streaming support in Conductor.** Deferred from v0.1. Useful for long reviews, long synthesis. Resolves to a future `plans/conductor-streaming.md` if there's pull from the consumers.
+- **LLM-based meta-routing for `--auto`.** Replace the rule-based router with a small LLM call that picks the provider given the task description. Higher quality, more expensive per call. Only worth it if rule-based proves insufficient. Resolves to a future plan.
+- **Cost tracking and budgets.** Conductor surfaces `usage` and (when known) `cost_usd` per call. Aggregating into a budget enforcement layer is its own concern; defer until a consumer asks for it.
+- **Tool-use (function-calling) support.** v0.1 is single-turn chat completions only. Multi-turn tool calling adds complexity (especially for Kimi reasoning models — reasoning_content preservation per LiteLLM #21672). Resolves to a future plan when a consumer needs it.
+
+## Known limitations at exit (v0.1)
+
+- **Single-turn only.** No tool-use, no streaming, no multi-call agents. Conductor v0.1 is "send a prompt, get a response."
+- **Auto-mode is naive.** Tag matching with simple set intersection. Will pick wrong sometimes. The remedy is to update tags or override with `--with`, not to make the router smarter in v0.1.
+- **No retries.** A failed call returns the error to the caller. Conductor doesn't try a fallback provider. Sentinel's role-router does this today; if Conductor needs it, it lands in v0.2.
+- **One config file location.** `~/.config/conductor/config.toml`. No per-project config in v0.1. Add later if needed.
+- **No telemetry, no usage reporting, no cost dashboards.** Output JSON includes `usage` per call; aggregation is the consumer's problem.
+- **Brew install only on macOS.** Linux supported via pip. Windows is not supported.
+
+## Meta — why this plan is in autumn-garage
+
+Conductor itself will have its own `.cortex/` for single-tool decisions once it's bootstrapped. This plan lives in autumn-garage because:
+
+1. The decision to *create* Conductor is cross-tool (it changes the Sentinel + Touchstone integration story). That's coordination, not single-tool work.
+2. Kimi-as-first-integration-test affects the autumn-garage Kimi rollout plan, which lives here.
+3. The three sibling plans being superseded all live here.
+
+Once Conductor v0.1 is shipped and its own `.cortex/` is healthy, future Conductor-internal decisions move there. Future Sentinel-and-Touchstone-and-Conductor coordination decisions stay here.

--- a/.cortex/plans/conductor-http-tool-use.md
+++ b/.cortex/plans/conductor-http-tool-use.md
@@ -1,0 +1,168 @@
+---
+Status: shipped
+Written: 2026-04-23
+Author: claude-code (Henry Modisett, @henry@perplexity.ai)
+Goal-hash: cdr3ttu1
+Updated-by:
+  - 2026-04-23T21:50 claude-code (created as Stage 3 follow-on to the Touchstone × Conductor integration plan)
+  - 2026-04-23T22:15 claude-code (Slice A/B/C all merged — conductor v0.3.0, v0.3.1, v0.3.2 cut; ASCII hero banner landed alongside)
+Cites: plans/touchstone-conductor-integration, journal/2026-04-21-stage-1-2-delivered, doctrine/0003-llm-providers-compose-by-contract, doctrine/0004-conductor-as-fourth-peer
+---
+
+# Conductor v0.3 — HTTP tool-use loop
+
+> Teach conductor's HTTP providers (kimi first, ollama next) to drive tool-using agent sessions. Today `kimi.exec(tools=...)` raises `UnsupportedCapability` — the router filters kimi/ollama out of any exec request with a non-empty tool set. This closes that gap.
+
+## Status: shipped (2026-04-23)
+
+All three slices merged same day. Tags cut for v0.3.0 / v0.3.1 / v0.3.2; homebrew-conductor bumped to v0.3.1 (Slice C bump pending Slice C PR merge). ASCII hero banner shipped alongside as a cross-slice improvement.
+
+- Slice A → [conductor#7](https://github.com/autumngarage/conductor/pull/7) (v0.3.0)
+- Slice B → [conductor#8](https://github.com/autumngarage/conductor/pull/8) (v0.3.1)
+- Slice C → [conductor#10](https://github.com/autumngarage/conductor/pull/10) (v0.3.2, CI pending)
+- Banner  → [conductor#9](https://github.com/autumngarage/conductor/pull/9) (CI pending)
+
+Final test count: 282 (was 203 pre-Stage-3). Ruff clean throughout.
+
+## Why (grounding)
+
+Stage 1+2 of the integration plan shipped `conductor exec` for shell-out providers (claude/codex/gemini). HTTP providers (kimi, ollama) still can't participate in `exec` with tools — shell-out CLIs own their own tool-use loop internally, but HTTP providers need conductor to orchestrate the loop ourselves.
+
+Three consumers block on this:
+
+- **Sentinel migration (Stage 5)** — the coder role is multi-turn with tool use. Can't migrate to `conductor exec` until kimi/ollama can drive that loop, since sentinel supports them as coder backends.
+- **Touchstone cheap-path reviews** — `[review.routing].small_with = "ollama"` + `mode = "review-only"` wants read-only tools. Today that filter collapses to no-tools + tag-only routing, so the router filters ollama out and small diffs fall through to hosted.
+- **Direct conductor users** — `conductor exec --with kimi --tools Read,Grep ...` gets UnsupportedCapability with no escape hatch. Documented limitation, but a real one.
+
+Grounds-in Doctrine 0003 (provider-contract composition): the `exec` interface is meant to be uniform across provider shapes. Today it isn't — shell-outs are exec-capable, HTTP ones aren't. Fixing that is load-bearing for the "every provider is a peer" property.
+
+## End state — what HTTP tool-use looks like
+
+### 1. kimi.exec drives a full tool-use loop
+
+```python
+# Internal flow inside KimiProvider.exec(task, tools={"Read","Grep"}, sandbox="read-only"):
+# 1. Build messages = [{role: user, content: task}]
+# 2. Build tools param from Conductor's portable Tool registry
+# 3. POST chat/completions with tools; parse response
+# 4. If assistant.tool_calls: execute each tool against the sandbox,
+#    append assistant + tool results to messages, GOTO 3
+# 5. Else (text-only response): return CallResponse(text=..., ...)
+# 6. Max iterations (default 10, configurable via --max-iterations flag or env)
+```
+
+Same surface as `conductor exec --auto --tools Read,Grep --sandbox read-only`. The loop runs inside kimi.exec. No changes to the CLI surface.
+
+### 2. Portable Tool registry
+
+A new `src/conductor/tools/` module owns the Tool protocol:
+
+```python
+class Tool(Protocol):
+    name: str           # "Read" | "Grep" | "Glob" | "Edit" | "Write" | "Bash"
+    description: str    # For the model's tools param
+    parameters_schema: dict  # JSON Schema for tool input
+    def execute(self, params: dict, *, cwd: Path, sandbox: str) -> str: ...
+```
+
+Each built-in tool gets an implementation. The sandbox arg is enforced at the tool level — `Edit.execute` refuses when sandbox is `read-only`, `Bash.execute` refuses when sandbox is `none`, etc. Path validation on every filesystem tool: no absolute paths outside `cwd`, no `..` that escapes, no symlinks that escape.
+
+### 3. Sandbox enforcement (the hard part)
+
+- **read-only** — Read/Grep/Glob work; Edit/Write/Bash raise.
+- **workspace-write** — Read/Grep/Glob/Edit/Write work, all scoped to `cwd` subtree. Bash works but runs with the cwd constrained; no env scrubbing in v1 (user's env inherits).
+- **none** — any non-empty tool set is a routing contradiction; router should never reach exec in this state.
+
+**In-process vs. subprocess sandbox.** A tool-use loop running in the conductor process means a malicious model could try to read env vars, exfiltrate secrets, etc. A subprocess sandbox (spawn child with ulimit + path restrictions) is safer but slower. **v1 does in-process with path validation**; `--sandbox strict` (subprocess) is a follow-up once we have a real threat model. Documented as a known limitation.
+
+### 4. Router updates
+
+- Kimi's `supported_tools` gains `{Read, Grep, Glob, Edit, Write, Bash}` (currently empty).
+- Kimi's `supported_sandboxes` gains `{read-only, workspace-write}` (currently `{none}`).
+- Ollama follows in a later slice.
+- Router filter logic is unchanged — the capability declarations just stop forcing kimi/ollama out of tool-using requests.
+
+## Sequencing — three slices
+
+Each slice is shippable in isolation, each is ~1 session of focused work.
+
+### Slice A — kimi read-only tools, no sandbox (this session, v0.3.0-alpha)
+
+- `src/conductor/tools/` module with Tool protocol, Read/Grep/Glob
+- Path validation: refuse absolute paths outside cwd, refuse symlink-escape
+- `KimiProvider.exec` runs the tool-use loop for read-only tool sets
+- `supported_tools = {Read, Grep, Glob}`, `supported_sandboxes = {read-only}`
+- Max iterations hardcoded to 10 in v1
+- Tests: mock httpx, assert tool loop; unit-test each Tool; path-validation tests; circuit-breaker test
+- Ships as v0.3.0 — first slice is a real release, not -alpha, because the scope is complete for what it promises
+
+### Slice B — kimi writes + ollama + sandbox semantics (~1 session)
+
+- Add Edit/Write/Bash to Tool registry
+- Path-constrained writes; Bash scoped to cwd
+- `supported_sandboxes = {read-only, workspace-write}` for both kimi and ollama
+- Ollama gets the same tool-use loop (its API is similar enough — `/api/chat` with tools, `/api/generate` for text-only)
+- v0.3.1
+
+### Slice C — subprocess sandbox + context-budget management (~1 session)
+
+- `--sandbox strict` spawns a subprocess with ulimit + path allowlist
+- Context-window tracking: abort loop if token budget exceeds model's context minus safety margin
+- Cost accounting for each tool round trip
+- v0.3.2
+
+### Out of scope (explicitly)
+
+- **Streaming tool-use** — each loop turn is non-streaming. Streaming is a separate feature (Stage 4) and adds complexity orthogonal to tool-use.
+- **Parallel tool calls** — OpenAI's schema allows multiple tool_calls in one response. We serialize them; the model rarely emits >3 in one turn and serial execution is simpler. Parallel is a future optimization.
+- **Cross-provider tool semantics parity** — claude's Bash sandbox is finer-grained than codex's `workspace-write`. Conductor's unified tool set is the lowest common denominator. Documented in `conductor doctor --explain-tools` (future command).
+
+## Risks
+
+### R1 — Path-validation gaps
+
+An in-process sandbox is only as safe as its path validation. Things that have bitten other tools:
+
+- `/tmp/../etc/passwd` — trivial; handle via `os.path.realpath` after joining
+- Symlinks inside cwd pointing outside — check `realpath` of every opened file, not just the join
+- Case-insensitive filesystems on macOS — path `A/B` might resolve to `a/b`; use `realpath` consistently
+- Windows separators if run on Windows (not supported today; explicitly out of scope)
+
+The path-validation helper is the one thing in this plan that *must* be correct. Unit tests the adversarial cases.
+
+### R2 — Model-schema drift
+
+OpenAI's function-calling schema has churned (functions → tools, different arg shapes). Moonshot/Kimi via Cloudflare mostly tracks it, but some quirks:
+
+- Moonshot's spec doesn't support `tool_choice = "required"` (documented in kimi.py header)
+- Multi-turn tool calls with thinking variants need `reasoning_content` echoed back on subsequent turns
+
+Slice A's test fixtures should include at least one Moonshot-style response shape, not just OpenAI reference.
+
+### R3 — Infinite / runaway loops
+
+A misbehaving model can request tool call → look at output → request same tool call again forever. Max iterations (10) is the circuit breaker. If we hit the cap, return the last assistant message as CallResponse.text with a note appended.
+
+### R4 — Cost surprise
+
+A 10-iteration tool-use session at max effort on claude-level tokens can cost ~$1. That's not obvious to a user accustomed to single-turn call(). The route log should include per-iteration token counts, not just final totals. `max_cost_usd` gate lands in Stage 4 but is already-relevant.
+
+## Success criteria
+
+1. **`conductor exec --with kimi --tools Read,Grep --sandbox read-only --task "summarize this repo"` works** on a real kimi-authed setup. 5+ tool calls executed, final text response returned.
+2. **Router auto-routes to kimi when only kimi has matching tags + read-only tool support.** Previously forced hosted-only fallback.
+3. **Path traversal blocked** — `conductor exec --with kimi --tools Read` asked to read `../../../etc/passwd` returns a tool error, not the file contents. Unit test on the validator.
+4. **Max-iteration circuit breaker fires** on a mocked model that infinitely requests the same tool. Deterministic test.
+5. **Sentinel migration plan unblocked** — a follow-up sentinel plan can reference this and say "ready." The actual migration is its own session.
+
+## Effort estimate
+
+- **Slice A (this session):** ~4-6 hours. Tools module + kimi loop + tests. Ships as v0.3.0.
+- **Slice B:** ~4-6 hours. Writes + ollama + sandbox semantics. v0.3.1.
+- **Slice C:** ~4-8 hours. Subprocess sandbox + budget tracking. v0.3.2.
+
+Total: ~2-3 sessions, which is why Stage 3 was scoped at 2-4 weeks in the original integration plan (that estimate assumed interruption-heavy cadence; focused sessions can be tighter).
+
+## Relationship to the master integration plan
+
+This plan implements Stage 3 of `plans/touchstone-conductor-integration`. Stage 5 (Sentinel migration) unblocks once Slice B ships — Sentinel's coder needs writes + sandbox, so read-only kimi isn't enough. Stage 4 (streaming + precise cost + budgets) is orthogonal and can ship in parallel.

--- a/.cortex/plans/llm-provider-additions.md
+++ b/.cortex/plans/llm-provider-additions.md
@@ -1,0 +1,124 @@
+---
+Status: superseded
+Written: 2026-04-20
+Author: human
+Goal-hash: a4c1e8b2
+Updated-by:
+  - 2026-04-20T00:00 human (created; first application of Doctrine 0003 — Kimi rollout)
+  - 2026-04-20T00:00 human (superseded by plans/conductor-bootstrap; Kimi becomes Conductor v0.1's integration test rather than two parallel per-tool PRs)
+Cites: doctrine/0003-llm-providers-compose-by-contract, doctrine/0004-conductor-as-fourth-peer, doctrine/0002-interactive-by-default, plans/conductor-bootstrap, journal/2026-04-20-conductor-decision, https://platform.kimi.ai/docs/api/quickstart.md, https://platform.kimi.ai/docs/models.md
+---
+
+> **SUPERSEDED 2026-04-20 by [`plans/conductor-bootstrap.md`](conductor-bootstrap.md).** Adding Kimi via two parallel per-tool PRs (Touchstone hook + Sentinel `moonshot.py`) was the original plan. Same-day refinement extracted Conductor as a fourth garage peer that owns provider adapters; Kimi is now Conductor v0.1's first integration test instead. The Doctrine 0003 contract still applies (`integration/providers.md` remains the canonical reference table). Per-tool migration to Conductor — replacing today's adapters with `conductor call` shell-outs — happens in separate Sentinel/Touchstone migration plans after Conductor v0.1 ships. Reasoning: see `journal/2026-04-20-conductor-decision.md`. The Kimi research, model-selection notes, and Moonshot-specific gotchas in this plan remain useful as input to Conductor's Kimi adapter — read it for context, not for action.
+
+# Adding LLM providers across the trio — Kimi first
+
+> Apply Doctrine 0003 (LLM providers compose by shared contract, not shared code) to add Kimi (Moonshot AI) as a callable provider in Touchstone (reviewer cascade) and Sentinel (role router). Establish the providers reference table at `integration/providers.md` so this rollout — and every future provider addition — has a single shared source of truth. Cortex Phase C inherits the menu when synthesis ships.
+
+## Why (grounding)
+
+Two tools want the same provider for their own reasons:
+
+- **Touchstone** wants reviewer choice. Today the cascade is hardcoded to `codex` (with `claude` and `gemini` configurable). Kimi is cheap (~$0.60/M in, $2.50/M out — 5–6× cheaper than Sonnet) and supports tool calling at 256k context. A reasonable choice for cost-sensitive review.
+- **Sentinel** wants role-aware routing. Monitor (high-frequency) and Researcher (long-context bulk) roles benefit from Kimi's pricing and context. Reviewer or Coder may stay on Claude/Codex.
+
+Without coordination, the two tools would diverge: different env var names, different default model IDs, different setup prompts, different smoke tests. Doctrine 0003 names the rule (per-tool implementation against a shared contract); this plan is the first application of that rule.
+
+Kimi's specifics (verified against `platform.kimi.ai/docs/api/quickstart.md`):
+
+- Base URL: `https://api.moonshot.ai/v1`
+- Auth: `Authorization: Bearer $MOONSHOT_API_KEY`
+- OpenAI SDK drop-in: `OpenAI(api_key=..., base_url="https://api.moonshot.ai/v1")`
+- Models worth defaulting to: `kimi-k2.6` (256k context, multimodal, tool calling). Alternatives: `kimi-k2-thinking` (reasoning, 300-step tool calling), `kimi-k2-turbo-preview` (faster, more expensive).
+- Official `kimi` CLI exists (`uv tool install --python 3.13 kimi-cli`) but is interactive-only — no `-p` / stdin / JSON output. **Not suitable for hook integration.** Both tools use the HTTP endpoint instead.
+
+Grounds-in: `.cortex/doctrine/0003-llm-providers-compose-by-contract`.
+
+## Approach
+
+**Step 1 — Reference table first.** Create `autumn-garage/integration/providers.md` (a new top-level integration directory in the coordination repo). Seed it with the current providers (claude, codex, openai, gemini, local) plus the new kimi entry. This document is the single source of truth that per-tool PRs reference.
+
+The table shape, one row per provider:
+
+| identifier | env var | endpoint shape | base URL | default model | smoke test |
+|---|---|---|---|---|---|
+| `kimi` | `MOONSHOT_API_KEY` | OpenAI-compatible HTTP | `https://api.moonshot.ai/v1` | `kimi-k2.6` | `curl -sf -H "Authorization: Bearer $MOONSHOT_API_KEY" https://api.moonshot.ai/v1/models` |
+| `claude` | `ANTHROPIC_API_KEY` | shell out to `claude -p` | — (CLI) | (per Claude defaults) | `claude -p "ping"` |
+| `codex` | `OPENAI_API_KEY` | shell out to `codex exec` | — (CLI) | (per Codex defaults) | `codex exec "ping"` |
+| `gemini` | `GEMINI_API_KEY` | shell out to `gemini -p` | — (CLI) | (per Gemini defaults) | `gemini -p "ping"` |
+| `local` | `LOCAL_LLM_BASE_URL`, `LOCAL_LLM_MODEL` | OpenAI-compatible HTTP (Ollama, LM Studio) | `$LOCAL_LLM_BASE_URL` | `$LOCAL_LLM_MODEL` | `curl -sf $LOCAL_LLM_BASE_URL/models` |
+
+The table is the contract instance. Per-tool implementations consult it; nothing else.
+
+**Step 2 — Touchstone PR.** Add `kimi` as a peer in the reviewer cascade (`hooks/codex-review.sh` and `.codex-review.toml` schema). Implementation calls the Moonshot HTTP endpoint via `curl` (matching how the OpenAI/openai-compatible path would work). Setup wizard inherits Doctrine 0002 — prompts for `MOONSHOT_API_KEY`, runs the smoke test, prints the equivalent flag form.
+
+**Step 3 — Sentinel PR.** Add `src/sentinel/providers/moonshot.py`. Likely shape: thin subclass of `openai.py` overriding `base_url` and the `MOONSHOT_API_KEY` env var read. Add `ProviderName.MOONSHOT = "moonshot"` to `config/schema.py`. Wire into the router. Update `sentinel init` wizard to offer Kimi as a provider choice for any role.
+
+**Step 4 — Dogfood in autumn-mail.** After both PRs ship, configure autumn-mail's `.sentinel/config.toml` to use Kimi for the Coder or Researcher role and run one `sentinel work --budget $5` cycle. Journal the result (cost, quality, any contract gaps surfaced).
+
+**Step 5 — Cortex Phase C absorption (deferred).** When Cortex ships `refresh-map` / `refresh-state`, the synthesis shell-out picks the provider from the same table. No new contract negotiation needed; this is the test of whether Doctrine 0003 actually scales to a third tool.
+
+## Success Criteria
+
+This plan is done when all of the following hold:
+
+1. `autumn-garage/integration/providers.md` exists with rows for claude, codex, openai, gemini, local, and kimi. Each row has all six fields populated.
+2. Touchstone PR shipped: `.codex-review.toml` accepts `"kimi"` in the reviewer list; the hook script invokes Moonshot's HTTP endpoint with `MOONSHOT_API_KEY`; review feedback round-trips end-to-end on a real diff.
+3. Touchstone setup wizard prompts for `MOONSHOT_API_KEY` when `kimi` is selected, runs the smoke test from the providers table verbatim, and prints the equivalent flag form.
+4. Sentinel PR shipped: `src/sentinel/providers/moonshot.py` exists; `ProviderName.MOONSHOT` registered; router resolves `provider = "moonshot"` to the new adapter; tests pass.
+5. Sentinel `init` wizard offers `moonshot` as a provider choice for any role with the same prompt shape used for other providers.
+6. One `sentinel work` cycle on autumn-mail with at least one role set to `moonshot` completes successfully and produces a `.cortex/journal/` entry per Protocol T1.6. Cost recorded in the cycle output.
+7. A journal entry in autumn-garage records the dogfood result (`2026-MM-DD-kimi-dogfood-cycle.md`), citing this plan, with verdict on whether Doctrine 0003's contract held up under real use.
+8. Both per-tool PRs reference Doctrine 0003 + this plan in their PR descriptions, and `integration/providers.md` is the single source of truth they pull from for env var names, default model, and smoke test (no duplicated values).
+
+## Work items
+
+### Coordination repo (autumn-garage)
+
+- [x] Create `autumn-garage/integration/providers.md` with the table above. (Shipped 2026-04-20 alongside this plan and Doctrine 0003.)
+- [ ] Update `state.md` to reflect the new workstream once first per-tool PR opens.
+- [ ] Open journal entry on dogfood completion (success criterion 7).
+- [ ] Open separate plan(s) for the two pre-existing drifts surfaced while writing the providers table (see Follow-ups). They block clean conformance with Doctrine 0003 but not the Kimi rollout itself.
+
+### Touchstone
+
+- [ ] `hooks/codex-review.sh`: add `kimi` branch in the reviewer-dispatch case statement; calls Moonshot HTTP via `curl` with the model from `integration/providers.md` as default.
+- [ ] `.codex-review.toml` schema: accept `"kimi"` in the `reviewers` array; document under example config.
+- [ ] Setup wizard (Doctrine 0002 compliance): prompt for `MOONSHOT_API_KEY`, run smoke test, print flag form.
+- [ ] README update: provider matrix gains a Kimi row.
+- [ ] PR description cites Doctrine 0003 + this plan + the providers reference table.
+
+### Sentinel
+
+- [ ] `src/sentinel/providers/moonshot.py`: new module, likely subclassing the openai-compatible base; reads `MOONSHOT_API_KEY`; default model `kimi-k2.6`.
+- [ ] `src/sentinel/config/schema.py`: add `MOONSHOT = "moonshot"` to `ProviderName` enum.
+- [ ] Router registration in `providers/router.py` (or wherever providers are registered today).
+- [ ] `sentinel init` wizard: include moonshot in provider choice list; prompt for env var; run smoke test (same one as Touchstone — verbatim from the providers table).
+- [ ] Tests: provider instantiation, basic chat call against a mocked endpoint, env var error handling.
+- [ ] README + provider docs update.
+- [ ] PR description cites Doctrine 0003 + this plan + the providers reference table.
+
+### Dogfood (autumn-mail)
+
+- [ ] After both PRs ship, configure `.sentinel/config.toml` with at least one role set to `provider = "moonshot"`.
+- [ ] Run `sentinel work --budget $5` and observe a full cycle.
+- [ ] Capture: cost, completion vs failure, any contract gaps.
+- [ ] Journal the result back in autumn-garage.
+
+## Follow-ups (deferred)
+
+- **Reconcile codex/openai identifier drift in Sentinel.** Sentinel currently labels the Codex provider `openai` (`src/sentinel/providers/openai.py`, class `OpenAIProvider`, `ProviderName.OPENAI`). Touchstone uses `codex` for the same thing. Doctrine 0003 §1 says identifiers match across tools. Fix: either rename Sentinel's identifier `openai` → `codex` (preferred — Touchstone shipped first and the identifier is more accurate), OR document the alias explicitly in `integration/providers.md` and accept it. If renaming, ship as a Sentinel-only PR with a backward-compat alias in config parsing for one minor version. Pre-existing drift, not blocking Kimi rollout — surface it now so the doctrine doesn't ship with a known unresolved violation.
+- **Align `local` invocation shape across tools.** Sentinel's `local.py` calls Ollama via HTTP (`httpx` against `:11434/api/chat`) with default model `qwen2.5-coder:14b`. Touchstone's reviewer cascade `local` entry expects a user-configured shell command (e.g., `ollama run YOUR_MODEL`) per `.codex-review.toml`. Both work today but a user moving between tools sees different config knobs for "the same" provider. Fix: pick one shape (HTTP is preferred — already works for any OpenAI-compatible local server), update the lagging tool, document in `integration/providers.md`. Pre-existing drift; resolve as a sibling workstream.
+- **Cortex Phase C provider integration.** When `refresh-map` / `refresh-state` ship, they pull from `integration/providers.md` for the synthesis backend choice. Verifies Doctrine 0003 scales to a third consumer without renegotiation. Resolves to a future `plans/cortex-phase-c-provider-wiring.md`.
+- **Additional providers behind the same pattern.** xAI Grok, DeepSeek, Mistral, Ollama-as-first-class-local — each is a row addition to `integration/providers.md` plus per-tool PRs. No new doctrine needed unless a provider breaks one of the contract's assumptions.
+- **Cost-aware default routing in Sentinel.** Once Kimi is in the menu, Sentinel could default Monitor/Researcher to Kimi based on cost-per-token if the user opts in. Resolves to a future Sentinel-only plan.
+
+## Known limitations at exit
+
+- **Reference table is hand-maintained.** Adding a provider means a manual edit to `integration/providers.md` before per-tool PRs can land cleanly. Acceptable because providers are added rarely. If this becomes a chokepoint, a small `garage providers list` CLI could read the table and lint per-tool configs against it.
+- **No retroactive enforcement.** Existing providers (claude, codex, gemini, local) were added before Doctrine 0003. They satisfy the contract de facto but weren't subject to it during their PR. If audit reveals divergence (e.g., one tool reads `OPENAI_API_KEY` from a different env var alias the other doesn't), it's a bug to fix, not a doctrine violation.
+- **Kimi's official CLI is interactive-only.** Both tools use the HTTP endpoint instead. If Moonshot ships a non-interactive CLI later (with `-p` / stdin / JSON), tools may migrate, but that's a contract revision, not a per-tool decision.
+
+## Meta — why this plan is in autumn-garage, not in touchstone or sentinel
+
+The same reasoning as `plans/sentinel-cortex-t16-integration.md`: a workstream that spans two or more tools is a coordination question. The implementation lands in the tool repos; the scope, contract, and success criteria live here. When an agent is dispatched to either tool's PR, that agent's brief points at this plan + Doctrine 0003 + `integration/providers.md`.

--- a/.cortex/plans/local-llm-provider-alignment.md
+++ b/.cortex/plans/local-llm-provider-alignment.md
@@ -1,0 +1,130 @@
+---
+Status: superseded
+Written: 2026-04-20
+Author: human
+Goal-hash: 3e9d51c8
+Updated-by:
+  - 2026-04-20T00:00 human (created; extracted from plans/llm-provider-additions follow-ups)
+  - 2026-04-20T00:00 human (superseded by plans/conductor-bootstrap; Conductor establishes canonical identifiers `ollama` (HTTP) and `local-command` (subprocess) — Option A from this plan — and consuming tools adopt them via shell-out)
+Cites: doctrine/0003-llm-providers-compose-by-contract, doctrine/0004-conductor-as-fourth-peer, plans/conductor-bootstrap, journal/2026-04-20-conductor-decision, integration/providers.md
+---
+
+> **SUPERSEDED 2026-04-20 by [`plans/conductor-bootstrap.md`](conductor-bootstrap.md).** This plan opened with three options (A: split into `ollama` + `local-command`; B: HTTP-only; C: subprocess-only) and asked the user to pick. The Conductor extraction picks **Option A** by construction — Conductor v0.1 ships `ollama` (httpx HTTP, default port `:11434`) as a first-class provider; the subprocess escape hatch can be added as `local-command` in a later Conductor release if a real consumer asks for it. The semantic gap between Touchstone's and Sentinel's current `local` implementations resolves when both tools migrate to `conductor call --with ollama`, at which point neither tool implements `local` directly. The architectural reasoning in this plan (Option A's tradeoffs, why splitting beats forced convergence) remains useful — read it for the rationale Conductor's choice rests on.
+
+# Align the `local` LLM provider semantics across Touchstone and Sentinel
+
+> The identifier `local` means different things in the two tools. Sentinel's `local` is **Ollama via HTTP** with a default model and a fixed endpoint. Touchstone's `local` is a **generic shell command escape hatch** — `command = "ollama run YOUR_MODEL"` or any user-supplied executable that takes a prompt on stdin. Doctrine 0003 says identifiers match across tools. The two semantics aren't reconcilable by tweaking config — one of them needs to be renamed, or both need to be split into two distinct rows in the providers table. **Investigate, decide, then ship in both repos.**
+
+## Why (grounding)
+
+Doctrine 0003 §1 says the same identifier is used in every tool's config. Today:
+
+- **Sentinel `local`** (`src/sentinel/providers/local.py`): hardcoded to `cli_command = "ollama"`, talks HTTP to `http://localhost:11434/api/chat`, default model `qwen2.5-coder:14b`. Tightly coupled to Ollama's endpoint shape. The provider's purpose is "run local LLMs via the Ollama daemon."
+- **Touchstone `local`** (per `hooks/codex-review.config.example.toml` lines 86–94): a generic `[review.local]` section with `command = "ollama run YOUR_MODEL"` and `auth_command = ""`. The hook pipes the review prompt to the configured `command` on stdin; whatever it returns is the review output. The purpose is "let users plug in any local LLM wrapper or custom script as a reviewer."
+
+These aren't two implementations of the same thing. They're two different abstractions sharing a name:
+
+- Sentinel's `local` = **opinionated Ollama HTTP client.**
+- Touchstone's `local` = **generic subprocess escape hatch.**
+
+A user who configures Sentinel for Ollama and then tries to configure Touchstone the same way encounters: different config keys (`provider` vs `command`), different mental models (HTTP endpoint vs shell command), different default behaviors (Ollama-specific defaults vs none). The drift is real and predates Doctrine 0003.
+
+This is the more interesting of the two surfaced drifts — unlike the codex/openai rename (purely cosmetic), this one is a real semantic gap that needs design work before fixing.
+
+Grounds-in: `.cortex/doctrine/0003-llm-providers-compose-by-contract`.
+
+## Approach
+
+**Phase 1 — Decide the right shape (this plan, before any code).**
+
+Three plausible end states; pick one, document the reasoning, then implement:
+
+**Option A — Two distinct identifiers: `ollama` (HTTP, opinionated) and `local-command` (subprocess, generic).**
+
+- Both tools support both identifiers. `ollama` is the "I run Ollama locally" path with a fixed HTTP shape and a default model; `local-command` is the "I have my own wrapper script" escape hatch.
+- Pros: each identifier has one meaning; users pick the one that matches their setup; the existing semantics are preserved, just renamed.
+- Cons: doubles the surface area in both tools (two new providers each); existing user configs need migration.
+
+**Option B — Converge on HTTP only: `local` means "OpenAI-compatible HTTP at a configurable URL."**
+
+- Sentinel's `local` already does this for Ollama. Touchstone's `local` becomes "POST to `$LOCAL_LLM_BASE_URL/v1/chat/completions` with `$LOCAL_LLM_MODEL`."
+- Pros: clean, single shape; works for Ollama, LM Studio, llama.cpp server, vLLM, any OpenAI-compatible local server; matches the Kimi pattern (HTTP via OpenAI-compatible endpoint).
+- Cons: removes Touchstone's "any subprocess" flexibility — users who today plug in a custom non-LLM reviewer script (e.g., a static analyzer or rule-based checker) lose that capability under the `local` name. They'd need a different mechanism (e.g., a `script` reviewer type).
+
+**Option C — Converge on subprocess only: `local` means "run this command, pipe prompt on stdin, read response from stdout."**
+
+- Touchstone's `local` already does this. Sentinel adopts the same shape — replaces its Ollama-specific HTTP path with a configurable command.
+- Pros: maximally flexible; works with any local tool (LLM or otherwise); matches Touchstone's existing surface.
+- Cons: loses Sentinel's HTTP optimizations (streaming, structured responses); subprocess-per-call is slower than persistent HTTP for high-frequency use (Sentinel's Monitor role).
+
+**Recommendation to vet with the user:** **Option A** (two identifiers). Reasoning:
+
+- It preserves both existing capabilities. No user loses functionality.
+- It cleanly matches Doctrine 0003: each identifier has one unambiguous meaning across tools.
+- The "escape hatch" identifier (`local-command`) is naturally rare-use and can be a thin shim in both tools.
+- The "opinionated HTTP" identifier (`ollama`) becomes the recommended default — and naturally extends to `lmstudio`, `llamacpp`, etc. as future row additions if needed (or stays generic enough to cover them all).
+
+**Open question for the user:** does the recommendation hold, or is one of B/C preferred? B is the "force everyone to a clean shape" answer; C is the "preserve flexibility above all" answer. The recommendation favors A because Doctrine 0002 (interactive-by-default) plus the user-base of solo devs who mostly run Ollama suggests opinionated defaults are valuable, but escape hatches matter when they matter.
+
+**Phase 2 — Implement (after the user picks a shape).**
+
+Concrete work depends on the choice. Phase 2 work items are stubbed below for Option A; rewrite if a different option is chosen.
+
+## Success Criteria
+
+This plan is done when all of the following hold:
+
+1. The user has explicitly chosen Option A, B, or C (recorded as a journal entry citing this plan).
+2. `integration/providers.md` reflects the chosen shape — either updates the `local` row or replaces it with two rows (e.g., `ollama` + `local-command`).
+3. Both Touchstone and Sentinel ship PRs that implement the chosen shape. Each PR cites Doctrine 0003 and this plan.
+4. Existing user configs continue to work, either unchanged (if Option A keeps `local` as one of the new identifiers) or via a one-version backward-compat alias with a deprecation warning (matches the codex/openai rename pattern in `plans/sentinel-codex-identifier-rename.md`).
+5. `sentinel init` and Touchstone's first-run wizard offer the new identifier(s) consistently — both tools call them the same thing and prompt for the same env vars / config keys.
+6. A journal entry in autumn-garage records the alignment shipping, citing both per-tool PRs and verifying Doctrine 0003 §1 is satisfied for the local-LLM space.
+7. Dogfood: configure the new shape in autumn-mail's Sentinel config and Touchstone reviewer cascade. One real cycle / push that exercises the local provider from both tools succeeds without confusion.
+
+## Work items (Option A — provisional, rewrite if shape changes)
+
+### Phase 1 — Decision
+
+- [ ] User picks A / B / C. Record decision in a journal entry.
+- [ ] Update this plan's Approach section to remove the alternatives and lock in the chosen shape.
+- [ ] Update `integration/providers.md` with the chosen identifier(s) and their fields (env var, endpoint shape, base URL, default model, smoke test).
+
+### Phase 2 — Sentinel repo (assumes Option A)
+
+- [ ] Rename `src/sentinel/providers/local.py` → `src/sentinel/providers/ollama.py`. Keep the HTTP shape; rename class `LocalProvider` → `OllamaProvider`; rename `ProviderName.LOCAL` → `ProviderName.OLLAMA`; keep `LOCAL` as a deprecated alias.
+- [ ] Add `src/sentinel/providers/local_command.py`: subprocess-based provider that runs a configured shell command, pipes the prompt to stdin, reads response from stdout. Mirror Touchstone's existing shape.
+- [ ] Add `ProviderName.LOCAL_COMMAND = "local-command"`.
+- [ ] Update `sentinel init` wizard to offer `ollama` (recommended) and `local-command` (escape hatch).
+- [ ] Tests for both providers; backward-compat tests for `provider = "local"` mapping to `ollama` with a deprecation warning.
+
+### Phase 2 — Touchstone repo (assumes Option A)
+
+- [ ] Add an `ollama` reviewer in `hooks/codex-review.sh`: HTTP POST to `$LOCAL_LLM_BASE_URL/v1/chat/completions` (default `http://localhost:11434/v1/chat/completions`) using the model from `integration/providers.md`.
+- [ ] Rename the existing `local` reviewer cascade entry to `local-command` (since it's the subprocess one). Keep `local` as a deprecated alias that resolves to `local-command` with a stderr warning.
+- [ ] Update `.codex-review.toml` schema and example config to document both `ollama` and `local-command` in the `[review]` section.
+- [ ] Update Touchstone's setup wizard / first-run prompts to offer both.
+- [ ] Self-tests for both reviewer paths.
+
+### Phase 2 — Coordination repo (autumn-garage)
+
+- [ ] Update `integration/providers.md`: replace the `local` row with `ollama` and `local-command` rows. Bump "Last update" date.
+- [ ] Update `plans/llm-provider-additions.md` Follow-ups: mark the local-alignment item as resolved by this plan.
+- [ ] Journal the alignment shipping.
+- [ ] Update `state.md` once both per-tool PRs are open.
+
+## Follow-ups (deferred)
+
+- **Other local-LLM ecosystems.** Once `ollama` is established as an HTTP-via-OpenAI-compatible identifier, consider whether LM Studio, vLLM, llama.cpp server need their own identifiers or can share `ollama` (the API surface is OpenAI-compatible; only the default port differs). Resolves to a future row addition discussion in `integration/providers.md`.
+- **Streaming support for local providers.** Sentinel's HTTP path could stream responses (Ollama supports it); Touchstone's hook path doesn't need streaming today. If streaming becomes desirable for Touchstone (long reviews), revisit. Not in scope here.
+- **Authentication for local providers.** Today both tools assume local LLMs need no auth. If that changes (e.g., a self-hosted vLLM behind a token), the providers table gains an env var field for `local-command` / `ollama`. Resolves to a row update when needed.
+
+## Known limitations at exit (assumes Option A)
+
+- **Two-tool migration.** Both Touchstone and Sentinel ship breaking-with-deprecation-alias renames at roughly the same time. Coordination matters: ship Sentinel and Touchstone PRs in the same week so users don't see one tool with the new names and the other with the old. Consider a shared dogfood cycle on autumn-mail to verify before either tool tags a release.
+- **The escape-hatch path stays niche.** `local-command` is rare-use by design. Documentation effort should not overweight it.
+- **Doctrine 0003 §1 doesn't strictly require renaming `local`** — it requires identifiers match across tools. If the user picks Option B or C, the rename pattern changes. Phase 2 work items are written for Option A; rewrite if needed.
+
+## Meta — why this plan is in autumn-garage
+
+Same reasoning as the sibling plans (`llm-provider-additions.md`, `sentinel-codex-identifier-rename.md`). The work spans two tools; coordination lives here; implementation lands in the tool repos. The first phase (deciding the shape) is purely coordination — no per-tool work happens until that's locked.


### PR DESCRIPTION
## Summary

Adopts the four conductor-specific plans from autumn-garage per the meta-repo discipline that plans live in their owning tool's repo (not in the meta-coordination repo). Companion to autumngarage/autumn-garage cleanup PR which deletes these from there.

- \`conductor-bootstrap.md\` — Status: active. The v0.1 bootstrap genesis plan.
- \`conductor-http-tool-use.md\` — Status: shipped. Stage 3 HTTP tool-use work; historical reference.
- \`llm-provider-additions.md\` — Status: superseded by conductor-bootstrap.
- \`local-llm-provider-alignment.md\` — Status: superseded by conductor-bootstrap.

Cite paths to autumn-garage doctrine/journal kept as-is for now (they become cross-repo refs after the cleanup PR; not load-bearing).

## Test plan

- [ ] Plans readable end-to-end
- [ ] Companion autumn-garage cleanup PR coordinated (will delete these from there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)