### PR TITLE
fix: enforce Touchstone sentinel contract on native review (#117)

### DIFF
--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -31,6 +31,7 @@ from conductor.providers.interface import (
     ProviderHTTPError,
     resolve_effort_tokens,
 )
+from conductor.providers.review_contract import ensure_requested_review_sentinel
 
 if TYPE_CHECKING:
     from conductor.session_log import SessionLog
@@ -321,8 +322,13 @@ class ClaudeProvider:
             )
 
         usage = data.get("usage") or {}
-        return CallResponse(
+        content = ensure_requested_review_sentinel(
+            provider_name=self.name,
+            prompt=review_prompt,
             text=data.get("result", ""),
+        )
+        return CallResponse(
+            text=content,
             provider=self.name,
             model=model,
             duration_ms=data.get("duration_ms") or duration_ms,

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -37,6 +37,7 @@ from conductor.providers.interface import (
     ProviderStalledError,
     resolve_effort_tokens,
 )
+from conductor.providers.review_contract import ensure_requested_review_sentinel
 
 if TYPE_CHECKING:
     from conductor.session_log import SessionLog
@@ -271,6 +272,11 @@ class CodexProvider:
             raise ProviderHTTPError(
                 f"codex review produced empty stdout: {result.stderr[:500]!r}"
             )
+        content = ensure_requested_review_sentinel(
+            provider_name=self.name,
+            prompt=review_prompt,
+            text=content,
+        )
 
         return CallResponse(
             text=content,

--- a/src/conductor/providers/gemini.py
+++ b/src/conductor/providers/gemini.py
@@ -32,6 +32,7 @@ from conductor.providers.interface import (
     ProviderHTTPError,
     resolve_effort_tokens,
 )
+from conductor.providers.review_contract import ensure_requested_review_sentinel
 
 if TYPE_CHECKING:
     from conductor.session_log import SessionLog
@@ -354,6 +355,11 @@ class GeminiProvider:
                 auth_prompts=tracker.prompts or None,
             )
 
+        content = ensure_requested_review_sentinel(
+            provider_name=self.name,
+            prompt=prompt,
+            text=data.get("response", ""),
+        )
         input_tokens, output_tokens = self._sum_usage(data)
         session_id = (
             data.get("session_id")
@@ -363,7 +369,7 @@ class GeminiProvider:
             or data.get("chatId")
         )
         return CallResponse(
-            text=data.get("response", ""),
+            text=content,
             provider=self.name,
             model=model,
             duration_ms=duration_ms,

--- a/src/conductor/providers/review_contract.py
+++ b/src/conductor/providers/review_contract.py
@@ -1,0 +1,51 @@
+"""Helpers for native review output contracts."""
+
+from __future__ import annotations
+
+import re
+import sys
+
+_REVIEW_SENTINEL_RE = re.compile(r"^\s*(CODEX_REVIEW_(?:CLEAN|FIXED|BLOCKED))\s*$")
+_SAFE_BLOCKED_SENTINEL = "CODEX_REVIEW_BLOCKED"
+
+
+def ensure_requested_review_sentinel(
+    *,
+    provider_name: str,
+    prompt: str,
+    text: str,
+) -> str:
+    """Guarantee the Touchstone sentinel when the caller requested it.
+
+    Invariant: if the input prompt contains the Touchstone sentinel contract,
+    the returned text has exactly one standalone sentinel line, and it is the
+    final non-empty line. Ambiguous provider output fails closed as BLOCKED.
+    """
+    if "CODEX_REVIEW_CLEAN" not in prompt:
+        return text
+
+    stripped = text.strip()
+    lines = stripped.splitlines()
+    sentinel_indexes: list[int] = []
+    for idx, line in enumerate(lines):
+        if _REVIEW_SENTINEL_RE.match(line):
+            sentinel_indexes.append(idx)
+
+    if len(sentinel_indexes) == 1 and sentinel_indexes[0] == len(lines) - 1:
+        return stripped
+
+    reason = "missing"
+    if sentinel_indexes:
+        reason = "misplaced" if len(sentinel_indexes) == 1 else "multiple"
+    print(
+        f"[conductor] {provider_name} review repaired {reason} "
+        f"Touchstone sentinel; appending {_SAFE_BLOCKED_SENTINEL}",
+        file=sys.stderr,
+    )
+    body_lines = [
+        line for line in lines if not _REVIEW_SENTINEL_RE.match(line)
+    ]
+    body = "\n".join(body_lines).rstrip()
+    if body:
+        return f"{body}\n{_SAFE_BLOCKED_SENTINEL}"
+    return _SAFE_BLOCKED_SENTINEL

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -320,6 +320,35 @@ def test_claude_review_uses_native_review_slash_command_read_only(mocker):
     assert response.text == "hello from claude"
 
 
+def test_claude_review_repairs_missing_requested_sentinel(mocker, capsys):
+    mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
+    fake = _FakePopen(
+        stdout_schedule=[
+            (
+                0,
+                json.dumps(
+                    {
+                        "result": "I found risky behavior but omitted the marker.",
+                        "usage": {},
+                    }
+                ),
+            )
+        ]
+    )
+    mocker.patch(
+        "conductor.providers.claude.subprocess.Popen",
+        side_effect=lambda args, **kwargs: fake,
+    )
+
+    response = ClaudeProvider().review("End with CODEX_REVIEW_CLEAN or BLOCKED.")
+
+    assert response.text.endswith("\nCODEX_REVIEW_BLOCKED")
+    assert "CODEX_REVIEW_CLEAN" not in response.text
+    assert "[conductor] claude review repaired missing Touchstone sentinel" in (
+        capsys.readouterr().err
+    )
+
+
 def test_claude_call_passes_resume_session_id_as_resume_flag(mocker):
     mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
     captured = mocker.patch(
@@ -869,6 +898,25 @@ def test_codex_review_uses_native_review_command(mocker):
     assert response.provider == "codex"
     assert response.model == "codex-review"
     assert response.text == "LGTM"
+
+
+def test_codex_review_repairs_missing_requested_sentinel(mocker, capsys):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    mocker.patch(
+        "conductor.providers.codex.subprocess.run",
+        return_value=_fake_completed(stdout="The changes need operator review.\n"),
+    )
+
+    response = CodexProvider().review(
+        "Return a final standalone CODEX_REVIEW_CLEAN or CODEX_REVIEW_BLOCKED line.",
+    )
+
+    assert response.text == (
+        "The changes need operator review.\nCODEX_REVIEW_BLOCKED"
+    )
+    assert "[conductor] codex review repaired missing Touchstone sentinel" in (
+        capsys.readouterr().err
+    )
 
 
 def test_codex_call_reads_output_backstop_when_ndjson_loses_agent_message(
@@ -1740,6 +1788,36 @@ def test_gemini_review_uses_code_review_extension_command(mocker, monkeypatch):
     assert fake.args[fake.args.index("--approval-mode") + 1] == "plan"
     assert response.provider == "gemini"
     assert response.text == "hello from gemini"
+
+
+def test_gemini_review_repairs_missing_requested_sentinel(
+    mocker,
+    monkeypatch,
+    capsys,
+):
+    mocker.patch("conductor.providers.gemini.shutil.which", return_value="/usr/bin/gemini")
+    _strip_gemini_auth_env(monkeypatch)
+    monkeypatch.setenv("GEMINI_API_KEY", "fake-key")
+    mocker.patch(
+        "conductor.providers.gemini.subprocess.run",
+        return_value=_fake_completed(stdout='[{"name":"code-review"}]'),
+    )
+    fake = _FakePopen(
+        stdout_schedule=[
+            (0, json.dumps({"response": "Plain review without the marker."}))
+        ]
+    )
+    mocker.patch(
+        "conductor.providers.gemini.subprocess.Popen",
+        side_effect=lambda args, **kwargs: fake,
+    )
+
+    response = GeminiProvider().review("End with CODEX_REVIEW_CLEAN or BLOCKED.")
+
+    assert response.text == "Plain review without the marker.\nCODEX_REVIEW_BLOCKED"
+    assert "[conductor] gemini review repaired missing Touchstone sentinel" in (
+        capsys.readouterr().err
+    )
 
 
 def test_gemini_call_with_resume_passes_resume_flag(mocker):


### PR DESCRIPTION
Codex/Claude/Gemini native review paths returned provider stdout verbatim,
so a clean review could ship without the requested CODEX_REVIEW_* sentinel
on the final line. Touchstone classified those as malformed-sentinel and,
in fail-closed mode, would block clean merges.

Add a shared review_contract helper that, when the input prompt contains
the Touchstone sentinel contract, asserts exactly one standalone sentinel
line at the end of the response. If the provider's output is missing,
misplaced, or duplicated, fall closed by appending CODEX_REVIEW_BLOCKED
and emitting a stderr warning. Never silently up-convert ambiguous output
to CODEX_REVIEW_CLEAN.

Apply the helper uniformly across codex, claude, and gemini review paths
per audit-weak-points methodology.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
