### PR TITLE
[codex] harden Claude exec startup

### DIFF
--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -16,6 +16,7 @@ import os
 import shutil
 import subprocess
 import time
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from conductor.providers.cli_auth import (
@@ -37,6 +38,8 @@ if TYPE_CHECKING:
 CLAUDE_DEFAULT_MODEL = "sonnet"
 CLAUDE_REQUEST_TIMEOUT_SEC = 180.0
 CLAUDE_AUTH_PROBE_TIMEOUT_SEC = 15.0
+CLAUDE_FIRST_OUTPUT_TIMEOUT_SEC = 45.0
+CLAUDE_SETTING_SOURCES = "user,project,local"
 CLAUDE_CLI_ENV = "CONDUCTOR_CLAUDE_CLI"
 
 # Sentinel: "caller didn't specify a timeout" vs "caller explicitly passed
@@ -84,10 +87,12 @@ class ClaudeProvider:
         cli_command: str | None = None,
         timeout_sec: float = CLAUDE_REQUEST_TIMEOUT_SEC,
         auth_probe_timeout_sec: float = CLAUDE_AUTH_PROBE_TIMEOUT_SEC,
+        first_output_timeout_sec: float | None = CLAUDE_FIRST_OUTPUT_TIMEOUT_SEC,
     ) -> None:
         self._cli = cli_command or os.environ.get(CLAUDE_CLI_ENV) or "claude"
         self._timeout_sec = timeout_sec
         self._auth_probe_timeout_sec = auth_probe_timeout_sec
+        self._first_output_timeout_sec = first_output_timeout_sec
 
     def _check_cli_path(self) -> tuple[bool, str | None]:
         """Cheap PATH-only check (no subprocess). Used by call()/exec()
@@ -317,6 +322,11 @@ class ClaudeProvider:
             args.extend(["--allowedTools", allowed_tools])
         if permission_mode is not None:
             args.extend(["--permission-mode", permission_mode])
+        if cwd is not None:
+            # Make project/local settings resolution explicit for headless
+            # nested Claude Code runs. The child still receives cwd/PWD below;
+            # this flag tells the CLI to include repo-scoped settings sources.
+            args.extend(["--setting-sources", CLAUDE_SETTING_SOURCES])
         if resume_session_id:
             # Claude Code resumes a prior session via UUID. The previous
             # CallResponse.session_id is the canonical handle; the new
@@ -334,15 +344,34 @@ class ClaudeProvider:
         start = time.monotonic()
         tracker = AuthPromptTracker(self.name, session_log=session_log)
         try:
-            import os as _os
-            proc_env = {**_os.environ, **env_overrides} if env_overrides else None
+            effective_cwd = self._effective_cwd(cwd)
+            proc_env = self._build_proc_env(env_overrides, effective_cwd=effective_cwd)
+            first_output_timeout_sec = self._effective_first_output_timeout(
+                max_stall_sec
+            )
+            if session_log is not None:
+                session_log.emit(
+                    "provider_diagnostic",
+                    {
+                        "provider": self.name,
+                        "check": "claude_exec_watchdogs",
+                        "first_output_timeout_sec": first_output_timeout_sec,
+                        "max_stall_sec": max_stall_sec,
+                    },
+                )
+            self._emit_project_settings_diagnostic(
+                effective_cwd=effective_cwd,
+                sandbox_permission_mode=permission_mode,
+                session_log=session_log,
+            )
             if live_auth_capture:
                 result = run_subprocess_with_live_stderr(
                     args=args,
-                    cwd=cwd,
+                    cwd=str(effective_cwd) if effective_cwd is not None else None,
                     env=proc_env,
                     timeout=timeout,
                     max_stall_sec=max_stall_sec,
+                    first_output_timeout_sec=first_output_timeout_sec,
                     provider_name=self.name,
                     session_log=session_log,
                     tracker=tracker,
@@ -354,7 +383,7 @@ class ClaudeProvider:
                     capture_output=True,
                     text=True,
                     timeout=timeout,
-                    cwd=cwd,
+                    cwd=str(effective_cwd) if effective_cwd is not None else None,
                     env=proc_env,
                 )
                 result = CapturedProcessResult(
@@ -407,3 +436,88 @@ class ClaudeProvider:
             raw=data,
             auth_prompts=tracker.prompts or None,
         )
+
+    def _effective_cwd(self, cwd: str | None) -> Path | None:
+        if cwd is None:
+            return None
+        return Path(cwd).expanduser().resolve(strict=False)
+
+    def _build_proc_env(
+        self,
+        env_overrides: dict[str, str],
+        *,
+        effective_cwd: Path | None,
+    ) -> dict[str, str] | None:
+        if not env_overrides and effective_cwd is None:
+            return None
+        proc_env = {**os.environ, **env_overrides}
+        if effective_cwd is not None:
+            proc_env["PWD"] = str(effective_cwd)
+        return proc_env
+
+    def _effective_first_output_timeout(
+        self,
+        max_stall_sec: int | None,
+    ) -> float | None:
+        if (
+            max_stall_sec is None
+            or max_stall_sec <= 0
+            or self._first_output_timeout_sec is None
+            or self._first_output_timeout_sec <= 0
+        ):
+            return None
+        if self._first_output_timeout_sec >= max_stall_sec:
+            return None
+        return self._first_output_timeout_sec
+
+    def _emit_project_settings_diagnostic(
+        self,
+        *,
+        effective_cwd: Path | None,
+        sandbox_permission_mode: str | None,
+        session_log: SessionLog | None,
+    ) -> None:
+        if effective_cwd is None or sandbox_permission_mode != "acceptEdits":
+            return
+        settings_json_path = effective_cwd / ".claude" / "settings.json"
+        settings_path = effective_cwd / ".claude" / "settings.local.json"
+        data = {
+            "provider": self.name,
+            "check": "claude_project_settings",
+            "cwd": str(effective_cwd),
+            "settings_json_path": str(settings_json_path),
+            "settings_path": str(settings_path),
+            "settings_json_exists": settings_json_path.exists(),
+            "settings_local_exists": settings_path.exists(),
+            "permission_mode": sandbox_permission_mode,
+        }
+        permission_keys: set[str] = set()
+        permission_sources: list[str] = []
+        for path in (settings_json_path, settings_path):
+            if not path.exists():
+                continue
+            raw = self._read_project_settings(path)
+            permissions = raw.get("permissions")
+            if isinstance(permissions, dict):
+                permission_sources.append(path.name)
+                permission_keys.update(str(key) for key in permissions)
+        data["permissions_configured"] = bool(permission_sources)
+        if permission_sources:
+            data["permission_sources"] = permission_sources
+            data["permission_keys"] = sorted(permission_keys)
+        if session_log is not None:
+            session_log.emit("provider_diagnostic", data)
+
+    def _read_project_settings(self, path: Path) -> dict:
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as e:
+            raise ProviderConfigError(
+                f"invalid Claude project settings JSON at {path}: "
+                f"{e.msg} (line {e.lineno}, column {e.colno})"
+            ) from e
+        if not isinstance(raw, dict):
+            raise ProviderConfigError(
+                f"Claude project settings at {path} must be a JSON object"
+            )
+        return raw

--- a/src/conductor/providers/cli_auth.py
+++ b/src/conductor/providers/cli_auth.py
@@ -185,6 +185,7 @@ def run_subprocess_with_live_stderr(
     env: dict[str, str] | None,
     timeout: float | None,
     max_stall_sec: float | None = None,
+    first_output_timeout_sec: float | None = None,
     provider_name: str | None = None,
     session_log: SessionLog | None = None,
     tracker: AuthPromptTracker,
@@ -226,6 +227,7 @@ def run_subprocess_with_live_stderr(
     stderr_thread.start()
 
     last_output = start
+    saw_output = False
     provider_label = provider_name or str(args[0])
     while True:
         now = time.monotonic()
@@ -241,7 +243,42 @@ def run_subprocess_with_live_stderr(
                 stderr="".join(parts["stderr"]),
             )
 
-        if max_stall_sec is not None and now - last_output > max_stall_sec:
+        if (
+            first_output_timeout_sec is not None
+            and not saw_output
+            and stream_q.empty()
+            and now - start > first_output_timeout_sec
+        ):
+            _terminate_process(process)
+            stdout_thread.join(timeout=1)
+            stderr_thread.join(timeout=1)
+            _drain_stream_queue(stream_q, parts, tracker)
+            elapsed = time.monotonic() - start
+            reason = (
+                "no_initial_provider_output_within_"
+                f"{_format_stall_seconds(first_output_timeout_sec)}s"
+            )
+            if session_log is not None:
+                session_log.emit(
+                    "error",
+                    {
+                        "provider": provider_label,
+                        "reason": reason,
+                        "phase": "first_output",
+                        "last_event": "provider_started",
+                        "silent_sec": round(elapsed, 1),
+                    },
+                )
+            raise ProviderStalledError(
+                f"{provider_label} CLI produced no output within "
+                f"{_format_stall_seconds(first_output_timeout_sec)}s after start"
+            )
+
+        if (
+            max_stall_sec is not None
+            and stream_q.empty()
+            and now - last_output > max_stall_sec
+        ):
             _terminate_process(process)
             stdout_thread.join(timeout=1)
             stderr_thread.join(timeout=1)
@@ -284,6 +321,7 @@ def run_subprocess_with_live_stderr(
             continue
 
         parts[stream_name].append(item)
+        saw_output = True
         last_output = time.monotonic()
         if stream_name == "stderr":
             tracker.observe_text(item, source="stderr")

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -393,6 +393,151 @@ def test_claude_exec_stall_watchdog_kills_silent_provider_and_logs_error(
     assert error_event["data"]["last_event"] == "provider_started"
 
 
+def test_claude_exec_first_output_watchdog_is_separate_from_mid_task_stall(
+    mocker,
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
+    fake = _FakePopen(stdout_schedule=[], hang_after_stdout=True)
+    mocker.patch(
+        "conductor.providers.claude.subprocess.Popen",
+        side_effect=lambda args, **kwargs: fake,
+    )
+    session_log = SessionLog(path=tmp_path / "claude-first-output-stall.ndjson")
+
+    with pytest.raises(ProviderStalledError) as exc:
+        ClaudeProvider(first_output_timeout_sec=0.05).exec(
+            "hi",
+            timeout_sec=1,
+            max_stall_sec=30,
+            session_log=session_log,
+        )
+
+    assert fake.terminated is True
+    assert "produced no output within 0.05s after start" in str(exc.value)
+    events = [
+        json.loads(line)
+        for line in session_log.log_path.read_text(encoding="utf-8").splitlines()
+    ]
+    diagnostic = next(
+        event
+        for event in events
+        if event["event"] == "provider_diagnostic"
+        and event["data"]["check"] == "claude_exec_watchdogs"
+    )
+    assert diagnostic["data"]["first_output_timeout_sec"] == 0.05
+    assert diagnostic["data"]["max_stall_sec"] == 30
+    error_event = next(event for event in events if event["event"] == "error")
+    assert error_event["data"]["reason"] == "no_initial_provider_output_within_0.05s"
+    assert error_event["data"]["phase"] == "first_output"
+    assert error_event["data"]["last_event"] == "provider_started"
+
+
+def test_claude_exec_first_output_watchdog_respects_stall_watchdog_disable(
+    mocker,
+):
+    mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
+    fake = _FakePopen(stdout_schedule=[], hang_after_stdout=True)
+    mocker.patch(
+        "conductor.providers.claude.subprocess.Popen",
+        side_effect=lambda args, **kwargs: fake,
+    )
+
+    with pytest.raises(ProviderError) as exc:
+        ClaudeProvider(first_output_timeout_sec=0.01).exec(
+            "hi",
+            timeout_sec=0.05,
+            max_stall_sec=None,
+        )
+
+    assert not isinstance(exc.value, ProviderStalledError)
+    assert "timed out" in str(exc.value)
+    assert fake.terminated is True
+
+
+def test_claude_exec_sets_pwd_to_configured_cwd_for_project_settings(
+    mocker,
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("PWD", "/not/the/project")
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    repo = tmp_path / "repo"
+    settings_dir = repo / ".claude"
+    settings_dir.mkdir(parents=True)
+    (settings_dir / "settings.json").write_text(
+        json.dumps({"permissions": {"deny": ["Bash(rm:*)"]}}),
+        encoding="utf-8",
+    )
+    (settings_dir / "settings.local.json").write_text(
+        json.dumps({"permissions": {"allow": ["Bash(git status:*)"]}}),
+        encoding="utf-8",
+    )
+    mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
+    fake = _FakePopen(stdout_schedule=[(0, CLAUDE_JSON)])
+    captured: dict[str, object] = {}
+
+    def factory(args, **kwargs):
+        fake.args = args
+        captured.update(kwargs)
+        return fake
+
+    mocker.patch("conductor.providers.claude.subprocess.Popen", side_effect=factory)
+    session_log = SessionLog(path=tmp_path / "claude-settings.ndjson")
+
+    response = ClaudeProvider(first_output_timeout_sec=1).exec(
+        "hi",
+        sandbox="workspace-write",
+        cwd=str(repo),
+        session_log=session_log,
+    )
+
+    assert response.text == "hello from claude"
+    assert "--setting-sources" in fake.args
+    assert fake.args[fake.args.index("--setting-sources") + 1] == "user,project,local"
+    assert captured["cwd"] == str(repo.resolve())
+    assert captured["env"]["PWD"] == str(repo.resolve())
+    events = [
+        json.loads(line)
+        for line in session_log.log_path.read_text(encoding="utf-8").splitlines()
+    ]
+    settings_event = next(
+        event
+        for event in events
+        if event["event"] == "provider_diagnostic"
+        and event["data"]["check"] == "claude_project_settings"
+    )
+    assert settings_event["data"]["settings_json_exists"] is True
+    assert settings_event["data"]["settings_local_exists"] is True
+    assert settings_event["data"]["permissions_configured"] is True
+    assert settings_event["data"]["permission_sources"] == [
+        "settings.json",
+        "settings.local.json",
+    ]
+    assert settings_event["data"]["permission_keys"] == ["allow", "deny"]
+    assert settings_event["data"]["permission_mode"] == "acceptEdits"
+
+
+def test_claude_exec_rejects_invalid_project_settings_before_launch(
+    mocker,
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    settings_dir = repo / ".claude"
+    settings_dir.mkdir(parents=True)
+    (settings_dir / "settings.local.json").write_text("{not json", encoding="utf-8")
+    mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
+    popen = mocker.patch("conductor.providers.claude.subprocess.Popen")
+
+    with pytest.raises(ProviderConfigError) as exc:
+        ClaudeProvider().exec("hi", sandbox="workspace-write", cwd=str(repo))
+
+    assert "invalid Claude project settings JSON" in str(exc.value)
+    assert popen.call_count == 0
+
+
 # ---------------------------------------------------------------------------
 # Codex
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the two open Claude exec issues:

- Adds a distinct first-output watchdog for Claude exec startup stalls, so sessions that never produce an initial provider byte fail before the generic long stall window.
- Keeps the existing mid-task stall watchdog separate and honors `--max-stall-seconds 0` by disabling the new first-output watchdog with it.
- Makes nested Claude Code runs deterministic for project settings by passing `--setting-sources user,project,local`, setting child `PWD` to the effective `--cwd`, and validating/logging project `.claude/settings.json` / `.claude/settings.local.json` diagnostics for workspace-write runs.

Root cause: Conductor only had a generic no-output watchdog and passed `cwd` to the child process without also making Claude Code's settings-source and `PWD` context explicit. That left startup hangs slow to recover and made repo-local Claude permission settings harder to reason about in nested non-interactive runs.

Fixes #104.
Fixes #105.

## Validation

- `uv run pytest tests/test_adapters_subprocess.py -k 'claude_exec'`
- `uv run pytest tests/test_adapters_subprocess.py`
- `uv run pytest`
- `uv run ruff check .`
- `git diff --check`