### PR TITLE
Handle older Conductor during review-only hooks

### DIFF
--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -55,6 +55,7 @@
 #   TOUCHSTONE_CONDUCTOR_EFFORT       — minimal|low|medium|high|max (default: medium)
 #   TOUCHSTONE_CONDUCTOR_TAGS         — comma-separated tag hints (default: code-review)
 #   TOUCHSTONE_CONDUCTOR_EXCLUDE      — comma-separated providers to skip
+#   CONDUCTOR_BIN                     — conductor executable to invoke (default: conductor)
 #   CODEX_REVIEW_SUPPRESS_LEGACY_WARNINGS — silence one-time migration hints
 #   CODEX_REVIEW_ENABLED              — true/false override for the [review].enabled setting
 #   CODEX_REVIEW_MODE                 — review-only|fix|diff-only|no-tests (default: fix)
@@ -139,6 +140,7 @@ TOUCHSTONE_LOCAL_REVIEWER_COMMAND="${TOUCHSTONE_LOCAL_REVIEWER_COMMAND:-}"
 TOUCHSTONE_LOCAL_REVIEWER_AUTH_COMMAND="${TOUCHSTONE_LOCAL_REVIEWER_AUTH_COMMAND:-}"
 # 2.0 conductor knobs — filled from [review.conductor] during TOML parse;
 # env vars (TOUCHSTONE_CONDUCTOR_*) override just before invocation.
+CONDUCTOR_BIN="${CONDUCTOR_BIN:-conductor}"
 CONDUCTOR_WITH=""
 CONDUCTOR_PREFER=""
 CONDUCTOR_EFFORT=""
@@ -950,15 +952,19 @@ ASSIST_EOF
 # and lets the router pick.
 
 reviewer_conductor_available() {
-  command -v conductor >/dev/null 2>&1
+  command -v "$CONDUCTOR_BIN" >/dev/null 2>&1
 }
 
 reviewer_conductor_auth_ok() {
   # Delegate to `conductor doctor --json` — cheap check, makes no upstream
   # calls, confirms at least one provider is configured.
   local doctor_json
-  doctor_json=$(conductor doctor --json 2>/dev/null) || return 1
+  doctor_json=$("$CONDUCTOR_BIN" doctor --json 2>/dev/null) || return 1
   echo "$doctor_json" | grep -q '"configured"[[:space:]]*:[[:space:]]*true'
+}
+
+reviewer_conductor_supports_review() {
+  "$CONDUCTOR_BIN" review --help >/dev/null 2>&1
 }
 
 reviewer_conductor_exec() {
@@ -987,13 +993,23 @@ reviewer_conductor_exec() {
     diff-only)
       # Read-only review intent. The diff is embedded in the prompt, and
       # Conductor should still use provider-native review when available.
-      subcommand="review"
+      if reviewer_conductor_supports_review; then
+        subcommand="review"
+      else
+        subcommand="call"
+      fi
       ;;
     review-only)
       # Merge review is pure review, not engineering. Route through
       # `conductor review` so Codex/Claude/Gemini can use their dedicated
       # review entrypoints instead of generic agent execution.
-      subcommand="review"
+      if reviewer_conductor_supports_review; then
+        subcommand="review"
+      else
+        subcommand="exec"
+        tools="Read,Grep,Glob,Bash"
+        sandbox="read-only"
+      fi
       ;;
     no-tests)
       subcommand="exec"
@@ -1033,7 +1049,7 @@ reviewer_conductor_exec() {
   # matches Conductor's established stdin-fallback path.
   CODEX_REVIEW_IN_PROGRESS=1 \
     printf '%s' "$prompt" \
-    | conductor "$subcommand" "${args[@]}"
+    | "$CONDUCTOR_BIN" "$subcommand" "${args[@]}"
 }
 
 # --------------------------------------------------------------------------
@@ -1800,7 +1816,7 @@ run_peer_review() {
   # wrapper when the primary timed out; peer call runs synchronously and
   # relies on conductor's own per-provider timeout (currently 300s default).
   peer_output="$(printf '%s' "$peer_prompt" \
-    | conductor call --auto \
+    | "$CONDUCTOR_BIN" call --auto \
         --exclude "$primary_provider" \
         --tags code-review \
         --effort medium \

--- a/tests/test_codex_review_sentinel.py
+++ b/tests/test_codex_review_sentinel.py
@@ -12,6 +12,55 @@ def test_codex_review_sentinel_shell_regression() -> None:
     subprocess.run(["bash", str(test_script)], cwd=repo, check=True)
 
 
+def _make_review_repo(tmp_path: Path) -> tuple[Path, dict[str, str]]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    sanitized_env = {
+        k: v
+        for k, v in os.environ.items()
+        if not (k.startswith("GIT_") or k.startswith("PRE_COMMIT_"))
+    }
+    env = {
+        **sanitized_env,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@t",
+    }
+
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, env=env, check=True)
+    subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=repo, env=env, check=True)
+    (repo / "README").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README"], cwd=repo, env=env, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "base"], cwd=repo, env=env, check=True)
+    (repo / "README").write_text("base\nfeature\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README"], cwd=repo, env=env, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "feature"], cwd=repo, env=env, check=True)
+
+    (repo / ".codex-review.toml").write_text(
+        textwrap.dedent(
+            """
+            [codex_review]
+            max_iterations = 1
+            max_diff_lines = 5000
+            cache_clean_reviews = false
+            safe_by_default = true
+            mode = "review-only"
+            on_error = "fail-open"
+            unsafe_paths = []
+
+            [review]
+            enabled = true
+            reviewer = "conductor"
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "add", ".codex-review.toml"], cwd=repo, env=env, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "config"], cwd=repo, env=env, check=True)
+    return repo, env
+
+
 def test_codex_review_wrapper_accepts_footer_after_sentinel(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -119,3 +168,62 @@ def test_codex_review_wrapper_accepts_footer_after_sentinel(tmp_path: Path) -> N
     conductor_invocations = conductor_args.read_text(encoding="utf-8").splitlines()
     assert any(line.startswith("review ") for line in conductor_invocations)
     assert not any(line.startswith("exec ") for line in conductor_invocations)
+
+
+def test_codex_review_wrapper_falls_back_when_conductor_lacks_review(
+    tmp_path: Path,
+) -> None:
+    repo, env = _make_review_repo(tmp_path)
+    fakes = tmp_path / "fakes"
+    fakes.mkdir()
+    conductor_args = tmp_path / "conductor-args.txt"
+    conductor = fakes / "conductor"
+    conductor.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            printf '%s\\n' "$*" >> "${FAKE_CONDUCTOR_ARGS:?}"
+            case "$1" in
+              doctor)
+                printf '{"configured": true}\\n'
+                ;;
+              review)
+                exit 2
+                ;;
+              exec)
+                cat >/dev/null
+                printf 'LGTM\\nCODEX_REVIEW_CLEAN\\n'
+                ;;
+              *)
+                exit 1
+                ;;
+            esac
+            """
+        ),
+        encoding="utf-8",
+    )
+    conductor.chmod(0o755)
+
+    script = Path(__file__).resolve().parent.parent / "scripts" / "codex-review.sh"
+    result = subprocess.run(
+        ["bash", str(script)],
+        cwd=repo,
+        env={
+            **env,
+            "PATH": f"{fakes}:{os.environ.get('PATH', '')}",
+            "CODEX_REVIEW_BASE": "HEAD~1",
+            "CODEX_REVIEW_MODE": "review-only",
+            "CODEX_REVIEW_DISABLE_CACHE": "1",
+            "CODEX_REVIEW_TIMEOUT": "5",
+            "FAKE_CONDUCTOR_ARGS": str(conductor_args),
+            "NO_COLOR": "1",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    conductor_invocations = conductor_args.read_text(encoding="utf-8").splitlines()
+    assert any(line == "review --help" for line in conductor_invocations)
+    assert any(line.startswith("exec ") for line in conductor_invocations)


### PR DESCRIPTION
## Summary
- make `scripts/codex-review.sh` detect whether the selected Conductor binary supports `conductor review`
- fall back to the old read-only `exec`/`call` behavior when the installed binary is older, instead of failing review-only hooks with exit 2
- add `CONDUCTOR_BIN` for explicit hook testing against a chosen Conductor executable
- add a regression test for the fallback path

## Tests
- `uv run ruff check .`
- `uv run pytest`

## Context
PR #111 added `conductor review`, but dogfooding the merge script exposed that hooks may still resolve an older installed `conductor` binary before the new release is installed. This keeps the merge-review path graceful during upgrades.