### PR TITLE
[codex] improve Claude readiness and stall recovery

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 import time
 from dataclasses import asdict, dataclass
@@ -85,6 +86,9 @@ PROFILE_PRECEDENCE_TEXT = (
 )
 DEFAULT_EXEC_MAX_STALL_SEC = 360
 MIN_EXEC_BRIEF_CHARS = 300
+GIT_RECOVERY_COMMAND_TIMEOUT_SEC = 2.0
+GIT_RECOVERY_MAX_COMMITS = 5
+GIT_RECOVERY_MAX_STATUS_PATHS = 8
 
 
 @dataclass(frozen=True)
@@ -776,6 +780,107 @@ def _collect_session_auth_prompts(session_log: SessionLog | None) -> list[dict] 
         seen.add(key)
         prompts.append(data)
     return prompts or None
+
+
+def _git_stdout(cwd: str, args: list[str], *, errors: list[str]) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=GIT_RECOVERY_COMMAND_TIMEOUT_SEC,
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        errors.append(f"`git {' '.join(args)}` failed: {e}")
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def _git_stall_recovery_lines(cwd: str | None) -> list[str]:
+    if not cwd:
+        return []
+
+    errors: list[str] = []
+    root = _git_stdout(cwd, ["rev-parse", "--show-toplevel"], errors=errors)
+    if not root:
+        if errors:
+            return [f"git recovery unavailable: {errors[0]}"]
+        return []
+
+    lines = [f"repo: {root}"]
+
+    branch = _git_stdout(cwd, ["branch", "--show-current"], errors=errors)
+    if not branch:
+        short_head = _git_stdout(cwd, ["rev-parse", "--short", "HEAD"], errors=errors)
+        branch = f"detached at {short_head}" if short_head else "unknown"
+    lines.append(f"branch: {branch}")
+
+    upstream = _git_stdout(
+        cwd,
+        ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+        errors=errors,
+    )
+    if upstream:
+        lines.append(f"upstream: {upstream}")
+        commits = _git_stdout(
+            cwd,
+            ["log", "--oneline", f"{upstream}..HEAD", "--"],
+            errors=errors,
+        )
+        commit_lines = commits.splitlines() if commits else []
+        if commit_lines:
+            first = commit_lines[0]
+            suffix = "" if len(commit_lines) == 1 else f"; latest: {first}"
+            lines.append(f"unpushed commits: {len(commit_lines)}{suffix}")
+        else:
+            lines.append("unpushed commits: none")
+    else:
+        lines.append("upstream: none configured")
+        commits = _git_stdout(
+            cwd,
+            ["log", "--oneline", f"-{GIT_RECOVERY_MAX_COMMITS}", "--"],
+            errors=errors,
+        )
+        if commits:
+            first = commits.splitlines()[0]
+            lines.append(f"recent local commit: {first}")
+
+    status = _git_stdout(cwd, ["status", "--porcelain"], errors=errors)
+    if status:
+        changed = status.splitlines()
+        lines.append(f"working tree: {len(changed)} changed path(s)")
+        for entry in changed[:GIT_RECOVERY_MAX_STATUS_PATHS]:
+            lines.append(f"changed: {entry}")
+        if len(changed) > GIT_RECOVERY_MAX_STATUS_PATHS:
+            hidden = len(changed) - GIT_RECOVERY_MAX_STATUS_PATHS
+            lines.append(f"changed: ... {hidden} more")
+    elif status == "":
+        lines.append("working tree: clean")
+
+    open_pr_script = Path(root) / "scripts" / "open-pr.sh"
+    if open_pr_script.exists():
+        lines.append(
+            "hint: inspect the diff, then run `bash scripts/open-pr.sh --auto-merge` "
+            "if the branch is ready"
+        )
+    else:
+        lines.append("hint: inspect with `git status`, then resume or finish the branch")
+    return lines
+
+
+def _maybe_echo_stall_recovery_hint(err: ProviderError, *, cwd: str | None) -> None:
+    if not isinstance(err, ProviderStalledError):
+        return
+    lines = _git_stall_recovery_lines(cwd)
+    if not lines:
+        return
+    click.echo("", err=True)
+    click.echo("Recoverable git state:", err=True)
+    for line in lines:
+        click.echo(f"  - {line}", err=True)
 
 
 def _format_route_log_line(decision: RouteDecision) -> str:
@@ -1575,6 +1680,7 @@ def exec_cmd(
             if session_log is not None:
                 session_log.mark_finished()
             click.echo(f"conductor: {e}", err=True)
+            _maybe_echo_stall_recovery_hint(e, cwd=cwd)
             sys.exit(1)
     else:
         if prefer is not None and provider_id != "openrouter":
@@ -1658,6 +1764,7 @@ def exec_cmd(
             session_log.emit("provider_failed", {"provider": provider_id, "error": str(e)})
             session_log.mark_finished()
             click.echo(f"conductor: {e}", err=True)
+            _maybe_echo_stall_recovery_hint(e, cwd=cwd)
             _maybe_echo_explicit_network_hint(provider_id, e)
             sys.exit(1)
         session_log.set_session_id(response.session_id)

--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
 
 CLAUDE_DEFAULT_MODEL = "sonnet"
 CLAUDE_REQUEST_TIMEOUT_SEC = 180.0
+CLAUDE_AUTH_PROBE_TIMEOUT_SEC = 15.0
 CLAUDE_CLI_ENV = "CONDUCTOR_CLAUDE_CLI"
 
 # Sentinel: "caller didn't specify a timeout" vs "caller explicitly passed
@@ -82,9 +83,11 @@ class ClaudeProvider:
         *,
         cli_command: str | None = None,
         timeout_sec: float = CLAUDE_REQUEST_TIMEOUT_SEC,
+        auth_probe_timeout_sec: float = CLAUDE_AUTH_PROBE_TIMEOUT_SEC,
     ) -> None:
         self._cli = cli_command or os.environ.get(CLAUDE_CLI_ENV) or "claude"
         self._timeout_sec = timeout_sec
+        self._auth_probe_timeout_sec = auth_probe_timeout_sec
 
     def _check_cli_path(self) -> tuple[bool, str | None]:
         """Cheap PATH-only check (no subprocess). Used by call()/exec()
@@ -126,9 +129,22 @@ class ClaudeProvider:
                 [self._cli, "auth", "status", "--json"],
                 capture_output=True,
                 text=True,
-                timeout=5,
+                timeout=self._auth_probe_timeout_sec,
             )
-        except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        except subprocess.TimeoutExpired as e:
+            health_ok, health_reason = self.health_probe(
+                timeout_sec=self._auth_probe_timeout_sec
+            )
+            if health_ok:
+                return True, None
+            return False, (
+                f"could not verify `{self._cli}` auth status: {e}. "
+                f"Fallback `{self._cli} --version` probe also failed: "
+                f"{health_reason or 'unknown failure'}. "
+                "Update the CLI (`brew upgrade claude`) and re-run, "
+                "or set `ANTHROPIC_API_KEY` for non-interactive use."
+            )
+        except (FileNotFoundError, OSError) as e:
             return False, (
                 f"could not verify `{self._cli}` auth status: {e}. "
                 "Update the CLI (`brew upgrade claude`) and re-run, "

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -141,15 +141,29 @@ def test_claude_configured_false_when_auth_probe_exits_nonzero(mocker):
     assert "upgrade" in reason.lower()
 
 
-def test_claude_configured_false_when_auth_probe_times_out(mocker):
+def test_claude_configured_true_when_auth_probe_times_out_but_cli_health_passes(mocker):
     mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
     mocker.patch(
         "conductor.providers.claude.subprocess.run",
-        side_effect=subprocess.TimeoutExpired(cmd="claude", timeout=5),
+        side_effect=[
+            subprocess.TimeoutExpired(cmd="claude", timeout=15),
+            _fake_completed(stdout="2.1.121 (Claude Code)"),
+        ],
+    )
+    ok, reason = ClaudeProvider().configured()
+    assert ok is True and reason is None
+
+
+def test_claude_configured_false_when_auth_and_health_probes_time_out(mocker):
+    mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
+    mocker.patch(
+        "conductor.providers.claude.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="claude", timeout=15),
     )
     ok, reason = ClaudeProvider().configured()
     assert ok is False
     assert "could not verify" in reason
+    assert "--version" in reason
 
 
 def test_claude_configured_false_when_auth_probe_returns_non_json(mocker):

--- a/tests/test_cli_log_file.py
+++ b/tests/test_cli_log_file.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from typing import TYPE_CHECKING
 
 from click.testing import CliRunner
@@ -252,6 +253,49 @@ def test_exec_provider_stall_records_terminal_session_metadata(
     meta = json.loads(meta_paths[0].read_text(encoding="utf-8"))
     assert meta["status"] != "running"
     assert meta["finished_at"] is not None
+
+
+def test_exec_provider_stall_prints_git_recovery_hint(
+    mocker,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True)
+    (repo / "notes.txt").write_text("partial work\n", encoding="utf-8")
+
+    mocker.patch.object(ClaudeProvider, "health_probe", return_value=(True, None))
+
+    def _fake_exec(self, task, model=None, **kwargs):
+        raise ProviderStalledError("claude CLI stalled after 1s with no output")
+
+    mocker.patch.object(ClaudeProvider, "exec", _fake_exec)
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--with",
+            "claude",
+            "--max-stall-seconds",
+            "1",
+            "--task",
+            "review the diff",
+            "--cwd",
+            str(repo),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "conductor: claude CLI stalled after 1s with no output" in result.stderr
+    assert "Recoverable git state:" in result.stderr
+    assert f"repo: {repo}" in result.stderr
+    assert "branch: main" in result.stderr
+    assert "upstream: none configured" in result.stderr
+    assert "working tree: 1 changed path(s)" in result.stderr
+    assert "changed: ?? notes.txt" in result.stderr
 
 
 def test_sessions_tail_without_active_session_prints_message(


### PR DESCRIPTION
## Summary

Fixes #100 by treating a Claude `auth status --json` timeout as indeterminate instead of immediately unavailable when the cheaper `claude --version` health probe still succeeds. This keeps `conductor list` and routing aligned with a Claude CLI that can execute.

Fixes #99 by printing a bounded git recovery snapshot when `conductor exec` exits on a provider stall inside a git repo. The snapshot includes repo, branch, upstream, unpushed commits, working-tree changes, and a repo-local `scripts/open-pr.sh --auto-merge` hint when available.

## Validation

- `uv run ruff check .`
- `uv run pytest tests/test_adapters_subprocess.py::test_claude_configured_true_when_auth_probe_times_out_but_cli_health_passes tests/test_adapters_subprocess.py::test_claude_configured_false_when_auth_and_health_probes_time_out tests/test_cli_log_file.py::test_exec_provider_stall_prints_git_recovery_hint`
- `uv run pytest`
- `uv run conductor list`