### PR TITLE
fix: enforce stall watchdog on codex review fallback (#119)

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -854,6 +854,7 @@ def _invoke_review_with_fallback(
     """Try native review providers in route order."""
     last_exc: Exception | None = None
     fallbacks: list[str] = []
+    failures: list[tuple[str, str]] = []
     candidates = list(decision.ranked)
 
     for idx, candidate in enumerate(candidates):
@@ -879,9 +880,11 @@ def _invoke_review_with_fallback(
             last_exc = e
             mark_outcome(candidate.name, "config")
             fallbacks.append(candidate.name)
+            failures.append((candidate.name, str(e)))
         except UnsupportedCapability as e:
             last_exc = e
             fallbacks.append(candidate.name)
+            failures.append((candidate.name, str(e)))
         except ProviderError as e:
             retryable, category = _is_retryable(e)
             if category == "rate-limit":
@@ -891,6 +894,7 @@ def _invoke_review_with_fallback(
             if not retryable:
                 raise
             fallbacks.append(candidate.name)
+            failures.append((candidate.name, str(e)))
 
         if idx + 1 < len(candidates) and not silent:
             click.echo(
@@ -900,6 +904,12 @@ def _invoke_review_with_fallback(
             )
 
     assert last_exc is not None
+    if failures:
+        details = "; ".join(
+            f"{name}: {message or type(last_exc).__name__}"
+            for name, message in failures
+        )
+        raise ProviderError(f"native review failed for all providers: {details}") from last_exc
     raise last_exc
 
 

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -220,7 +220,6 @@ class CodexProvider:
         title: str | None = None,
     ) -> CallResponse:
         """Run Codex's native code-review command."""
-        del max_stall_sec  # `codex review` is a single subprocess, not streamed.
         ok, reason = self._check_cli_path()
         if not ok:
             raise ProviderConfigError(reason or "codex not configured")
@@ -245,6 +244,11 @@ class CodexProvider:
         args.append("-")
 
         timeout = self._timeout_sec if timeout_sec is None else timeout_sec
+        effective_timeout = timeout
+        watchdog_timeout = False
+        if max_stall_sec is not None and (timeout is None or max_stall_sec < timeout):
+            effective_timeout = max_stall_sec
+            watchdog_timeout = True
         start = time.monotonic()
         try:
             result = subprocess.run(
@@ -252,11 +256,15 @@ class CodexProvider:
                 input=review_prompt,
                 capture_output=True,
                 text=True,
-                timeout=timeout,
+                timeout=effective_timeout,
                 cwd=cwd,
             )
         except subprocess.TimeoutExpired as e:
             elapsed = time.monotonic() - start
+            if watchdog_timeout:
+                raise ProviderStalledError(
+                    f"codex review stalled after {max_stall_sec:g}s with no stdout"
+                ) from e
             raise ProviderError(
                 f"codex review timed out after {elapsed:.0f}s"
             ) from e

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -919,6 +919,24 @@ def test_codex_review_repairs_missing_requested_sentinel(mocker, capsys):
     )
 
 
+def test_codex_review_stall_watchdog_fails_fast(mocker):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    captured_timeout: float | None = None
+
+    def fake_run(args, **kwargs):
+        nonlocal captured_timeout
+        captured_timeout = kwargs["timeout"]
+        raise subprocess.TimeoutExpired(cmd=args, timeout=kwargs["timeout"])
+
+    mocker.patch("conductor.providers.codex.subprocess.run", side_effect=fake_run)
+
+    with pytest.raises(ProviderStalledError) as exc:
+        CodexProvider().review("Review this.", timeout_sec=60, max_stall_sec=0.05)
+
+    assert captured_timeout == 0.05
+    assert "codex review stalled after 0.05s" in str(exc.value)
+
+
 def test_codex_call_reads_output_backstop_when_ndjson_loses_agent_message(
     mocker, monkeypatch, tmp_path
 ):

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -607,6 +607,39 @@ def test_review_auto_does_not_route_to_generic_code_review_tag_provider(mocker):
     assert "→ claude" in result.stderr
 
 
+def test_review_auto_exhausted_fallback_names_stalled_codex_and_claude(mocker):
+    from conductor.providers.interface import ProviderError, ProviderStalledError
+
+    _stub_all_configured(mocker, {"codex", "claude"})
+    mocker.patch.object(CodexProvider, "review_configured", return_value=(True, None))
+    mocker.patch.object(ClaudeProvider, "review_configured", return_value=(True, None))
+    mocker.patch.object(
+        CodexProvider,
+        "review",
+        side_effect=ProviderStalledError("codex review stalled after 0.05s"),
+    )
+    mocker.patch.object(
+        ClaudeProvider,
+        "review",
+        side_effect=ProviderError("claude review timed out after 1s"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "review",
+            "--auto",
+            "--brief",
+            "Review this merge using the project reviewer guide.",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "native review failed for all providers" in result.stderr
+    assert "codex review stalled after 0.05s" in result.stderr
+    assert "claude review timed out after 1s" in result.stderr
+
+
 def test_review_with_provider_without_native_review_errors():
     result = CliRunner().invoke(
         main,


### PR DESCRIPTION
CodexProvider.review() previously discarded max_stall_sec and ran the
subprocess with a single wall-clock timeout, so a Codex CLI hung at
startup or a model that produced no output kept the process alive until
the outer caller's timeout fired. In Touchstone's review cascade, that
meant the Claude→Codex fallback could stall silently for 5 minutes
before the outer 300s timeout killed it.

Bound the subprocess timeout by max_stall_sec when the caller passes a
shorter stall budget than the wall-clock timeout, and raise
ProviderStalledError on stall (retryable in the cascade) versus the
existing ProviderError on full-timeout.

Also fix the cascade's exhausted-fallback error to name every failed
provider rather than only the last one, so an operator sees the full
chain in fail-closed mode.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
