### PR TITLE
fix: enforce Touchstone sentinel at the review CLI emission boundary (#137)

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -56,6 +56,7 @@ from conductor.providers import (
 from conductor.providers.review_contract import (
     ReviewContextError,
     build_review_task_prompt,
+    ensure_requested_review_sentinel,
 )
 from conductor.router import (
     VALID_PREFER_MODES,
@@ -950,6 +951,13 @@ def _invoke_review_with_fallback(
                     ),
                     effort=effort,
                 )
+            repaired_text = ensure_requested_review_sentinel(
+                provider_name=response.provider,
+                prompt=task,
+                text=response.text,
+            )
+            if repaired_text != response.text:
+                response = replace(response, text=repaired_text)
             mark_outcome(candidate.name, "success")
             tried.append((candidate.name, "success"))
             if not silent and len(tried) > 1:

--- a/src/conductor/providers/review_contract.py
+++ b/src/conductor/providers/review_contract.py
@@ -8,6 +8,11 @@ import sys
 from pathlib import Path
 
 _REVIEW_SENTINEL_RE = re.compile(r"^\s*(CODEX_REVIEW_(?:CLEAN|FIXED|BLOCKED))\s*$")
+_REVIEW_SENTINELS = (
+    "CODEX_REVIEW_CLEAN",
+    "CODEX_REVIEW_FIXED",
+    "CODEX_REVIEW_BLOCKED",
+)
 _SAFE_BLOCKED_SENTINEL = "CODEX_REVIEW_BLOCKED"
 _DEFAULT_PATCH_CONTEXT_MAX_BYTES = 200_000
 
@@ -180,7 +185,7 @@ def ensure_requested_review_sentinel(
     the returned text has exactly one standalone sentinel line, and it is the
     final non-empty line. Ambiguous provider output fails closed as BLOCKED.
     """
-    if "CODEX_REVIEW_CLEAN" not in prompt:
+    if not _prompt_requests_review_sentinel(prompt):
         return text
 
     stripped = text.strip()
@@ -208,3 +213,20 @@ def ensure_requested_review_sentinel(
     if body:
         return f"{body}\n{_SAFE_BLOCKED_SENTINEL}"
     return _SAFE_BLOCKED_SENTINEL
+
+
+def _prompt_requests_review_sentinel(prompt: str) -> bool:
+    """Return True only for prompts that ask for a final review sentinel."""
+    if "CODEX_REVIEW_CLEAN" not in prompt:
+        return False
+    normalized = prompt.lower()
+    return any(
+        phrase in normalized
+        for phrase in (
+            "last line",
+            "final standalone",
+            "end with",
+            "ends with",
+            "end your output",
+        )
+    )

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -753,6 +753,108 @@ def test_review_auto_generic_fallback_prompt_includes_diff(mocker, tmp_path):
     assert "+fallback diff marker" in prompt
 
 
+def test_review_auto_generic_fallback_repairs_requested_sentinel(mocker, tmp_path):
+    from conductor.providers.interface import ProviderStalledError
+
+    # Regression for issue #137's weak point: before the CLI-level guard, a
+    # call()-based review fallback returned this prose unchanged and the hook
+    # later failed closed with malformed-sentinel.
+    repo = _make_diff_repo(tmp_path)
+    _stub_all_configured(mocker, {"codex", "claude", "openrouter"})
+    mocker.patch.object(CodexProvider, "review_configured", return_value=(True, None))
+    mocker.patch.object(ClaudeProvider, "review_configured", return_value=(True, None))
+    mocker.patch.object(
+        ClaudeProvider,
+        "review",
+        side_effect=ProviderStalledError("claude review stalled"),
+    )
+    mocker.patch.object(
+        CodexProvider,
+        "review",
+        side_effect=ProviderStalledError("codex review stalled"),
+    )
+    mocker.patch.object(
+        OpenRouterProvider,
+        "call",
+        return_value=CallResponse(
+            text=(
+                "The changes consistently route through the requested path. "
+                "I did not find a blocking correctness issue."
+            ),
+            provider="openrouter",
+            model="test-model",
+            duration_ms=10,
+            usage={},
+            raw={},
+        ),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "review",
+            "--auto",
+            "--max-fallbacks",
+            "3",
+            "--cwd",
+            str(repo),
+            "--base",
+            "HEAD~1",
+            "--brief",
+            (
+                "The LAST line of your output must be exactly one of these "
+                "three sentinels: CODEX_REVIEW_CLEAN, CODEX_REVIEW_FIXED, "
+                "or CODEX_REVIEW_BLOCKED."
+            ),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    lines = result.stdout.strip().splitlines()
+    assert lines[-1] == "CODEX_REVIEW_BLOCKED"
+    assert sum(1 for line in lines if line.startswith("CODEX_REVIEW_")) == 1
+    assert "review repaired missing Touchstone sentinel" in result.stderr
+
+
+def test_review_auto_codex_subprocess_repairs_requested_sentinel(mocker):
+    # Exercises the same conductor review --auto -> codex subprocess path used
+    # by scripts/codex-review.sh when codex is the selected native reviewer.
+    _stub_all_configured(mocker, {"codex"})
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    mocker.patch(
+        "conductor.providers.codex.subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            args=["codex", "review"],
+            returncode=0,
+            stdout=(
+                "The changes consistently route through the requested path. "
+                "I did not find a blocking correctness issue.\n"
+            ),
+            stderr="",
+        ),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "review",
+            "--auto",
+            "--silent-route",
+            "--brief",
+            (
+                "The LAST line of your output must be exactly one of these "
+                "three sentinels: CODEX_REVIEW_CLEAN, CODEX_REVIEW_FIXED, "
+                "or CODEX_REVIEW_BLOCKED."
+            ),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    lines = result.stdout.strip().splitlines()
+    assert lines[-1] == "CODEX_REVIEW_BLOCKED"
+    assert sum(1 for line in lines if line.startswith("CODEX_REVIEW_")) == 1
+
+
 def test_review_with_gemini_emits_plain_text_without_json_envelope(mocker):
     _stub_all_configured(mocker, {"gemini"})
     mocker.patch.object(GeminiProvider, "review_configured", return_value=(True, None))

--- a/tests/test_review_contract.py
+++ b/tests/test_review_contract.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+
+from conductor.providers.review_contract import ensure_requested_review_sentinel
+
+STRICT_SENTINEL_PROMPT = """
+## Output contract -- strict
+
+The LAST line of your output must be exactly one of these three sentinels:
+
+- CODEX_REVIEW_CLEAN -- no blocking issues found
+- CODEX_REVIEW_FIXED -- you applied auto-fixes
+- CODEX_REVIEW_BLOCKED -- blocking issues remain
+"""
+
+
+@pytest.mark.parametrize(
+    "sentinel",
+    [
+        "CODEX_REVIEW_CLEAN",
+        "CODEX_REVIEW_FIXED",
+        "CODEX_REVIEW_BLOCKED",
+    ],
+)
+def test_review_sentinel_contract_accepts_each_final_sentinel(sentinel: str):
+    text = f"Review body.\n{sentinel}\n"
+
+    repaired = ensure_requested_review_sentinel(
+        provider_name="codex",
+        prompt=STRICT_SENTINEL_PROMPT,
+        text=text,
+    )
+
+    assert repaired == f"Review body.\n{sentinel}"
+
+
+def test_review_sentinel_contract_repairs_prose_without_standalone_sentinel():
+    repaired = ensure_requested_review_sentinel(
+        provider_name="codex",
+        prompt=STRICT_SENTINEL_PROMPT,
+        text=(
+            "I did not find a blocking issue. The reviewer should emit "
+            "CODEX_REVIEW_CLEAN for that case."
+        ),
+    )
+
+    assert repaired == (
+        "I did not find a blocking issue. The reviewer should emit "
+        "CODEX_REVIEW_CLEAN for that case.\nCODEX_REVIEW_BLOCKED"
+    )
+    assert repaired.splitlines()[-1] == "CODEX_REVIEW_BLOCKED"
+    assert sum(1 for line in repaired.splitlines() if line.startswith("CODEX_REVIEW_")) == 1
+
+
+def test_review_sentinel_contract_ignores_non_contract_assist_prompt():
+    text = "Answer the primary reviewer. This peer response is advisory only."
+
+    repaired = ensure_requested_review_sentinel(
+        provider_name="codex",
+        prompt=(
+            "Answer the primary reviewer concisely and directly. Do not emit "
+            "CODEX_REVIEW_CLEAN, CODEX_REVIEW_FIXED, or CODEX_REVIEW_BLOCKED."
+        ),
+        text=text,
+    )
+
+    assert repaired == text


### PR DESCRIPTION
Issue #137 reported that `conductor review --auto` could emit prose
without the Touchstone sentinel, causing scripts/codex-review.sh to
fail closed with `malformed-sentinel`. The codex adapter already
applied `ensure_requested_review_sentinel` inside `review()`, but
review fallbacks that go through `provider.call()` (OpenRouter and
generic) returned text unchanged — so the contract was contingent on
which provider/path the router happened to pick.

This change moves the repair to `_invoke_review_with_fallback` so
every review response that conductor emits passes through the helper
before reaching stdout, regardless of provider type or call path.

Also tightens the trigger: the helper now fires only when the prompt
both names a sentinel and includes an output-contract phrase
("last line", "end with", ...). The previous `"CODEX_REVIEW_CLEAN" in
prompt` check false-positived on the peer-review prompt, which says
"Do not emit CODEX_REVIEW_*" and would wrongly get a BLOCKED line
appended.

Tests:
- new generic-fallback regression in tests/test_cli_v02.py fails on
  main and passes after the CLI-boundary repair
- new tests/test_review_contract.py covers all three sentinel tokens
  and the assist-prompt suppression case

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
