### PR TITLE
test: scrub inherited GIT_* env vars at session start

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -43,6 +43,7 @@ from conductor.providers import (
     QUALITY_TIERS,
     CallResponse,
     ClaudeProvider,
+    CodexProvider,
     NativeReviewProvider,
     OpenRouterProvider,
     ProviderConfigError,
@@ -113,6 +114,7 @@ DEFAULT_COUNCIL_ROUNDS = 1
 class BriefInput:
     body: str
     source: str
+    attachments: tuple[Path, ...] = ()
 
 
 # --------------------------------------------------------------------------- #
@@ -126,6 +128,7 @@ def _read_task(
     *,
     brief: str | None = None,
     brief_file: str | None = None,
+    attach: tuple[str, ...] = (),
 ) -> BriefInput:
     explicit_sources = [
         (name, value)
@@ -175,7 +178,19 @@ def _read_task(
     body = body.strip()
     if not body:
         raise click.UsageError("brief is empty after stripping whitespace.")
-    return BriefInput(body=body, source=source)
+
+    attachments: tuple[Path, ...] = ()
+    if attach:
+        resolved: list[Path] = []
+        for raw_path in attach:
+            path = Path(raw_path).expanduser()
+            if not path.is_file():
+                raise click.UsageError(
+                    f"--attach path {raw_path!r} is not a readable file."
+                )
+            resolved.append(path.resolve())
+        attachments = tuple(resolved)
+    return BriefInput(body=body, source=source, attachments=attachments)
 
 
 def _warn_if_short_exec_brief(
@@ -192,6 +207,27 @@ def _warn_if_short_exec_brief(
         "--brief-file with goal, context, scope, constraints, expected output, "
         "and validation. Pass --allow-short-brief to silence this warning.",
         err=True,
+    )
+
+
+def _ensure_supports_attachments(
+    provider_obj: object,
+    attachments: tuple[Path, ...],
+) -> None:
+    """Raise UnsupportedCapability if attachments cannot route to this provider.
+
+    The supported set is currently {codex}; surface a copy-pasteable fix so the
+    operator doesn't have to guess which provider to switch to.
+    """
+    if not attachments:
+        return
+    if getattr(provider_obj, "supports_image_attachments", False):
+        return
+    name = getattr(provider_obj, "name", provider_obj.__class__.__name__)
+    raise UnsupportedCapability(
+        f"provider {name!r} does not accept image attachments. "
+        "Re-run with `--with codex` (or `--auto` once another image-capable "
+        "provider lands)."
     )
 
 
@@ -679,6 +715,7 @@ def _invoke_with_fallback(
     resume_session_id: str | None = None,
     session_log: SessionLog | None = None,
     models_by_provider: dict[str, tuple[str, ...]] | None = None,
+    attachments: tuple[Path, ...] = (),
 ) -> tuple[CallResponse, list[str]]:
     """Try the decision's ranked providers in order; fallback on retryable errors.
 
@@ -762,6 +799,7 @@ def _invoke_with_fallback(
                         session_log=session_log,
                     )
                 elif isinstance(provider, ClaudeProvider):
+                    _ensure_supports_attachments(provider, attachments)
                     response = provider.exec(
                         task,
                         model=model,
@@ -775,7 +813,22 @@ def _invoke_with_fallback(
                         resume_session_id=resume_session_id,
                         session_log=session_log,
                     )
+                elif isinstance(provider, CodexProvider):
+                    response = provider.exec(
+                        task,
+                        model=model,
+                        effort=effort,
+                        tools=tools,
+                        sandbox=sandbox,
+                        cwd=cwd,
+                        timeout_sec=timeout_sec,
+                        max_stall_sec=max_stall_sec,
+                        resume_session_id=resume_session_id,
+                        session_log=session_log,
+                        attachments=attachments,
+                    )
                 else:
+                    _ensure_supports_attachments(provider, attachments)
                     response = provider.exec(
                         task,
                         model=model,
@@ -790,6 +843,7 @@ def _invoke_with_fallback(
                     )
             else:
                 if isinstance(provider, OpenRouterProvider):
+                    _ensure_supports_attachments(provider, attachments)
                     response = provider.call(
                         task,
                         model=model,
@@ -800,7 +854,16 @@ def _invoke_with_fallback(
                         log_selection=not silent,
                         resume_session_id=resume_session_id,
                     )
+                elif isinstance(provider, CodexProvider):
+                    response = provider.call(
+                        task,
+                        model=model,
+                        effort=effort,
+                        resume_session_id=resume_session_id,
+                        attachments=attachments,
+                    )
                 else:
+                    _ensure_supports_attachments(provider, attachments)
                     response = provider.call(
                         task,
                         model=model,
@@ -1630,6 +1693,16 @@ def main(ctx: click.Context) -> None:
     default=None,
     help="Read the delegation brief from a UTF-8 file. Use '-' to read stdin.",
 )
+@click.option(
+    "--attach",
+    "attach",
+    multiple=True,
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+    help=(
+        "Attach a file to the brief. Repeat for multiple. Today only `codex` "
+        "accepts attachments; review and council kinds do not pass them through."
+    ),
+)
 @click.option("--log-file", default=None, help="For exec: write structured NDJSON events.")
 @click.option("--json", "as_json", is_flag=True, default=False)
 @click.option("--verbose-route", is_flag=True, default=False)
@@ -1666,6 +1739,7 @@ def ask(
     task_file: str | None,
     brief: str | None,
     brief_file: str | None,
+    attach: tuple[str, ...],
     log_file: str | None,
     as_json: bool,
     verbose_route: bool,
@@ -1698,10 +1772,23 @@ def ask(
     if review_target_count > 1:
         raise click.UsageError("use only one of --base, --commit, or --uncommitted.")
 
-    brief_input = _read_task(task, task_file, brief=brief, brief_file=brief_file)
+    brief_input = _read_task(
+        task, task_file, brief=brief, brief_file=brief_file, attach=attach
+    )
     if plan.mode == "exec":
         _warn_if_short_exec_brief(brief_input, allow_short_brief=allow_short_brief)
     body = brief_input.body
+    attachments = brief_input.attachments
+
+    # `ask --kind {review,council}` doesn't have a path for attachments —
+    # review forwards a diff to the provider's native review mode (no attach
+    # API), and council always routes through OpenRouter. Reject up front
+    # rather than silently dropping the user's files.
+    if attachments and plan.mode in {"review", "council"}:
+        raise click.UsageError(
+            f"--attach is not supported for --kind {plan.mode}; "
+            "use `conductor exec --with codex --attach ...` instead."
+        )
 
     if not (silent_route or as_json):
         click.echo(_format_semantic_plan_line(plan), err=True)
@@ -1781,6 +1868,7 @@ def ask(
             exclude=exclude_set,
             priority=_semantic_priority(plan),
             shadow=True,
+            attachments_required=bool(attachments),
         )
     except (NoConfiguredProvider, InvalidRouterRequest, MutedProvidersError) as e:
         click.echo(f"conductor: {e}", err=True)
@@ -1827,6 +1915,7 @@ def ask(
                 silent=silent_route or as_json,
                 session_log=session_log,
                 models_by_provider=models_by_provider,
+                attachments=attachments,
         )
     except UnsupportedCapability as e:
         if session_log is not None:
@@ -1935,6 +2024,16 @@ def ask(
     help="Read the delegation brief from a UTF-8 file. Use '-' to read stdin.",
 )
 @click.option(
+    "--attach",
+    "attach",
+    multiple=True,
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+    help=(
+        "Attach a file to the brief. Repeat for multiple. Today only `codex` "
+        "accepts attachments; `--auto` will route accordingly."
+    ),
+)
+@click.option(
     "--model",
     default=None,
     help="Override the provider's default model.",
@@ -1984,6 +2083,7 @@ def call(
     task_file: str | None,
     brief: str | None,
     brief_file: str | None,
+    attach: tuple[str, ...],
     model: str | None,
     as_json: bool,
     verbose_route: bool,
@@ -2034,8 +2134,10 @@ def call(
         task_file,
         brief=brief,
         brief_file=brief_file,
+        attach=attach,
     )
     body = brief_input.body
+    attachments = brief_input.attachments
     effort_value = _parse_effort(effort)
 
     decision: RouteDecision | None = None
@@ -2047,6 +2149,7 @@ def call(
                 effort=effort_value,
                 exclude=frozenset(_parse_csv(exclude)),
                 shadow=True,
+                attachments_required=bool(attachments),
             )
         except (NoConfiguredProvider, InvalidRouterRequest, MutedProvidersError) as e:
             click.echo(f"conductor: {e}", err=True)
@@ -2068,6 +2171,7 @@ def call(
                 max_stall_sec=None,
                 start_timeout_sec=None,
                 silent=silent_route or as_json,
+                attachments=attachments,
             )
         except ProviderConfigError as e:
             click.echo(f"conductor: {e}", err=True)
@@ -2085,6 +2189,11 @@ def call(
             provider = get_provider(provider_id)
         except KeyError as e:
             raise click.UsageError(str(e)) from e
+        try:
+            _ensure_supports_attachments(provider, attachments)
+        except UnsupportedCapability as e:
+            click.echo(f"conductor: {e}", err=True)
+            sys.exit(2)
         print_caller_banner(provider_id, silent=silent_route or as_json)
         try:
             if isinstance(provider, OpenRouterProvider):
@@ -2096,6 +2205,14 @@ def call(
                     prefer=_validate_prefer(prefer),
                     log_selection=not (silent_route or as_json),
                     resume_session_id=resume_session_id,
+                )
+            elif isinstance(provider, CodexProvider):
+                response = provider.call(
+                    body,
+                    model=model,
+                    effort=effort_value,
+                    resume_session_id=resume_session_id,
+                    attachments=attachments,
                 )
             else:
                 response = provider.call(
@@ -2517,6 +2634,16 @@ def review(
     default=None,
     help="Read the delegation brief from a UTF-8 file. Use '-' to read stdin.",
 )
+@click.option(
+    "--attach",
+    "attach",
+    multiple=True,
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+    help=(
+        "Attach a file to the brief. Repeat for multiple. Today only `codex` "
+        "accepts attachments; `--auto` will route accordingly."
+    ),
+)
 @click.option("--model", default=None, help="Override the provider's default model.")
 @click.option(
     "--log-file",
@@ -2581,6 +2708,7 @@ def exec_cmd(
     task_file: str | None,
     brief: str | None,
     brief_file: str | None,
+    attach: tuple[str, ...],
     model: str | None,
     log_file: str | None,
     as_json: bool,
@@ -2632,12 +2760,14 @@ def exec_cmd(
         task_file,
         brief=brief,
         brief_file=brief_file,
+        attach=attach,
     )
     _warn_if_short_exec_brief(
         brief_input,
         allow_short_brief=allow_short_brief,
     )
     body = brief_input.body
+    attachments = brief_input.attachments
     tools_set = _validate_tools(tools)
     sandbox_value = _validate_sandbox(sandbox, warn=sandbox is not None)
     effort_value = _parse_effort(effort)
@@ -2656,6 +2786,7 @@ def exec_cmd(
                 sandbox=sandbox_value,
                 exclude=frozenset(_parse_csv(exclude)),
                 shadow=True,
+                attachments_required=bool(attachments),
             )
         except (NoConfiguredProvider, InvalidRouterRequest, MutedProvidersError) as e:
             click.echo(f"conductor: {e}", err=True)
@@ -2700,6 +2831,7 @@ def exec_cmd(
                 silent=silent_route or as_json,
                 resume_session_id=resume_session_id,
                 session_log=session_log,
+                attachments=attachments,
             )
         except UnsupportedCapability as e:
             if session_log is not None:
@@ -2729,6 +2861,11 @@ def exec_cmd(
             provider = get_provider(provider_id)
         except KeyError as e:
             raise click.UsageError(str(e)) from e
+        try:
+            _ensure_supports_attachments(provider, attachments)
+        except UnsupportedCapability as e:
+            click.echo(f"conductor: {e}", err=True)
+            sys.exit(2)
         session_log = _start_exec_session_log(
             log_file=log_file,
             resume_session_id=resume_session_id,
@@ -2787,6 +2924,20 @@ def exec_cmd(
                     start_timeout_sec=start_timeout_sec,
                     resume_session_id=resume_session_id,
                     session_log=session_log,
+                )
+            elif isinstance(provider, CodexProvider):
+                response = provider.exec(
+                    body,
+                    model=model,
+                    effort=effort_value,
+                    tools=tools_set,
+                    sandbox=sandbox_value,
+                    cwd=cwd,
+                    timeout_sec=timeout_sec,
+                    max_stall_sec=max_stall_sec,
+                    resume_session_id=resume_session_id,
+                    session_log=session_log,
+                    attachments=attachments,
                 )
             else:
                 response = provider.exec(

--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -65,6 +65,7 @@ class ClaudeProvider:
     quality_tier = "frontier"
     supported_tools = frozenset({"Read", "Grep", "Glob", "Edit", "Write", "Bash"})
     supports_effort = True
+    supports_image_attachments = False
     effort_to_thinking = {
         "minimal": 0,
         "low": 2_000,

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -91,6 +91,7 @@ class CodexProvider:
     quality_tier = "frontier"
     supported_tools = frozenset({"Read", "Grep", "Glob", "Edit", "Write", "Bash"})
     supports_effort = True
+    supports_image_attachments = True
     effort_to_thinking = {
         "minimal": 0,
         "low": 2_000,
@@ -566,6 +567,7 @@ class CodexProvider:
         *,
         effort: str | int = "medium",
         resume_session_id: str | None = None,
+        attachments: tuple[Path, ...] = (),
     ) -> CallResponse:
         return self._run(
             task,
@@ -573,6 +575,7 @@ class CodexProvider:
             effort=effort,
             sandbox="danger-full-access",
             resume_session_id=resume_session_id,
+            attachments=attachments,
         )
 
     def exec(
@@ -589,6 +592,7 @@ class CodexProvider:
         liveness_interval_sec: float = 30.0,
         resume_session_id: str | None = None,
         session_log: SessionLog | None = None,
+        attachments: tuple[Path, ...] = (),
     ) -> CallResponse:
         return self._run(
             task,
@@ -602,6 +606,7 @@ class CodexProvider:
             stream=True,
             resume_session_id=resume_session_id,
             session_log=session_log,
+            attachments=attachments,
         )
 
     def _run(
@@ -618,6 +623,7 @@ class CodexProvider:
         stream: bool = False,
         resume_session_id: str | None = None,
         session_log: SessionLog | None = None,
+        attachments: tuple[Path, ...] = (),
     ) -> CallResponse:
         # Cheap PATH check on the hot path; auth state surfaces as a CLI
         # exit failure below if needed. configured() (with auth probe) is
@@ -669,6 +675,9 @@ class CodexProvider:
             ]
         if codex_effort_flag:
             args.extend(["-c", f"model_reasoning_effort={codex_effort_flag}"])
+
+        for attachment in attachments:
+            args.extend(["-i", str(attachment)])
 
         if timeout_sec_override is _USE_DEFAULT:
             timeout = self._timeout_sec

--- a/src/conductor/providers/gemini.py
+++ b/src/conductor/providers/gemini.py
@@ -104,6 +104,7 @@ class GeminiProvider:
     quality_tier = "strong"
     supported_tools = frozenset({"Read", "Grep", "Glob", "Edit", "Write", "Bash"})
     supports_effort = True
+    supports_image_attachments = False
     effort_to_thinking = {
         "minimal": 0,
         "low": 2_000,

--- a/src/conductor/providers/interface.py
+++ b/src/conductor/providers/interface.py
@@ -17,6 +17,8 @@ Capability declarations (v0.2):
   - quality_tier            — "frontier" | "strong" | "standard" | "local"
   - supported_tools         — frozenset of tool names ({Read, Grep, Glob, Edit, Write, Bash})
   - supports_effort         — whether the provider has a thinking/reasoning dial
+  - supports_image_attachments — whether the provider can accept image file attachments
+                                 alongside the brief (today: codex only)
   - effort_to_thinking      — mapping from symbolic effort level to expected thinking tokens
   - cost_per_1k_in/out/thinking — for prefer=cheapest scoring
   - typical_p50_ms          — for prefer=fastest scoring
@@ -165,6 +167,7 @@ class Provider(Protocol):
     quality_tier: ClassVar[str]
     supported_tools: ClassVar[frozenset[str]]
     supports_effort: ClassVar[bool]
+    supports_image_attachments: ClassVar[bool]
     effort_to_thinking: ClassVar[dict[str, int]]
     cost_per_1k_in: ClassVar[float]
     cost_per_1k_out: ClassVar[float]

--- a/src/conductor/providers/ollama.py
+++ b/src/conductor/providers/ollama.py
@@ -205,6 +205,7 @@ class OllamaProvider:
         {"Read", "Grep", "Glob", "Edit", "Write", "Bash"}
     )
     supports_effort = False  # base ollama models don't expose a thinking dial
+    supports_image_attachments = False
     effort_to_thinking: dict[str, int] = {}
     cost_per_1k_in = 0.0
     cost_per_1k_out = 0.0

--- a/src/conductor/providers/openrouter.py
+++ b/src/conductor/providers/openrouter.py
@@ -68,6 +68,7 @@ class OpenRouterProvider:
         {"Read", "Grep", "Glob", "Edit", "Write", "Bash"}
     )
     supports_effort = True
+    supports_image_attachments = False
     effort_to_thinking = {
         "minimal": 0,
         "low": 2_000,

--- a/src/conductor/providers/shell.py
+++ b/src/conductor/providers/shell.py
@@ -88,6 +88,7 @@ class ShellProvider:
     # Capability declarations that are the same for every shell provider.
     supported_tools: frozenset[str] = frozenset()
     supports_effort: bool = False
+    supports_image_attachments: bool = False
     effort_to_thinking: dict[str, int] = {}  # noqa: RUF012
     cost_per_1k_thinking: float = 0.0
 

--- a/src/conductor/router.py
+++ b/src/conductor/router.py
@@ -276,6 +276,7 @@ def pick(
     exclude: frozenset[str] | set[str] | list[str] | None = None,
     priority: tuple[str, ...] = DEFAULT_PRIORITY,
     shadow: bool = False,
+    attachments_required: bool = False,
 ) -> tuple[Provider, RouteDecision]:
     """Pick the best provider for ``task_tags`` under the given preferences.
 
@@ -343,7 +344,11 @@ def pick(
             tools_ok = (
                 not tools_set or tools_set.issubset(provider.supported_tools)
             )
-            if tools_ok:
+            attachments_ok = (
+                not attachments_required
+                or getattr(provider, "supports_image_attachments", False)
+            )
+            if tools_ok and attachments_ok:
                 unconfigured[name] = failure
             continue
 
@@ -351,6 +356,11 @@ def pick(
         if tools_set and not tools_set.issubset(provider.supported_tools):
             missing = sorted(tools_set - provider.supported_tools)
             skipped.append((name, f"does not support tools: {missing}"))
+            continue
+        if attachments_required and not getattr(
+            provider, "supports_image_attachments", False
+        ):
+            skipped.append((name, "does not support image attachments"))
             continue
         # Session-local health filter.
         health_reason = _health_filter(name)
@@ -373,6 +383,7 @@ def pick(
         raise NoConfiguredProvider(
             "no provider satisfies the routing request. "
             f"prefer={prefer!r} tools={sorted(tools_set)} "
+            f"attachments_required={attachments_required} "
             f"exclude={sorted(exclude_set)}. Skipped: {skipped}"
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+"""Test-suite-wide fixtures and environment scrubbing.
+
+When pre-commit's pre-push hook runs the test suite, it inherits the bare
+repo's git env (notably ``GIT_DIR``). Tests that create disposable repos in
+``tmp_path`` and shell out to ``git`` then attach to the *bare repo's* index
+instead of their own — re-init warnings, contaminated indexes, and "no
+.pre-commit-config.yaml" failures from the bare repo's hooks chain all
+follow.
+
+We strip the offending vars once at collection so every test sees a clean
+environment regardless of how pytest was launched. The vars listed here
+are the full set git inspects to locate the active repo (see ``man
+git-environment``).
+"""
+
+from __future__ import annotations
+
+import os
+
+for _var in (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_COMMON_DIR",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_NAMESPACE",
+):
+    os.environ.pop(_var, None)

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -1205,6 +1205,48 @@ def test_codex_call_with_resume_uses_resume_subcommand(mocker):
     assert "--ephemeral" not in args
 
 
+def test_codex_call_forwards_attachments_as_image_flags(mocker, tmp_path):
+    """codex exec accepts `-i, --image <FILE>...` (repeatable). Conductor must
+    forward each attachment as a separate `-i <path>` pair so the provider
+    sees the file. Regression coverage for the cross-provider --attach plumbing."""
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    captured = mocker.patch(
+        "conductor.providers.codex.subprocess.run",
+        return_value=_fake_completed(stdout=CODEX_NDJSON),
+    )
+
+    img1 = tmp_path / "screen.png"
+    img1.write_bytes(b"\x89PNG\r\n\x1a\n")
+    img2 = tmp_path / "diagram.png"
+    img2.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    CodexProvider().call("look at these", attachments=(img1, img2))
+
+    args = captured.call_args.args[0]
+    image_pairs = [
+        (args[i], args[i + 1])
+        for i in range(len(args) - 1)
+        if args[i] == "-i"
+    ]
+    assert image_pairs == [
+        ("-i", str(img1)),
+        ("-i", str(img2)),
+    ]
+
+
+def test_codex_call_omits_image_flags_when_no_attachments(mocker):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    captured = mocker.patch(
+        "conductor.providers.codex.subprocess.run",
+        return_value=_fake_completed(stdout=CODEX_NDJSON),
+    )
+
+    CodexProvider().call("hi")
+
+    args = captured.call_args.args[0]
+    assert "-i" not in args
+
+
 def test_codex_call_raises_when_no_agent_message(mocker):
     mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
     mocker.patch(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -337,3 +337,53 @@ def test_router_defaults_list_marks_repo_override(monkeypatch, tmp_path):
     assert result.exit_code == 0, result.output
     assert "code-review = codex (repo override)" in result.output
     assert "long-context = gemini (home)" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --attach plumbing — image attachments to providers that accept them.
+# ---------------------------------------------------------------------------
+
+
+def test_call_attach_nonexistent_path_errors():
+    """Click's `exists=True` validation rejects bogus --attach paths up front."""
+    result = CliRunner().invoke(
+        main,
+        [
+            "call",
+            "--with",
+            "codex",
+            "--brief",
+            "look at this",
+            "--attach",
+            "/nonexistent/never-here.png",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "never-here.png" in result.output
+
+
+def test_call_attach_routed_to_text_only_provider_exits_2(monkeypatch, tmp_path):
+    """A user pointing --attach at a provider that doesn't accept attachments
+    must get a copy-pasteable fix instead of a silently dropped image."""
+    monkeypatch.setenv(OPENROUTER_API_KEY_ENV, "or-test-key")
+    _stub_kimi_catalog(monkeypatch)
+    img = tmp_path / "screen.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "call",
+            "--with",
+            "kimi",
+            "--brief",
+            "describe this image",
+            "--attach",
+            str(img),
+        ],
+    )
+
+    assert result.exit_code == 2, result.output
+    assert "kimi" in result.output
+    assert "image attachments" in result.output
+    assert "--with codex" in result.output

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -239,6 +239,27 @@ def test_unknown_tool_name_raises():
     assert "NotARealTool" in str(exc.value)
 
 
+def test_attachments_required_excludes_providers_without_capability(mocker):
+    """When the caller declares attachments_required=True, only providers with
+    supports_image_attachments=True survive routing — codex today, joined by
+    others as adapters opt in."""
+    _stub_configured(mocker, {"claude": True, "codex": True, "kimi": True})
+    provider, decision = pick(
+        [], prefer="best", attachments_required=True
+    )
+    assert provider.name == "codex"
+    skipped = dict(decision.candidates_skipped)
+    assert "does not support image attachments" in skipped["claude"]
+    assert "does not support image attachments" in skipped["kimi"]
+
+
+def test_attachments_required_no_eligible_provider_raises(mocker):
+    _stub_configured(mocker, {"claude": True, "kimi": True})
+    with pytest.raises(NoConfiguredProvider) as exc:
+        pick([], prefer="best", attachments_required=True)
+    assert "attachments_required=True" in str(exc.value)
+
+
 # ---------------------------------------------------------------------------
 # v0.2 — exclude
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
When pre-commit's pre-push hook runs the test suite, it inherits the bare
repo's `GIT_DIR` (and friends). Tests that create a disposable repo in
`tmp_path` and shell out to git then re-attach to the bare repo's index
instead of their own — observed as `re-init: ignored --initial-branch=main`
warnings, contaminated indexes in the surrounding worktree, and a cascade
of failures (`test_branch_guard.*`, `test_cli_v02.test_review_auto_*`,
`test_cli_log_file.test_exec_provider_stall_prints_git_recovery_hint`)
that pass when run via `uv run pytest` directly but fail under the
pre-push hook.

Strip the offending vars once at collection so every test sees a clean
git env regardless of how pytest was launched. The set listed mirrors
what `man git-environment` documents as the active-repo locator vars.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
