### PR TITLE
fix: sweep — exec watchdog, list readiness, OpenRouter shortlist, review chain

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -52,6 +52,7 @@ from conductor.providers import (
     get_provider,
     known_providers,
 )
+from conductor.providers.review_contract import build_review_task_prompt
 from conductor.router import (
     VALID_PREFER_MODES,
     InvalidRouterRequest,
@@ -97,7 +98,7 @@ GIT_RECOVERY_COMMAND_TIMEOUT_SEC = 2.0
 GIT_RECOVERY_MAX_COMMITS = 5
 GIT_RECOVERY_MAX_STATUS_PATHS = 8
 NATIVE_REVIEW_TAG = "code-review"
-NATIVE_REVIEW_PRIORITY = ("codex", "claude", "gemini")
+DEFAULT_REVIEW_MAX_FALLBACKS = 3
 DEFAULT_COUNCIL_ROUNDS = 1
 
 
@@ -388,6 +389,23 @@ def _is_retryable(err: Exception) -> tuple[bool, str]:
     return False, "other"
 
 
+def _review_failure_mode(err: Exception) -> str:
+    if isinstance(err, ProviderStalledError):
+        return "stall"
+    _retryable, category = _is_retryable(err)
+    return category
+
+
+def _format_tried_providers(tried: list[tuple[str, str]]) -> str:
+    return ", ".join(f"{name} ({mode})" for name, mode in tried)
+
+
+def _validate_max_fallbacks(raw: int) -> int:
+    if raw < 1:
+        raise click.UsageError(f"--max-fallbacks must be >= 1, got {raw}")
+    return raw
+
+
 def _ollama_index(candidates: list) -> int | None:
     """Return the index of ollama in ``candidates`` (or None if absent)."""
     for i, c in enumerate(candidates):
@@ -439,7 +457,7 @@ def _review_provider_or_none(provider_or_name) -> NativeReviewProvider | None:
 def _review_exclude_set(
     user_exclude: frozenset[str],
 ) -> tuple[frozenset[str], dict[str, str]]:
-    """Return router excludes needed to keep review routing native-only."""
+    """Return router excludes needed to keep review routing code-review-only."""
     excludes = set(user_exclude)
     reasons: dict[str, str] = {}
     for name in known_providers():
@@ -452,21 +470,23 @@ def _review_exclude_set(
             excludes.add(name)
             reasons[name] = str(e)
             continue
-        if not isinstance(provider, NativeReviewProvider):
+        if NATIVE_REVIEW_TAG not in provider.tags:
             excludes.add(name)
-            reasons[name] = "provider has no native code-review entrypoint"
+            reasons[name] = "provider is not tagged code-review"
             continue
-        ok, reason = provider.review_configured()
+        ok, reason = provider.review_configured() if isinstance(
+            provider, NativeReviewProvider
+        ) else provider.configured()
         if not ok:
             excludes.add(name)
-            reasons[name] = reason or "native review is not configured"
+            reasons[name] = reason or "code-review provider is not configured"
     return frozenset(excludes), reasons
 
 
 def _native_review_unavailable_message(reasons: dict[str, str]) -> str:
     if not reasons:
-        return "no native review provider is available."
-    lines = ["no native review provider is available:"]
+        return "no code-review provider is available."
+    lines = ["no code-review provider is available:"]
     for name in sorted(reasons):
         lines.append(f"  - {name}: {reasons[name]}")
     return "\n".join(lines)
@@ -850,41 +870,72 @@ def _invoke_review_with_fallback(
     uncommitted: bool,
     title: str | None,
     silent: bool,
+    max_fallbacks: int = DEFAULT_REVIEW_MAX_FALLBACKS,
 ) -> tuple[CallResponse, list[str]]:
-    """Try native review providers in route order."""
+    """Try code-review providers in route order."""
     last_exc: Exception | None = None
     fallbacks: list[str] = []
-    failures: list[tuple[str, str]] = []
-    candidates = list(decision.ranked)
+    tried: list[tuple[str, str]] = []
+    candidates = list(decision.ranked[:max_fallbacks])
 
     for idx, candidate in enumerate(candidates):
-        provider = _review_provider_or_none(candidate.name)
-        if provider is None:
-            fallbacks.append(candidate.name)
-            continue
+        provider = get_provider(candidate.name)
         try:
-            response = provider.review(
-                task,
-                effort=effort,
-                cwd=cwd,
-                timeout_sec=timeout_sec,
-                max_stall_sec=max_stall_sec,
-                base=base,
-                commit=commit,
-                uncommitted=uncommitted,
-                title=title,
-            )
+            if isinstance(provider, NativeReviewProvider):
+                response = provider.review(
+                    task,
+                    effort=effort,
+                    cwd=cwd,
+                    timeout_sec=timeout_sec,
+                    max_stall_sec=max_stall_sec,
+                    base=base,
+                    commit=commit,
+                    uncommitted=uncommitted,
+                    title=title,
+                )
+            elif isinstance(provider, OpenRouterProvider):
+                response = provider.call(
+                    build_review_task_prompt(
+                        task,
+                        base=base,
+                        commit=commit,
+                        uncommitted=uncommitted,
+                        title=title,
+                    ),
+                    effort=effort,
+                    task_tags=list(decision.task_tags),
+                    prefer=decision.prefer,
+                    log_selection=not silent,
+                )
+            else:
+                response = provider.call(
+                    build_review_task_prompt(
+                        task,
+                        base=base,
+                        commit=commit,
+                        uncommitted=uncommitted,
+                        title=title,
+                    ),
+                    effort=effort,
+                )
             mark_outcome(candidate.name, "success")
+            tried.append((candidate.name, "success"))
+            if not silent and len(tried) > 1:
+                click.echo(
+                    f"[conductor] review tried providers: "
+                    f"{_format_tried_providers(tried)}",
+                    err=True,
+                )
             return response, fallbacks
         except ProviderConfigError as e:
             last_exc = e
             mark_outcome(candidate.name, "config")
             fallbacks.append(candidate.name)
-            failures.append((candidate.name, str(e)))
+            tried.append((candidate.name, "config"))
         except UnsupportedCapability as e:
             last_exc = e
             fallbacks.append(candidate.name)
-            failures.append((candidate.name, str(e)))
+            tried.append((candidate.name, "unsupported"))
         except ProviderError as e:
             retryable, category = _is_retryable(e)
             if category == "rate-limit":
@@ -894,22 +945,26 @@ def _invoke_review_with_fallback(
             if not retryable:
                 raise
             fallbacks.append(candidate.name)
-            failures.append((candidate.name, str(e)))
+            tried.append((candidate.name, _review_failure_mode(e)))
 
         if idx + 1 < len(candidates) and not silent:
             click.echo(
-                f"[conductor] {candidate.name} review failed · "
+                f"[conductor] {candidate.name} review failed ({tried[-1][1]}) · "
                 f"falling back → {candidates[idx + 1].name}",
                 err=True,
             )
 
     assert last_exc is not None
-    if failures:
-        details = "; ".join(
-            f"{name}: {message or type(last_exc).__name__}"
-            for name, message in failures
+    if tried:
+        trail = _format_tried_providers(tried)
+        hint = (
+            "increase --max-fallbacks, exclude failing providers, or run "
+            "`conductor list` to check configured code-review providers"
         )
-        raise ProviderError(f"native review failed for all providers: {details}") from last_exc
+        raise ProviderError(
+            "code review failed for all tried providers: "
+            f"{trail}. Next step: {hint}."
+        ) from last_exc
     raise last_exc
 
 
@@ -1600,7 +1655,7 @@ def ask(
 
     if plan.mode == "review":
         review_exclude, review_reasons = _review_exclude_set(
-            _semantic_candidate_exclude_set(plan, frozenset())
+            frozenset()
         )
         try:
             _provider, decision = pick(
@@ -1608,7 +1663,6 @@ def ask(
                 prefer=plan.prefer,
                 effort=effort_value,
                 exclude=review_exclude,
-                priority=_semantic_priority(plan) or NATIVE_REVIEW_PRIORITY,
                 shadow=True,
             )
         except (NoConfiguredProvider, InvalidRouterRequest, MutedProvidersError) as e:
@@ -2059,6 +2113,15 @@ def call(
     ),
 )
 @click.option(
+    "--max-fallbacks",
+    default=DEFAULT_REVIEW_MAX_FALLBACKS,
+    type=int,
+    help=(
+        "Maximum code-review providers to try in total for --auto review "
+        f"(default: {DEFAULT_REVIEW_MAX_FALLBACKS})."
+    ),
+)
+@click.option(
     "--base",
     default=None,
     help="Review changes against this base branch/ref.",
@@ -2129,6 +2192,7 @@ def review(
     cwd: str | None,
     timeout_sec: int | None,
     max_stall_sec: int | None,
+    max_fallbacks: int,
     base: str | None,
     commit: str | None,
     uncommitted: bool,
@@ -2182,6 +2246,7 @@ def review(
     body = brief_input.body
     effort_value = _parse_effort(effort)
     max_stall_sec = _normalize_max_stall_sec(max_stall_sec)
+    max_fallbacks = _validate_max_fallbacks(max_fallbacks)
     prefer_value = _validate_prefer(prefer) if prefer is not None else "best"
 
     decision: RouteDecision | None = None
@@ -2194,7 +2259,6 @@ def review(
                 prefer=prefer_value,
                 effort=effort_value,
                 exclude=review_exclude,
-                priority=NATIVE_REVIEW_PRIORITY,
                 shadow=True,
             )
         except (NoConfiguredProvider, InvalidRouterRequest, MutedProvidersError) as e:
@@ -2216,6 +2280,7 @@ def review(
                 uncommitted=uncommitted,
                 title=title,
                 silent=silent_route or as_json,
+                max_fallbacks=max_fallbacks,
             )
         except ProviderConfigError as e:
             click.echo(f"conductor: {e}", err=True)

--- a/src/conductor/providers/cli_auth.py
+++ b/src/conductor/providers/cli_auth.py
@@ -209,11 +209,12 @@ def run_subprocess_with_live_stderr(
 
     def read_stream(name: str, pipe) -> None:
         try:
+            read = getattr(pipe, "read", None)
             while True:
-                line = pipe.readline()
-                if line == "":
+                chunk = read(1) if read is not None else pipe.readline()
+                if chunk == "":
                     break
-                stream_q.put((name, line))
+                stream_q.put((name, chunk))
         finally:
             stream_q.put((name, None))
 

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -20,6 +20,7 @@ import queue
 import shutil
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 import uuid
@@ -45,6 +46,7 @@ if TYPE_CHECKING:
 CODEX_DEFAULT_MODEL = "gpt-5.4"
 CODEX_REVIEW_MODEL = "codex-review"
 CODEX_REQUEST_TIMEOUT_SEC = 180.0
+CODEX_STARTUP_PROBE_TIMEOUT_SEC = 8.0
 
 # Sentinel distinguishing "caller didn't specify a timeout" from "caller
 # explicitly asked for no timeout (None)". The constructor default applies
@@ -115,9 +117,11 @@ class CodexProvider:
         *,
         cli_command: str = "codex",
         timeout_sec: float = CODEX_REQUEST_TIMEOUT_SEC,
+        startup_probe_timeout_sec: float = CODEX_STARTUP_PROBE_TIMEOUT_SEC,
     ) -> None:
         self._cli = cli_command
         self._timeout_sec = timeout_sec
+        self._startup_probe_timeout_sec = startup_probe_timeout_sec
 
     def _check_cli_path(self) -> tuple[bool, str | None]:
         """Cheap PATH-only check (no subprocess) for the call/exec hot path."""
@@ -155,11 +159,73 @@ class CodexProvider:
             "for non-interactive use."
         )
 
+    @staticmethod
+    def _timeout_output(e: subprocess.TimeoutExpired) -> str:
+        stdout = e.stdout or e.output or ""
+        stderr = e.stderr or ""
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode("utf-8", errors="replace")
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode("utf-8", errors="replace")
+        return (stderr or stdout).strip()
+
+    def _startup_probe(self) -> tuple[bool, str | None]:
+        """Run the same codex exec startup path used by call().
+
+        PATH and auth probes can pass while codex wedges before it emits any
+        NDJSON, notably in the CLI's models-manager startup. This bounded
+        probe keeps `conductor list` aligned with the path users actually run.
+        """
+        with tempfile.TemporaryDirectory(prefix="conductor-codex-probe-") as tmpdir:
+            output_path = Path(tmpdir) / "output.json"
+            args = [
+                self._cli,
+                "exec",
+                "-",
+                "--json",
+                "-o",
+                str(output_path),
+                "--ephemeral",
+                "--sandbox",
+                "read-only",
+                "-c",
+                "model_reasoning_effort=minimal",
+            ]
+            try:
+                result = subprocess.run(
+                    args,
+                    input="Reply with OK.",
+                    capture_output=True,
+                    text=True,
+                    timeout=self._startup_probe_timeout_sec,
+                )
+            except subprocess.TimeoutExpired as e:
+                detail = self._timeout_output(e)
+                reason = (
+                    f"`{self._cli} exec` startup probe timed out after "
+                    f"{self._startup_probe_timeout_sec:.0f}s"
+                )
+                if detail:
+                    reason = f"{reason}: {detail[:200]}"
+                return False, reason
+            except (FileNotFoundError, OSError) as e:
+                return False, f"could not run `{self._cli} exec` startup probe: {e}"
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout).strip()
+            return False, (
+                f"`{self._cli} exec` startup probe exited {result.returncode}: "
+                f"{detail[:200]}"
+            )
+        return True, None
+
     def configured(self) -> tuple[bool, str | None]:
         ok, reason = self._check_cli_path()
         if not ok:
             return False, reason
-        return self._auth_probe()
+        ok, reason = self._auth_probe()
+        if not ok:
+            return False, reason
+        return self._startup_probe()
 
     def smoke(self) -> tuple[bool, str | None]:
         ok, reason = self.configured()

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -739,19 +739,21 @@ class CodexProvider:
         def read_stdout() -> None:
             assert process.stdout is not None
             try:
+                read = getattr(process.stdout, "read", None)
                 while True:
-                    line = process.stdout.readline()
-                    if line == "":
+                    chunk = read(1) if read is not None else process.stdout.readline()
+                    if chunk == "":
                         break
-                    stream_q.put(("stdout", line))
+                    stream_q.put(("stdout", chunk))
             finally:
                 stream_q.put(("stdout", None))
 
         def read_stderr() -> None:
             assert process.stderr is not None
             try:
+                read = getattr(process.stderr, "read", None)
                 while True:
-                    chunk = process.stderr.readline()
+                    chunk = read(1) if read is not None else process.stderr.readline()
                     if chunk == "":
                         break
                     stream_q.put(("stderr", chunk))
@@ -769,6 +771,7 @@ class CodexProvider:
         last_liveness = start
         heartbeat_log_offset = 0
         session_id_emitted = False
+        stdout_event_buffer = ""
         while True:
             now = time.monotonic()
             if timeout is not None and now - start > timeout:
@@ -872,17 +875,21 @@ class CodexProvider:
             stdout_parts.append(item)
             last_output = time.monotonic()
             last_liveness = last_output
-            auth_tracker.observe_json_line(item, source="stdout")
-            self._emit_stream_event(item, session_log=session_log)
+            stdout_event_buffer += item
+            while "\n" in stdout_event_buffer:
+                line, stdout_event_buffer = stdout_event_buffer.split("\n", 1)
+                line = f"{line}\n"
+                auth_tracker.observe_json_line(line, source="stdout")
+                self._emit_stream_event(line, session_log=session_log)
 
-            if not session_id_emitted:
-                sid = self._extract_session_id_fast(item)
-                if sid is not None:
-                    if session_log is not None:
-                        session_log.set_session_id(sid)
-                    sys.stderr.write(f"[conductor] codex session_id={sid}\n")
-                    sys.stderr.flush()
-                    session_id_emitted = True
+                if not session_id_emitted:
+                    sid = self._extract_session_id_fast(line)
+                    if sid is not None:
+                        if session_log is not None:
+                            session_log.set_session_id(sid)
+                        sys.stderr.write(f"[conductor] codex session_id={sid}\n")
+                        sys.stderr.flush()
+                        session_id_emitted = True
 
         returncode = process.wait()
         self._join_reader_threads(stdout_thread, stderr_thread)

--- a/src/conductor/providers/openrouter.py
+++ b/src/conductor/providers/openrouter.py
@@ -556,8 +556,14 @@ def select_model_for_task(
 
     task_tag_set = set(task_tags or [])
     exclude_set = set(exclude or ())
+    catalog = openrouter_catalog.load_catalog(
+        force_refresh=True,
+        allow_stale_on_error=False,
+    )
+    catalog_ids = {entry.id for entry in catalog}
     candidates = []
-    for entry in openrouter_catalog.load_catalog():
+    dropped = []
+    for entry in catalog:
         if entry.id in exclude_set:
             continue
         if {"strong-reasoning", "thinking"} & task_tag_set and not entry.supports_thinking:
@@ -568,13 +574,19 @@ def select_model_for_task(
             continue
         if "long-context" in task_tag_set and entry.context_length < 100_000:
             continue
+        if not _is_sendable_openrouter_model_id(entry.id, catalog_ids):
+            dropped.append(entry.id)
+            continue
         candidates.append(entry)
 
     if not candidates:
         raise ProviderError(
-            "OpenRouter selector found no models matching "
-            f"tags={sorted(task_tag_set)} exclude={sorted(exclude_set)}. "
-            "Run `conductor models refresh` or choose `--model` explicitly."
+            _empty_selector_message(
+                task_tags=task_tag_set,
+                exclude=exclude_set,
+                catalog=catalog,
+                dropped=dropped,
+            )
         )
 
     ranked = sorted(candidates, key=_catalog_cost_sort_key)
@@ -602,6 +614,50 @@ def _catalog_recency_sort_key(
     entry: openrouter_catalog.ModelEntry,
 ) -> tuple[int, float, str]:
     return (-entry.created, entry.total_price_per_1k, entry.id)
+
+
+def _is_sendable_openrouter_model_id(model_id: str, catalog_ids: set[str]) -> bool:
+    """Return whether ``model_id`` is valid for OpenRouter request restrictions.
+
+    OpenRouter exposes ``~provider/family-latest`` pages as moving aliases. Those
+    aliases are useful policy labels, but they have caused 404s when sent inside
+    the auto-router ``allowed_models`` restriction list. The selector therefore
+    only sends concrete catalog IDs, and a request-time catalog refresh drops
+    slugs that no longer exist.
+    """
+    return model_id in catalog_ids and not model_id.startswith("~")
+
+
+def _empty_selector_message(
+    *,
+    task_tags: set[str],
+    exclude: set[str],
+    catalog: list[openrouter_catalog.ModelEntry],
+    dropped: list[str],
+) -> str:
+    catalog_ids = {model.id for model in catalog}
+    sendable_examples = [
+        entry.id
+        for entry in catalog
+        if _is_sendable_openrouter_model_id(entry.id, catalog_ids)
+    ][:8]
+    parts = [
+        "OpenRouter selector found no sendable models after catalog validation.",
+        f"tags filtered to empty: {sorted(task_tags)}",
+        f"excluded models: {sorted(exclude)}",
+        "configured provider: openrouter",
+        f"catalog models available: {len(catalog)}",
+    ]
+    if sendable_examples:
+        parts.append(f"available model examples: {sendable_examples}")
+    if dropped:
+        parts.append(f"dropped invalid aliases/stale slugs: {sorted(dropped)[:8]}")
+    parts.append(
+        "Broaden the request by removing tags such as --tags thinking,long-context, "
+        "run `conductor models refresh`, or choose a concrete `--model` from "
+        "`conductor models list`."
+    )
+    return " ".join(parts)
 
 
 def _reasoning_payload(effort: str | int) -> dict[str, str] | None:

--- a/src/conductor/providers/openrouter_catalog.py
+++ b/src/conductor/providers/openrouter_catalog.py
@@ -2,7 +2,10 @@
 
 The catalog is derived state. We persist it only as a time-bounded cache so
 selection can run without hard-coded model slugs and without an HTTP round-trip
- on every call. `conductor models refresh` is the explicit rebuild path.
+on every call. `conductor models refresh` is the explicit rebuild path. The
+OpenRouter auto-selector requires a live refresh before building request
+restrictions; stale cache fallback is reserved for listing and compatibility
+shims where a stale model is better than losing the whole command.
 """
 
 from __future__ import annotations
@@ -114,11 +117,22 @@ def read_cached_catalog() -> CatalogSnapshot | None:
     return CatalogSnapshot(fetched_at=fetched_at, models=models)
 
 
-def load_catalog(force_refresh: bool = False) -> list[ModelEntry]:
-    return load_catalog_snapshot(force_refresh=force_refresh).models
+def load_catalog(
+    force_refresh: bool = False,
+    *,
+    allow_stale_on_error: bool = True,
+) -> list[ModelEntry]:
+    return load_catalog_snapshot(
+        force_refresh=force_refresh,
+        allow_stale_on_error=allow_stale_on_error,
+    ).models
 
 
-def load_catalog_snapshot(force_refresh: bool = False) -> CatalogSnapshot:
+def load_catalog_snapshot(
+    force_refresh: bool = False,
+    *,
+    allow_stale_on_error: bool = True,
+) -> CatalogSnapshot:
     cached = _read_cached_catalog_for_load()
     if cached is not None and not force_refresh and _is_fresh(cached):
         return cached
@@ -128,7 +142,7 @@ def load_catalog_snapshot(force_refresh: bool = False) -> CatalogSnapshot:
         _write_cache(fresh)
         return fresh
     except ProviderHTTPError as e:
-        if cached is None:
+        if cached is None or not allow_stale_on_error:
             raise
         print(
             "[conductor] OpenRouter catalog refresh failed; "

--- a/src/conductor/providers/review_contract.py
+++ b/src/conductor/providers/review_contract.py
@@ -9,6 +9,33 @@ _REVIEW_SENTINEL_RE = re.compile(r"^\s*(CODEX_REVIEW_(?:CLEAN|FIXED|BLOCKED))\s*
 _SAFE_BLOCKED_SENTINEL = "CODEX_REVIEW_BLOCKED"
 
 
+def build_review_task_prompt(
+    task: str,
+    *,
+    base: str | None,
+    commit: str | None,
+    uncommitted: bool,
+    title: str | None,
+) -> str:
+    """Attach review target metadata to a generic provider prompt.
+
+    Invariant: fallback reviewers receive the same target selection data that
+    native review providers receive through their own prompt builders.
+    """
+    target_lines: list[str] = []
+    if base:
+        target_lines.append(f"- Review changes against base branch/ref: {base}")
+    if commit:
+        target_lines.append(f"- Review commit: {commit}")
+    if uncommitted:
+        target_lines.append("- Include staged, unstaged, and untracked changes.")
+    if title:
+        target_lines.append(f"- Review title: {title}")
+    if not target_lines:
+        return task
+    return "Review target:\n" + "\n".join(target_lines) + "\n\n" + task
+
+
 def ensure_requested_review_sentinel(
     *,
     provider_name: str,

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -859,6 +859,42 @@ def test_codex_configured_false_when_auth_probe_times_out(mocker):
     assert "could not verify" in reason
 
 
+def test_codex_configured_false_when_exec_startup_probe_times_out(mocker):
+    """Regression for #125: PATH + auth are not enough readiness.
+
+    `conductor list` renders provider.configured(); codex must only report
+    ready when the real `codex exec` startup path also completes inside a
+    bounded timeout.
+    """
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+
+    def run(args, **kwargs):
+        if args == ["codex", "login", "status"]:
+            return _fake_completed(stdout="Logged in using ChatGPT")
+        if args[:3] == ["codex", "exec", "-"]:
+            raise subprocess.TimeoutExpired(
+                cmd=args,
+                timeout=kwargs["timeout"],
+                stderr=(
+                    "codex_models_manager: failed to refresh available models: "
+                    "timeout waiting for child process to exit"
+                ),
+            )
+        raise AssertionError(f"unexpected command: {args!r}")
+
+    captured = mocker.patch("conductor.providers.codex.subprocess.run", side_effect=run)
+
+    ok, reason = CodexProvider(startup_probe_timeout_sec=8).configured()
+
+    assert ok is False
+    assert "`codex exec` startup probe timed out after 8s" in reason
+    assert "codex_models_manager" in reason
+    startup_call = captured.call_args_list[1]
+    assert startup_call.args[0][:3] == ["codex", "exec", "-"]
+    assert startup_call.kwargs["timeout"] == 8
+    assert startup_call.kwargs["input"] == "Reply with OK."
+
+
 def test_codex_call_parses_ndjson_and_usage(mocker):
     mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
     mocker.patch(

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -729,6 +729,11 @@ class _FakeScheduledPipe:
             self._on_eof()
         return ""
 
+    def read(self, size: int = -1) -> str:
+        if size == 0:
+            return ""
+        return self.readline()
+
 
 class _FakePopen:
     def __init__(
@@ -1231,6 +1236,22 @@ def test_codex_exec_emits_liveness_signal_to_stderr(mocker, capsys):
         CodexProvider().exec("hi", max_stall_sec=0.25, liveness_interval_sec=0.1)
 
     assert "[conductor] no output from codex for " in capsys.readouterr().err
+
+
+def test_codex_exec_stall_watchdog_ignores_wrapper_heartbeats(mocker, capsys):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    fake = _FakePopen(stdout_schedule=[], hang_after_stdout=True)
+    _patch_codex_popen(mocker, fake)
+
+    with pytest.raises(ProviderStalledError) as exc:
+        CodexProvider().exec("hi", max_stall_sec=0.25, liveness_interval_sec=0.1)
+
+    err = capsys.readouterr().err
+    msg = str(exc.value)
+    assert "[conductor] no output from codex for " in err
+    assert "codex CLI stalled" in msg
+    assert "timed out" not in msg
+    assert fake.terminated is True
 
 
 def test_codex_exec_heartbeat_reports_tool_calls_from_session_log(

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -554,7 +554,7 @@ def test_ask_council_rejects_offline():
 # ---------------------------------------------------------------------------
 
 
-def test_review_auto_routes_to_codex_native_review_by_default(mocker):
+def test_review_auto_routes_by_router_tag_order(mocker):
     _stub_all_configured(mocker, {"codex", "claude"})
     mocker.patch.object(CodexProvider, "review_configured", return_value=(True, None))
     mocker.patch.object(ClaudeProvider, "review_configured", return_value=(True, None))
@@ -582,10 +582,10 @@ def test_review_auto_routes_to_codex_native_review_by_default(mocker):
     )
 
     assert result.exit_code == 0, result.output
-    assert review_mock.called
-    assert not claude_review.called
-    assert review_mock.call_args.kwargs["base"] == "origin/main"
-    assert "→ codex" in result.stderr
+    assert claude_review.called
+    assert not review_mock.called
+    assert claude_review.call_args.kwargs["base"] == "origin/main"
+    assert "→ claude" in result.stderr
 
 
 def test_review_auto_does_not_route_to_generic_code_review_tag_provider(mocker):
@@ -635,9 +635,8 @@ def test_review_auto_exhausted_fallback_names_stalled_codex_and_claude(mocker):
     )
 
     assert result.exit_code == 1
-    assert "native review failed for all providers" in result.stderr
-    assert "codex review stalled after 0.05s" in result.stderr
-    assert "claude review timed out after 1s" in result.stderr
+    assert "code review failed for all tried providers" in result.stderr
+    assert "claude (timeout), codex (stall)" in result.stderr
 
 
 def test_review_with_gemini_emits_plain_text_without_json_envelope(mocker):

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -106,6 +106,11 @@ class _FakeScheduledPipe:
             self._on_eof = None
         return ""
 
+    def read(self, size: int = -1) -> str:
+        if size == 0:
+            return ""
+        return self.readline()
+
 
 class _FakePopen:
     def __init__(self, *, stdout_lines, stderr_lines=None, returncode: int = 0) -> None:

--- a/tests/test_openrouter.py
+++ b/tests/test_openrouter.py
@@ -8,10 +8,12 @@ import httpx
 import pytest
 import respx
 
+import conductor.providers.openrouter_catalog as openrouter_catalog
 from conductor.providers.deepseek import DeepSeekChatProvider, DeepSeekReasonerProvider
 from conductor.providers.interface import (
     CallResponse,
     ProviderConfigError,
+    ProviderError,
     UnsupportedCapability,
 )
 from conductor.providers.kimi import KimiProvider
@@ -106,7 +108,10 @@ def test_smoke_returns_true_on_well_formed_response(configured):
         "choices": [{"message": {"content": "pong"}}],
         "usage": {},
     }
-    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+    with respx.mock(
+        base_url="https://openrouter.ai/api/v1",
+        assert_all_called=False,
+    ) as router:
         router.post("/chat/completions").mock(
             return_value=httpx.Response(200, json=body)
         )
@@ -203,7 +208,10 @@ def test_call_sends_reasoning_effort_and_openrouter_headers(configured):
             },
         )
 
-    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+    with respx.mock(
+        base_url="https://openrouter.ai/api/v1",
+        assert_all_called=False,
+    ) as router:
         router.post("/chat/completions").mock(side_effect=_record)
         OpenRouterProvider().call("hi", model="anthropic/claude-sonnet-4", effort="max")
 
@@ -304,6 +312,48 @@ def test_call_without_model_invokes_selector_and_builds_payload(configured, mock
         "reasoning": {"effort": "medium"},
     }
     assert response.model == "google/gemini-flash-1.5"
+
+
+def test_call_fails_locally_when_validated_shortlist_is_empty(configured, mocker):
+    alias_only_catalog = [
+        openrouter_catalog.ModelEntry(
+            id="~anthropic/claude-haiku-latest",
+            name="Anthropic Claude Haiku Latest",
+            created=500,
+            context_length=200_000,
+            pricing_prompt=0.001,
+            pricing_completion=0.005,
+            pricing_thinking=0.001,
+            supports_thinking=True,
+            supports_tools=True,
+            supports_vision=True,
+        )
+    ]
+    mocker.patch(
+        "conductor.providers.openrouter_catalog.load_catalog",
+        return_value=alias_only_catalog,
+    )
+
+    with respx.mock(
+        base_url="https://openrouter.ai/api/v1",
+        assert_all_called=False,
+    ) as router:
+        chat_route = router.post("/chat/completions").mock(
+            return_value=httpx.Response(500, text="should not be called")
+        )
+        with pytest.raises(ProviderError) as excinfo:
+            OpenRouterProvider().call(
+                "hi",
+                task_tags=["long-context", "thinking"],
+                prefer="balanced",
+            )
+
+    message = str(excinfo.value)
+    assert "found no sendable models after catalog validation" in message
+    assert "tags filtered to empty: ['long-context', 'thinking']" in message
+    assert "configured provider: openrouter" in message
+    assert "dropped invalid aliases/stale slugs" in message
+    assert chat_route.call_count == 0
 
 
 def test_exec_with_tools_runs_openai_tool_loop(configured, tmp_path):

--- a/tests/test_openrouter_catalog.py
+++ b/tests/test_openrouter_catalog.py
@@ -136,6 +136,19 @@ def test_load_catalog_falls_back_to_stale_cache_on_network_error(
     assert "using stale cache" in capsys.readouterr().err
 
 
+def test_load_catalog_can_require_fresh_catalog_on_network_error(catalog_cache):
+    stale_at = int(time.time()) - (48 * 3600)
+    _write_snapshot(catalog_cache, fetched_at=stale_at)
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.get("/models").mock(side_effect=httpx.ConnectError("network down"))
+        with pytest.raises(
+            ProviderHTTPError,
+            match="network error refreshing OpenRouter catalog",
+        ):
+            openrouter_catalog.load_catalog_snapshot(allow_stale_on_error=False)
+
+
 def test_load_catalog_raises_without_cache_on_network_error(catalog_cache):
     with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
         router.get("/models").mock(side_effect=httpx.ConnectError("network down"))

--- a/tests/test_openrouter_selector.py
+++ b/tests/test_openrouter_selector.py
@@ -113,6 +113,31 @@ def test_prefer_best_returns_auto_with_shortlist(mocker, fixture_catalog):
     assert shortlist[0] == "recent/general"
 
 
+def test_selector_drops_tilde_aliases_from_auto_shortlist(mocker, fixture_catalog):
+    alias = openrouter_catalog.ModelEntry(
+        id="~anthropic/claude-haiku-latest",
+        name="Anthropic Claude Haiku Latest",
+        created=500,
+        context_length=200_000,
+        pricing_prompt=0.001,
+        pricing_completion=0.005,
+        pricing_thinking=0.001,
+        supports_thinking=True,
+        supports_tools=True,
+        supports_vision=True,
+    )
+    mocker.patch(
+        "conductor.providers.openrouter_catalog.load_catalog",
+        return_value=[alias, *fixture_catalog],
+    )
+
+    payload = select_model_for_task([], "best", "medium")
+
+    shortlist = payload["plugins"][0]["allowed_models"]
+    assert "~anthropic/claude-haiku-latest" not in shortlist
+    assert all(not model.startswith("~") for model in shortlist)
+
+
 @pytest.mark.parametrize(
     ("tags", "expected"),
     [
@@ -156,5 +181,5 @@ def test_empty_filtered_result_raises_clear_error(mocker, fixture_catalog):
         return_value=fixture_catalog,
     )
 
-    with pytest.raises(ProviderError, match="found no models matching"):
+    with pytest.raises(ProviderError, match="tags filtered to empty"):
         select_model_for_task(["vision", "thinking"], "cheapest", "medium")

--- a/tests/test_review_cascade.py
+++ b/tests/test_review_cascade.py
@@ -18,19 +18,190 @@ import textwrap
 from pathlib import Path
 
 import pytest
+from click.testing import CliRunner
 
-# These tests pin pre-2.0 multi-reviewer cascade behavior
-# (`["codex", "claude"]`-style configs). Touchstone 2.0 replaced that
-# cascade with conductor-as-only-reviewer; conductor handles its own
-# internal fallback. The fix-mode safety assertions in this file are
-# still valuable, but each test needs to be rewritten against
-# `["conductor"]` config + fake conductor binaries instead of
-# fake codex/claude. Skipping the module until that refactor lands.
-pytestmark = pytest.mark.skip(
-    reason="pre-2.0 cascade contract; needs refactor for conductor-only routing"
+from conductor.cli import main
+from conductor.providers import (
+    CallResponse,
+    ClaudeProvider,
+    CodexProvider,
+    DeepSeekChatProvider,
+    DeepSeekReasonerProvider,
+    GeminiProvider,
+    KimiProvider,
+    OllamaProvider,
+    OpenRouterProvider,
 )
+from conductor.router import reset_health
 
 SCRIPT_PATH = Path(__file__).resolve().parent.parent / "scripts" / "codex-review.sh"
+LEGACY_SKIP_REASON = "pre-2.0 shell cascade contract; conductor routing tests cover issue #127"
+
+
+@pytest.fixture(autouse=True)
+def _clean_health(monkeypatch, tmp_path):
+    reset_health()
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    yield
+    reset_health()
+
+
+def _stub_all_configured(mocker, configured_names: set[str]) -> None:
+    classes = {
+        "kimi": KimiProvider,
+        "claude": ClaudeProvider,
+        "codex": CodexProvider,
+        "deepseek-chat": DeepSeekChatProvider,
+        "deepseek-reasoner": DeepSeekReasonerProvider,
+        "gemini": GeminiProvider,
+        "ollama": OllamaProvider,
+        "openrouter": OpenRouterProvider,
+    }
+    for name, cls in classes.items():
+        ok = name in configured_names
+        mocker.patch.object(
+            cls,
+            "configured",
+            lambda self, _ok=ok, _n=name: (_ok, None if _ok else f"{_n} not configured"),
+        )
+        if hasattr(cls, "review_configured"):
+            mocker.patch.object(
+                cls,
+                "review_configured",
+                lambda self, _ok=ok, _n=name: (
+                    _ok,
+                    None if _ok else f"{_n} review not configured",
+                ),
+            )
+
+
+def _fake_response(provider: str) -> CallResponse:
+    return CallResponse(
+        text=f"{provider} reviewed",
+        provider=provider,
+        model="test-model",
+        duration_ms=10,
+        usage={},
+        raw={},
+    )
+
+
+def test_review_chain_walks_past_codex_to_next_code_review_provider(mocker) -> None:
+    from conductor.providers.interface import ProviderStalledError
+
+    _stub_all_configured(mocker, {"claude", "codex", "openrouter"})
+    claude_review = mocker.patch.object(
+        ClaudeProvider,
+        "review",
+        side_effect=ProviderStalledError("claude review stalled"),
+    )
+    codex_review = mocker.patch.object(
+        CodexProvider,
+        "review",
+        side_effect=ProviderStalledError("codex review stalled"),
+    )
+    openrouter_call = mocker.patch.object(
+        OpenRouterProvider,
+        "call",
+        return_value=_fake_response("openrouter"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "review",
+            "--auto",
+            "--max-fallbacks",
+            "3",
+            "--brief",
+            "Review this merge using the project reviewer guide.",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert claude_review.called
+    assert codex_review.called
+    assert openrouter_call.called
+    assert result.stdout == "openrouter reviewed\n"
+    assert "claude review failed (stall)" in result.stderr
+    assert "codex review failed (stall)" in result.stderr
+    assert "claude (stall), codex (stall), openrouter (success)" in result.stderr
+
+
+def test_review_max_fallbacks_caps_total_attempts(mocker) -> None:
+    from conductor.providers.interface import ProviderStalledError
+
+    _stub_all_configured(mocker, {"claude", "codex", "openrouter"})
+    mocker.patch.object(
+        ClaudeProvider,
+        "review",
+        side_effect=ProviderStalledError("claude review stalled"),
+    )
+    mocker.patch.object(
+        CodexProvider,
+        "review",
+        side_effect=ProviderStalledError("codex review stalled"),
+    )
+    openrouter_call = mocker.patch.object(
+        OpenRouterProvider,
+        "call",
+        return_value=_fake_response("openrouter"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "review",
+            "--auto",
+            "--max-fallbacks",
+            "2",
+            "--brief",
+            "Review this merge using the project reviewer guide.",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert not openrouter_call.called
+    assert "claude (stall), codex (stall)" in result.stderr
+    assert "openrouter" not in result.stderr
+
+
+def test_review_exhausted_error_includes_tried_provider_trail(mocker) -> None:
+    from conductor.providers.interface import ProviderHTTPError, ProviderStalledError
+
+    _stub_all_configured(mocker, {"claude", "codex", "openrouter"})
+    mocker.patch.object(
+        ClaudeProvider,
+        "review",
+        side_effect=ProviderHTTPError("Anthropic returned 429 rate limit"),
+    )
+    mocker.patch.object(
+        CodexProvider,
+        "review",
+        side_effect=ProviderStalledError("codex review stalled"),
+    )
+    mocker.patch.object(
+        OpenRouterProvider,
+        "call",
+        side_effect=ProviderHTTPError("OpenRouter returned HTTP 503"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "review",
+            "--auto",
+            "--max-fallbacks",
+            "3",
+            "--brief",
+            "Review this merge using the project reviewer guide.",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "code review failed for all tried providers" in result.stderr
+    assert "claude (rate-limit), codex (stall), openrouter (5xx)" in result.stderr
+    assert "Next step:" in result.stderr
 
 
 def _write_executable(path: Path, body: str) -> None:
@@ -568,4 +739,23 @@ def test_stderr_tail_surfaced_on_failure(tmp_path: Path) -> None:
         "Codex stderr (rate-limit JSON) should be tailed into user output, "
         "not silenced. This is the core silent-failure bug.\n"
         f"stdout={result.stdout!r}"
+    )
+
+
+for _legacy_name in (
+    "test_usage_limit_falls_through_to_next_reviewer",
+    "test_malformed_sentinel_falls_through",
+    "test_cascade_exhausted_records_chain",
+    "test_cascade_exhausted_blocks_when_fail_closed",
+    "test_fix_mode_discards_partial_edits_before_fallthrough",
+    "test_fix_mode_aborts_on_unauthorized_commits",
+    "test_fix_mode_aborts_on_sideways_checkout",
+    "test_fix_mode_aborts_on_branch_switch_at_same_sha",
+    "test_fix_mode_aborts_on_swapped_stash",
+    "test_fix_mode_aborts_on_reviewer_stash",
+    "test_fix_mode_aborts_when_pre_review_worktree_dirty",
+    "test_stderr_tail_surfaced_on_failure",
+):
+    globals()[_legacy_name] = pytest.mark.skip(reason=LEGACY_SKIP_REASON)(
+        globals()[_legacy_name]
     )


### PR DESCRIPTION
Bundles four bug fixes into one squash-merge per the project's "first preference: bundle" guidance from principles/git-workflow.md.

Closes #124 — exec watchdog: --max-stall-seconds bypassed by conductor's own heartbeat lines
Closes #125 — conductor list: 'ready' status doesn't catch codex_models_manager startup failure
Closes #126 — OpenRouter routing: shortlist contains no matching models, returns HTTP 404
Closes #127 — Review provider fallback should chain beyond claude→codex when both stall

## What changed
- codex exec: read child stdout/stderr as byte chunks, buffer stdout back to complete NDJSON lines, and keep wrapper liveness separate from child output for stall detection.
- conductor list/codex readiness: add a bounded real `codex exec` startup probe after PATH/auth checks.
- OpenRouter selector/catalog: force fresh catalog validation for auto-router shortlists, drop `~` aliases, and fail locally when no sendable models remain.
- review chain: route across all ready `code-review` providers, add `--max-fallbacks`, and report the tried-provider trail.

## Tests
- `test_codex_exec_stall_watchdog_ignores_wrapper_heartbeats`
- `test_codex_configured_false_when_exec_startup_probe_times_out`
- `test_call_fails_locally_when_validated_shortlist_is_empty`
- `test_selector_drops_tilde_aliases_from_auto_shortlist`
- `test_load_catalog_can_require_fresh_catalog_on_network_error`
- `test_review_chain_walks_past_codex_to_next_code_review_provider`
- `test_review_max_fallbacks_caps_total_attempts`
- `test_review_exhausted_error_includes_tried_provider_trail`

## Validation
- uv run pytest: 745 passed, 15 skipped
- uv run ruff check src/ tests/: clean
