### PR TITLE
fix: tokenize CONDUCTOR_BIN so multi-word values work in codex-review.sh

### DIFF
--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -141,6 +141,9 @@ TOUCHSTONE_LOCAL_REVIEWER_AUTH_COMMAND="${TOUCHSTONE_LOCAL_REVIEWER_AUTH_COMMAND
 # 2.0 conductor knobs — filled from [review.conductor] during TOML parse;
 # env vars (TOUCHSTONE_CONDUCTOR_*) override just before invocation.
 CONDUCTOR_BIN="${CONDUCTOR_BIN:-conductor}"
+# Tokenize so multi-word values (e.g. CONDUCTOR_BIN="uv run conductor") work
+# in `command -v` checks and when invoked as command + args.
+read -ra CONDUCTOR_BIN_ARGV <<< "$CONDUCTOR_BIN"
 CONDUCTOR_WITH=""
 CONDUCTOR_PREFER=""
 CONDUCTOR_EFFORT=""
@@ -951,19 +954,19 @@ ASSIST_EOF
 # just declares capability-level intent through tools and lets the router pick.
 
 reviewer_conductor_available() {
-  command -v "$CONDUCTOR_BIN" >/dev/null 2>&1
+  command -v "${CONDUCTOR_BIN_ARGV[0]}" >/dev/null 2>&1
 }
 
 reviewer_conductor_auth_ok() {
   # Delegate to `conductor doctor --json` — cheap check, makes no upstream
   # calls, confirms at least one provider is configured.
   local doctor_json
-  doctor_json=$("$CONDUCTOR_BIN" doctor --json 2>/dev/null) || return 1
+  doctor_json=$("${CONDUCTOR_BIN_ARGV[@]}" doctor --json 2>/dev/null) || return 1
   echo "$doctor_json" | grep -q '"configured"[[:space:]]*:[[:space:]]*true'
 }
 
 reviewer_conductor_supports_review() {
-  "$CONDUCTOR_BIN" review --help >/dev/null 2>&1
+  "${CONDUCTOR_BIN_ARGV[@]}" review --help >/dev/null 2>&1
 }
 
 reviewer_conductor_exec() {
@@ -1043,7 +1046,7 @@ reviewer_conductor_exec() {
   # matches Conductor's established stdin-fallback path.
   CODEX_REVIEW_IN_PROGRESS=1 \
     printf '%s' "$prompt" \
-    | "$CONDUCTOR_BIN" "$subcommand" "${args[@]}"
+    | "${CONDUCTOR_BIN_ARGV[@]}" "$subcommand" "${args[@]}"
 }
 
 # --------------------------------------------------------------------------
@@ -1817,7 +1820,7 @@ run_peer_review() {
   # wrapper when the primary timed out; peer call runs synchronously and
   # relies on conductor's own per-provider timeout (currently 300s default).
   peer_output="$(printf '%s' "$peer_prompt" \
-    | "$CONDUCTOR_BIN" call --auto \
+    | "${CONDUCTOR_BIN_ARGV[@]}" call --auto \
         --exclude "$primary_provider" \
         --tags code-review \
         --effort medium \

--- a/tests/test_codex_review_sentinel.sh
+++ b/tests/test_codex_review_sentinel.sh
@@ -52,4 +52,14 @@ assert_detector \
   $'CODEX_REVIEW_CLEAN\nCODEX_REVIEW_BLOCKED\n' \
   ""
 
+# Regression: CONDUCTOR_BIN must be tokenized into CONDUCTOR_BIN_ARGV so that
+# multi-word values (e.g. CONDUCTOR_BIN="uv run conductor") work in
+# `command -v` checks and as command + args. The only legitimate single-token
+# read of CONDUCTOR_BIN is the `read -ra` tokenization itself.
+bad_uses="$(grep -nE '"\$CONDUCTOR_BIN"' "$SCRIPT" | grep -v 'read -ra' || true)"
+if [ -n "$bad_uses" ]; then
+  printf 'FAIL: CONDUCTOR_BIN must use ${CONDUCTOR_BIN_ARGV[@]} for invocation; found single-token use:\n%s\n' "$bad_uses" >&2
+  exit 1
+fi
+
 printf 'ok\n'


### PR DESCRIPTION
## Summary
- Tokenize `CONDUCTOR_BIN` once into `CONDUCTOR_BIN_ARGV` so multi-word values (e.g. `CONDUCTOR_BIN="uv run conductor"`) work in `command -v` checks and as command + args.
- Add a structural regression test that fails if any new caller reintroduces the single-token `"$CONDUCTOR_BIN"` invocation pattern.

## Why
During the PR #135 merge, the operator hit this: `command -v "uv run conductor"` returned not-found, the script's `reviewer_conductor_available()` failed, and the script fell through to its "no reviewer available" fail-open path and let an ambiguous review through.

## Note on review path
The Codex pre-merge reviewer is currently emitting prose verdicts without the `CODEX_REVIEW_CLEAN` / `BLOCKED` sentinel. PR #129's fail-closed-on-malformed-sentinel logic correctly defends against that — that's the intended behavior — but it means the auto-merge path can't ship this fix until the reviewer-side sentinel issue is resolved separately. Filing that as a follow-up issue. The diff here is small (4 invocation-site rewrites + a structural lint test), reviewable inline.

## Test plan
- [x] `bash tests/test_codex_review_sentinel.sh` (regression test passes)
- [x] `uv run pytest tests/test_codex_review_sentinel.py` (4 passed)
- [x] `uv run ruff check src/ tests/` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)