### PR TITLE
docs: journal PR 101 merge

### DIFF
--- a/.cortex/journal/2026-04-28-pr-101-merged.md
+++ b/.cortex/journal/2026-04-28-pr-101-merged.md
@@ -1,0 +1,26 @@
+# PR #101 merged - improve Claude readiness and stall recovery
+
+**Date:** 2026-04-28
+**Type:** pr-merged
+**Trigger:** T1.9
+**Cites:** GitHub issues #99 and #100
+**Merge-commit:** e891083fcc600b254c873985cffc53c956a7a5bc
+**Branch:** fix/github-issues-99-100
+
+> Conductor now treats Claude auth-probe timeouts as indeterminate when the CLI health probe still succeeds, and stall exits now print recoverable git state for repo-backed exec runs.
+
+## What shipped
+
+- Claude readiness no longer reports unavailable solely because `claude auth status --json` exceeded the auth-probe timeout; Conductor falls back to `claude --version` before deciding the provider is unavailable.
+- `conductor exec` now prints a bounded git recovery block when a provider stall occurs inside a git repo, including repo, branch, upstream, unpushed commits, working-tree changes, and an `open-pr.sh` hint when present.
+- Regression coverage now pins both the Claude timeout fallback and the stall recovery hint.
+
+## Closes / advances
+
+- **Plans:** none.
+- **Doctrine:** none.
+- **Journal linkage:** this merge closes GitHub issues #99 and #100.
+
+## Follow-ups (deferred to future work)
+
+None.

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -109,6 +110,7 @@ ROUTE_REQUIRED_FIELDS: frozenset[str] = frozenset(
 )
 
 _FIXTURE_DIR = Path(__file__).parent / "fixtures"
+CONDUCTOR_CLI = [sys.executable, "-m", "conductor.cli"]
 
 
 # ---------------------------------------------------------------------------
@@ -153,7 +155,7 @@ def _conductor_configured() -> bool:
     """Return True if at least one provider is configured, used to gate live tests."""
     try:
         result = subprocess.run(
-            ["conductor", "list", "--json"],
+            [*CONDUCTOR_CLI, "list", "--json"],
             capture_output=True,
             text=True,
             timeout=10,
@@ -181,7 +183,7 @@ class TestFlagSurface:
 
     def test_call_has_all_documented_stable_flags(self) -> None:
         result = subprocess.run(
-            ["conductor", "call", "--help"],
+            [*CONDUCTOR_CLI, "call", "--help"],
             capture_output=True,
             text=True,
         )
@@ -194,7 +196,7 @@ class TestFlagSurface:
 
     def test_exec_has_all_documented_stable_flags(self) -> None:
         result = subprocess.run(
-            ["conductor", "exec", "--help"],
+            [*CONDUCTOR_CLI, "exec", "--help"],
             capture_output=True,
             text=True,
         )
@@ -252,7 +254,7 @@ def test_live_call_matches_documented_schema() -> None:
 
     result = subprocess.run(
         [
-            "conductor",
+            *CONDUCTOR_CLI,
             "call",
             "--with",
             "claude",


### PR DESCRIPTION
## Summary

Adds the required Cortex T1.9 post-merge journal entry for PR #101.

Also fixes the CLI contract tests so CI invokes the checked-out module (`python -m conductor.cli`) instead of requiring a separately installed `conductor` executable on PATH.

## Validation

- `uv run pytest tests/test_cli_contract.py`
- `uv run ruff check .`
- `uv run pytest`
- GitHub Actions `validate` passed.