### PR TITLE
fix: strip local-build version metadata from wiring writes

### DIFF
--- a/src/conductor/agent_wiring.py
+++ b/src/conductor/agent_wiring.py
@@ -70,13 +70,13 @@ _REPO_SCOPED_KINDS = frozenset(
 
 def _managed_comment(version: str) -> str:
     return (
-        f"<!-- managed-by: conductor v{version} — "
+        f"<!-- managed-by: conductor v{_canonical_wiring_version(version)} — "
         f"do not edit; run `conductor init --unwire` to remove -->"
     )
 
 
 def _sentinel_begin(version: str) -> str:
-    return f"<!-- conductor:begin v{version} -->"
+    return f"<!-- conductor:begin v{_canonical_wiring_version(version)} -->"
 
 
 def _normalize_generated_text(text: str) -> str:
@@ -431,7 +431,7 @@ def write_managed_frontmatter(
         lines.append(_frontmatter_line(key, value))
     # managed-by last: the user sees name/description/etc. first when they
     # open the file; our marker sits at the bottom of the frontmatter.
-    lines.append(f"managed-by: conductor v{version}")
+    lines.append(f"managed-by: conductor v{_canonical_wiring_version(version)}")
     lines.append("---")
     path.write_text(
         _normalize_generated_text("\n".join(lines) + "\n\n" + body),

--- a/tests/test_agent_wiring.py
+++ b/tests/test_agent_wiring.py
@@ -242,6 +242,33 @@ def test_remove_sentinel_block_on_unmanaged_file_returns_false(tmp_path):
     assert path.read_text(encoding="utf-8") == "# user-owned\n"
 
 
+def test_wiring_writers_strip_local_build_version_metadata(tmp_path):
+    # Writes mirror the freshness check's canonicalization so committed
+    # wiring files don't carry developer-specific +local-build hashes
+    # when init is run from a working tree ahead of the latest tag.
+    dirty = "0.8.3+1.g7fb0b70"
+
+    sentinel_path = tmp_path / "AGENTS.md"
+    aw.inject_sentinel_block(sentinel_path, "@x", version=dirty)
+    sentinel_text = sentinel_path.read_text(encoding="utf-8")
+    assert "<!-- conductor:begin v0.8.3 -->" in sentinel_text
+    assert "+1.g7fb0b70" not in sentinel_text
+
+    md_path = tmp_path / "guidance.md"
+    aw.write_managed_markdown(md_path, "body\n", version=dirty)
+    md_text = md_path.read_text(encoding="utf-8")
+    assert "managed-by: conductor v0.8.3" in md_text
+    assert "+1.g7fb0b70" not in md_text
+
+    fm_path = tmp_path / "rule.mdc"
+    aw.write_managed_frontmatter(
+        fm_path, {"description": "x"}, "body", version=dirty
+    )
+    fm_text = fm_path.read_text(encoding="utf-8")
+    assert "managed-by: conductor v0.8.3" in fm_text
+    assert "+1.g7fb0b70" not in fm_text
+
+
 # --------------------------------------------------------------------------- #
 # wire_claude_code end-to-end.
 # --------------------------------------------------------------------------- #
@@ -381,7 +408,8 @@ def test_wire_then_unwire_then_wire_round_trip():
 def test_version_extraction_handles_prerelease(tmp_path):
     path = tmp_path / "notes.md"
     aw.write_managed_markdown(path, "body", version="0.4.0.dev1+g1234abc")
-    assert aw.read_managed_version(path) == "0.4.0.dev1+g1234abc"
+    # Prerelease tag is preserved; local-build metadata is stripped at write.
+    assert aw.read_managed_version(path) == "0.4.0.dev1"
 
 
 def test_managed_path_stays_out_of_arbitrary_dirs(tmp_path):


### PR DESCRIPTION
The freshness check (`_canonical_wiring_version` + `_wiring_versions_match`)
already canonicalizes both sides before comparing, but the write side
embedded the raw `__version__` — so files committed from a working tree
ahead of the latest tag carried developer-specific local hashes (e.g.
`<!-- conductor:begin v0.8.3+1.g7fb0b70 -->`).

Mirror the read-side canonicalization on the write side, in the three
embed points (`_managed_comment`, `_sentinel_begin`, and the
`managed-by` line in `write_managed_frontmatter`).

Closes #141.

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
