### PR TITLE
fix: unwrap Gemini review JSON envelope and cover plain-text fallback (#120)

### DIFF
--- a/src/conductor/providers/gemini.py
+++ b/src/conductor/providers/gemini.py
@@ -16,6 +16,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -71,6 +72,26 @@ GEMINI_AUTH_ENV_VARS = (
 # Default OAuth credentials file written by the CLI's first-run browser
 # flow. Override per-instance via the constructor for tests.
 GEMINI_DEFAULT_OAUTH_CREDS_PATH = Path.home() / ".gemini" / "oauth_creds.json"
+
+
+def _extract_review_response_text(response: object) -> str:
+    if not isinstance(response, str):
+        return ""
+    stripped = response.strip()
+    if not stripped:
+        return response
+    try:
+        inner = json.loads(stripped)
+    except json.JSONDecodeError:
+        return response
+    if isinstance(inner, dict) and isinstance(inner.get("response"), str):
+        print(
+            "[conductor] gemini review repaired JSON response envelope; "
+            "extracting inner response text",
+            file=sys.stderr,
+        )
+        return inner["response"]
+    return response
 
 
 class GeminiProvider:
@@ -338,8 +359,13 @@ class GeminiProvider:
         except json.JSONDecodeError:
             if not stdout:
                 raise ProviderHTTPError("gemini review produced empty stdout") from None
-            return CallResponse(
+            content = ensure_requested_review_sentinel(
+                provider_name=self.name,
+                prompt=prompt,
                 text=stdout,
+            )
+            return CallResponse(
+                text=content,
                 provider=self.name,
                 model=model,
                 duration_ms=duration_ms,
@@ -355,10 +381,11 @@ class GeminiProvider:
                 auth_prompts=tracker.prompts or None,
             )
 
+        content = _extract_review_response_text(data.get("response", ""))
         content = ensure_requested_review_sentinel(
             provider_name=self.name,
             prompt=prompt,
-            text=data.get("response", ""),
+            text=content,
         )
         input_tokens, output_tokens = self._sum_usage(data)
         session_id = (

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -1838,6 +1838,48 @@ def test_gemini_review_repairs_missing_requested_sentinel(
     )
 
 
+def test_gemini_review_extracts_inner_json_response_and_preserves_sentinel(
+    mocker,
+    monkeypatch,
+    capsys,
+):
+    mocker.patch("conductor.providers.gemini.shutil.which", return_value="/usr/bin/gemini")
+    _strip_gemini_auth_env(monkeypatch)
+    monkeypatch.setenv("GEMINI_API_KEY", "fake-key")
+    mocker.patch(
+        "conductor.providers.gemini.subprocess.run",
+        return_value=_fake_completed(stdout='[{"name":"code-review"}]'),
+    )
+    outer = {
+        "response": json.dumps(
+            {
+                "response": (
+                    "The submitted code follows the requested contract.\n"
+                    "CODEX_REVIEW_CLEAN"
+                )
+            }
+        ),
+        "stats": {},
+    }
+    fake = _FakePopen(stdout_schedule=[(0, json.dumps(outer))])
+    mocker.patch(
+        "conductor.providers.gemini.subprocess.Popen",
+        side_effect=lambda args, **kwargs: fake,
+    )
+
+    response = GeminiProvider().review(
+        "End with CODEX_REVIEW_CLEAN or CODEX_REVIEW_BLOCKED."
+    )
+
+    assert response.text == (
+        "The submitted code follows the requested contract.\nCODEX_REVIEW_CLEAN"
+    )
+    assert response.text.lstrip()[0] != "{"
+    assert "[conductor] gemini review repaired JSON response envelope" in (
+        capsys.readouterr().err
+    )
+
+
 def test_gemini_call_with_resume_passes_resume_flag(mocker):
     mocker.patch("conductor.providers.gemini.shutil.which", return_value="/usr/bin/gemini")
     captured = mocker.patch(

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -640,6 +640,32 @@ def test_review_auto_exhausted_fallback_names_stalled_codex_and_claude(mocker):
     assert "claude review timed out after 1s" in result.stderr
 
 
+def test_review_with_gemini_emits_plain_text_without_json_envelope(mocker):
+    _stub_all_configured(mocker, {"gemini"})
+    mocker.patch.object(GeminiProvider, "review_configured", return_value=(True, None))
+    mocker.patch.object(
+        GeminiProvider,
+        "review",
+        return_value=CallResponse(
+            text="Plain review\nCODEX_REVIEW_CLEAN",
+            provider="gemini",
+            model="gemini-2.5-pro",
+            duration_ms=10,
+            usage={},
+            raw={"response": "{\"response\": \"Plain review\\nCODEX_REVIEW_CLEAN\"}"},
+        ),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["review", "--with", "gemini", "--brief", "End with CODEX_REVIEW_CLEAN."],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.stdout == "Plain review\nCODEX_REVIEW_CLEAN\n"
+    assert not result.stdout.lstrip().startswith("{")
+
+
 def test_review_with_provider_without_native_review_errors():
     result = CliRunner().invoke(
         main,


### PR DESCRIPTION
The Gemini Code Review extension wraps its model response in a JSON
envelope under "response", and a JSON-shaped string can also appear
inside that "response" value. Conductor was passing the outer "response"
through verbatim as CallResponse.text, so a successful review surfaced
to Touchstone's hook as raw JSON and was classified as malformed-sentinel.

When the inner string parses as JSON containing a "response" field,
extract that inner text before applying the sentinel contract, and emit
a stderr note. This preserves --json semantics at the CLI boundary;
only the response text changes.

Also extend the sentinel repair to Gemini's JSONDecodeError fallback,
which previously returned plain stdout verbatim (flagged on PR #121
review). Per audit-weak-points, all gemini review return paths now
honor the contract uniformly.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
