### PR TITLE
chore: refresh repo agent wiring from v0.8.2 to v0.8.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ If there are zero blocking issues, the review is just: "LGTM."
 
 @.cortex/protocol.md
 
-<!-- conductor:begin v0.8.2 -->
+<!-- conductor:begin v0.8.3 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,7 @@ The old `--sandbox` flag is still parseable for compatibility, but it is depreca
 
 Because the child has the same ambient authority as the parent, prompts should still be explicit about ownership: whether the child may edit files, run tests, use network, or perform git operations. For PR workflows in this repo, the parent agent still owns commit, push, and PR creation unless the user explicitly delegates those steps.
 
-<!-- conductor:begin v0.8.2 -->
+<!-- conductor:begin v0.8.3 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,4 +1,4 @@
-<!-- conductor:begin v0.8.2 -->
+<!-- conductor:begin v0.8.3 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)


### PR DESCRIPTION
`conductor init --yes` rewrites the conductor-managed sentinel block
inside `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`, bumping the version
marker from `v0.8.2` to `v0.8.3` so the freshness check stays silent
on the released version.

The init writer used the local-build version `v0.8.3+1.g7fb0b70`; that
canonicalizes to `0.8.3` for freshness purposes (`+...` build metadata
is stripped) but ties the committed file to a specific dev-build hash,
so this commit pins to the clean release marker `v0.8.3` instead. A
minor follow-up would be to make `conductor init` emit the canonical
version directly to avoid this manual cleanup on future bumps.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
