### PR TITLE
Preserve Codex review prompts with targets

### DIFF
--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -228,17 +228,19 @@ class CodexProvider:
         codex_effort_flag = (
             _EFFORT_TO_CODEX_FLAG.get(effort) if isinstance(effort, str) else None
         )
+        review_prompt = self._build_review_prompt(
+            task,
+            base=base,
+            commit=commit,
+            uncommitted=uncommitted,
+            title=title,
+        )
         args = [self._cli, "review"]
         if codex_effort_flag:
             args.extend(["-c", f"model_reasoning_effort={codex_effort_flag}"])
-        if uncommitted:
-            args.append("--uncommitted")
-        if base:
-            args.extend(["--base", base])
-        if commit:
-            args.extend(["--commit", commit])
-        if title:
-            args.extend(["--title", title])
+        # `codex review` rejects target flags when a prompt is supplied.
+        # Touchstone always needs a strict sentinel/rubric prompt, so encode
+        # the target in the prompt instead of forwarding --base/--commit.
         args.append("-")
 
         timeout = self._timeout_sec if timeout_sec is None else timeout_sec
@@ -246,7 +248,7 @@ class CodexProvider:
         try:
             result = subprocess.run(
                 args,
-                input=task,
+                input=review_prompt,
                 capture_output=True,
                 text=True,
                 timeout=timeout,
@@ -294,6 +296,28 @@ class CodexProvider:
                 },
             },
         )
+
+    @staticmethod
+    def _build_review_prompt(
+        task: str,
+        *,
+        base: str | None,
+        commit: str | None,
+        uncommitted: bool,
+        title: str | None,
+    ) -> str:
+        target_lines: list[str] = []
+        if base:
+            target_lines.append(f"- Review changes against base branch/ref: {base}")
+        if commit:
+            target_lines.append(f"- Review commit: {commit}")
+        if uncommitted:
+            target_lines.append("- Include staged, unstaged, and untracked changes.")
+        if title:
+            target_lines.append(f"- Review title: {title}")
+        if not target_lines:
+            return task
+        return "Review target:\n" + "\n".join(target_lines) + "\n\n" + task
 
     def _parse_ndjson(
         self, stdout: str

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -770,12 +770,13 @@ def test_codex_review_uses_native_review_command(mocker):
     assert args[0:2] == ["codex", "review"]
     assert "-c" in args
     assert args[args.index("-c") + 1] == "model_reasoning_effort=medium"
-    assert "--base" in args
-    assert args[args.index("--base") + 1] == "origin/main"
-    assert "--title" in args
-    assert args[args.index("--title") + 1] == "PR review"
+    assert "--base" not in args
+    assert "--title" not in args
     assert args[-1] == "-"
-    assert captured.call_args.kwargs["input"] == "Use AGENTS.md rubric."
+    prompt = captured.call_args.kwargs["input"]
+    assert "Review changes against base branch/ref: origin/main" in prompt
+    assert "Review title: PR review" in prompt
+    assert "Use AGENTS.md rubric." in prompt
     assert response.provider == "codex"
     assert response.model == "codex-review"
     assert response.text == "LGTM"


### PR DESCRIPTION
## Summary
- stop forwarding `--base`/target flags to `codex review` when Conductor has a required review prompt
- encode the requested review target in the Codex review instructions instead, preserving Touchstone's sentinel contract
- update adapter tests to assert target metadata is carried in stdin rather than conflicting CLI flags

## Tests
- `uv run ruff check .`
- `uv run pytest`

## Context
After releasing 0.7.3, a real review-only hook run correctly routed to `conductor review` and native Codex review, but Codex rejected `--base` with a prompt. Touchstone always needs to pass a strict rubric/sentinel prompt, so Conductor must not combine Codex target flags with prompt mode.