### PR TITLE
fix: route OpenRouter coding exec to curated stack

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -810,6 +810,7 @@ def _invoke_with_fallback(
                     "provider": candidate.name,
                     "mode": mode,
                     "model": model,
+                    "models": list(candidate_models or ()),
                     "tools": sorted(tools),
                     "sandbox": sandbox,
                     "cwd": cwd,

--- a/src/conductor/openrouter_model_stacks.py
+++ b/src/conductor/openrouter_model_stacks.py
@@ -1,0 +1,34 @@
+"""Audited OpenRouter model stacks for task classes where auto is too vague."""
+
+from __future__ import annotations
+
+OPENROUTER_CODING_STACK_VERSION = "2026-05-04"
+
+# Verified against OpenRouter's /models catalog on 2026-05-04. This is an
+# explicit quality policy for repo-editing tool-use work: do not delegate these
+# tasks to raw openrouter/auto, where upstream may choose cheap or flash models.
+OPENROUTER_CODING_HIGH: tuple[str, ...] = (
+    "openai/gpt-5.3-codex",
+    "openai/gpt-5.5",
+    "anthropic/claude-sonnet-4.6",
+    "google/gemini-3.1-pro-preview",
+    "qwen/qwen3-coder-plus",
+    "deepseek/deepseek-v4-pro",
+)
+
+OPENROUTER_CODING_MAX: tuple[str, ...] = (
+    "openai/gpt-5.3-codex",
+    "openai/gpt-5.5-pro",
+    "anthropic/claude-opus-4.7",
+    "anthropic/claude-sonnet-4.6",
+    "google/gemini-3.1-pro-preview",
+    "qwen/qwen3-coder-plus",
+    "deepseek/deepseek-v4-pro",
+)
+
+
+def openrouter_coding_stack(effort: str | int) -> tuple[str, ...]:
+    """Return the OpenRouter model stack for tool-using coding work."""
+    if effort == "max":
+        return OPENROUTER_CODING_MAX
+    return OPENROUTER_CODING_HIGH

--- a/src/conductor/providers/openrouter.py
+++ b/src/conductor/providers/openrouter.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 import httpx
 
 from conductor import credentials
+from conductor.openrouter_model_stacks import openrouter_coding_stack
 from conductor.providers.interface import (
     CallResponse,
     ProviderConfigError,
@@ -231,7 +232,10 @@ class OpenRouterProvider:
                 exclude=exclude,
             )
             payload.update(selector_payload)
-            selected_model = str(payload["model"])
+            if "models" in payload:
+                selected_model = str(payload["models"][0])
+            else:
+                selected_model = str(payload["model"])
             if payload.get("reasoning") is None:
                 payload.pop("reasoning", None)
             if log_selection:
@@ -538,14 +542,30 @@ def select_model_for_task(
             "Use best, balanced, cheapest, or fastest."
         )
 
+    task_tag_set = set(task_tags or [])
+    exclude_set = set(exclude or ())
+
     if prefer in {"best", "balanced"}:
+        if "tool-use" in task_tag_set:
+            coding_stack = tuple(
+                model
+                for model in openrouter_coding_stack(effort)
+                if model not in exclude_set
+            )
+            if not coding_stack:
+                raise ProviderError(
+                    "OpenRouter coding stack was fully excluded. "
+                    f"excluded models: {sorted(exclude_set)}"
+                )
+            return {
+                "models": list(coding_stack),
+                "reasoning": _reasoning_payload(effort),
+            }
         return {
             "model": OPENROUTER_DEFAULT_MODEL,
             "reasoning": _reasoning_payload(effort),
         }
 
-    task_tag_set = set(task_tags or [])
-    exclude_set = set(exclude or ())
     catalog = openrouter_catalog.load_catalog(
         force_refresh=True,
         allow_stale_on_error=False,
@@ -646,7 +666,9 @@ def _log_selector_choice(
     payload: dict[str, object],
 ) -> None:
     tags_text = ",".join(task_tags or []) or "none"
-    if payload["model"] == OPENROUTER_DEFAULT_MODEL:
+    if "models" in payload:
+        target = f"models={payload['models']}"
+    elif payload["model"] == OPENROUTER_DEFAULT_MODEL:
         plugins = payload.get("plugins") or []
         shortlist = []
         if plugins and isinstance(plugins, list):

--- a/src/conductor/semantic.py
+++ b/src/conductor/semantic.py
@@ -11,6 +11,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
+from conductor.openrouter_model_stacks import (
+    OPENROUTER_CODING_HIGH,
+    OPENROUTER_CODING_MAX,
+)
+
 SemanticKind = Literal["research", "code", "review", "council"]
 SemanticMode = Literal["call", "exec", "review", "council"]
 EffortBucket = Literal["minimal", "low", "medium", "high", "max"]
@@ -171,7 +176,7 @@ _CODE: dict[EffortBucket, SemanticPlan] = {
         candidates=(
             SemanticCandidate("codex"),
             SemanticCandidate("claude"),
-            SemanticCandidate("openrouter"),
+            SemanticCandidate("openrouter", OPENROUTER_CODING_HIGH),
             SemanticCandidate("ollama"),
         ),
     ),
@@ -185,7 +190,7 @@ _CODE: dict[EffortBucket, SemanticPlan] = {
         candidates=(
             SemanticCandidate("codex"),
             SemanticCandidate("claude"),
-            SemanticCandidate("openrouter"),
+            SemanticCandidate("openrouter", OPENROUTER_CODING_MAX),
             SemanticCandidate("ollama"),
         ),
     ),

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -24,6 +24,7 @@ import respx
 from click.testing import CliRunner
 
 from conductor.cli import SANDBOX_DEPRECATION_WARNING, main
+from conductor.openrouter_model_stacks import OPENROUTER_CODING_HIGH
 from conductor.providers import (
     CallResponse,
     ClaudeProvider,
@@ -519,6 +520,7 @@ def test_ask_code_high_falls_back_to_openrouter_exec_before_ollama(mocker):
     assert exec_mock.call_args.kwargs["tools"] == frozenset(
         {"Read", "Grep", "Glob", "Edit", "Write", "Bash"}
     )
+    assert exec_mock.call_args.kwargs["models"] == OPENROUTER_CODING_HIGH
     payload = json.loads(result.stdout)
     assert [candidate["provider"] for candidate in payload["semantic"]["candidates"]] == [
         "codex",
@@ -526,6 +528,9 @@ def test_ask_code_high_falls_back_to_openrouter_exec_before_ollama(mocker):
         "openrouter",
         "ollama",
     ]
+    assert payload["semantic"]["candidates"][2]["models"] == list(
+        OPENROUTER_CODING_HIGH
+    )
 
 
 def test_ask_code_medium_falls_through_from_openrouter_404_to_ollama(mocker):

--- a/tests/test_openrouter.py
+++ b/tests/test_openrouter.py
@@ -9,6 +9,7 @@ import pytest
 import respx
 
 import conductor.providers.openrouter_catalog as openrouter_catalog
+from conductor.openrouter_model_stacks import OPENROUTER_CODING_HIGH
 from conductor.providers.deepseek import DeepSeekChatProvider, DeepSeekReasonerProvider
 from conductor.providers.interface import (
     CallResponse,
@@ -451,6 +452,44 @@ def test_exec_with_tools_runs_openai_tool_loop(configured, tmp_path):
         "name": "Read",
         "content": "tool loop works",
     }
+
+
+def test_exec_with_tools_uses_curated_coding_stack_by_default(configured, tmp_path):
+    captured: dict[str, object] = {}
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        captured["payload"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "model": OPENROUTER_CODING_HIGH[0],
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "implementation complete",
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 3},
+            },
+        )
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.post("/chat/completions").mock(side_effect=_record)
+        response = OpenRouterProvider().exec(
+            "Implement the change.",
+            tools=frozenset({"Read", "Edit", "Write"}),
+            sandbox="none",
+            cwd=str(tmp_path),
+        )
+
+    assert response.model == OPENROUTER_CODING_HIGH[0]
+    assert captured["payload"]["models"] == list(OPENROUTER_CODING_HIGH)
+    assert "model" not in captured["payload"]
+    assert "openrouter/auto" not in captured["payload"]["models"]
+    assert "google/gemini-2.5-flash-lite" not in captured["payload"]["models"]
 
 
 def test_exec_with_tools_rejects_model_and_models_together(configured):

--- a/tests/test_openrouter_selector.py
+++ b/tests/test_openrouter_selector.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import pytest
 
 import conductor.providers.openrouter_catalog as openrouter_catalog
+from conductor.openrouter_model_stacks import (
+    OPENROUTER_CODING_HIGH,
+    OPENROUTER_CODING_MAX,
+)
 from conductor.providers.interface import ProviderError
 from conductor.providers.openrouter import OPENROUTER_DEFAULT_MODEL, select_model_for_task
 
@@ -109,6 +113,71 @@ def test_prefer_best_returns_unrestricted_auto_without_catalog(mocker, fixture_c
     assert payload["model"] == OPENROUTER_DEFAULT_MODEL
     assert payload["reasoning"] == {"effort": "medium"}
     assert "plugins" not in payload
+    load_catalog.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("prefer", "effort", "expected_stack"),
+    [
+        ("best", "high", OPENROUTER_CODING_HIGH),
+        ("balanced", "medium", OPENROUTER_CODING_HIGH),
+        ("best", "max", OPENROUTER_CODING_MAX),
+    ],
+)
+def test_tool_use_best_and_balanced_use_curated_coding_stack_without_catalog(
+    mocker,
+    fixture_catalog,
+    prefer,
+    effort,
+    expected_stack,
+):
+    load_catalog = mocker.patch(
+        "conductor.providers.openrouter_catalog.load_catalog",
+        return_value=fixture_catalog,
+    )
+
+    payload = select_model_for_task(["tool-use", "strong-reasoning"], prefer, effort)
+
+    assert payload["models"] == list(expected_stack)
+    assert payload["models"][0] == "openai/gpt-5.3-codex"
+    assert payload["reasoning"] == {"effort": "xhigh" if effort == "max" else effort}
+    assert "model" not in payload
+    assert OPENROUTER_DEFAULT_MODEL not in payload["models"]
+    assert "google/gemini-2.5-flash-lite" not in payload["models"]
+    load_catalog.assert_not_called()
+
+
+def test_tool_use_coding_stack_honors_excluded_models(mocker, fixture_catalog):
+    load_catalog = mocker.patch(
+        "conductor.providers.openrouter_catalog.load_catalog",
+        return_value=fixture_catalog,
+    )
+
+    payload = select_model_for_task(
+        ["tool-use"],
+        "best",
+        "high",
+        exclude={OPENROUTER_CODING_HIGH[0]},
+    )
+
+    assert payload["models"] == list(OPENROUTER_CODING_HIGH[1:])
+    load_catalog.assert_not_called()
+
+
+def test_tool_use_coding_stack_errors_when_fully_excluded(mocker, fixture_catalog):
+    load_catalog = mocker.patch(
+        "conductor.providers.openrouter_catalog.load_catalog",
+        return_value=fixture_catalog,
+    )
+
+    with pytest.raises(ProviderError, match="coding stack was fully excluded"):
+        select_model_for_task(
+            ["tool-use"],
+            "best",
+            "high",
+            exclude=set(OPENROUTER_CODING_HIGH),
+        )
+
     load_catalog.assert_not_called()
 
 

--- a/tests/test_semantic.py
+++ b/tests/test_semantic.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import pytest
 
+from conductor.openrouter_model_stacks import (
+    OPENROUTER_CODING_HIGH,
+    OPENROUTER_CODING_MAX,
+)
 from conductor.semantic import SEMANTIC_KINDS, plan_for
 
 
@@ -47,6 +51,14 @@ def test_high_code_escalates_to_agentic_coding_stack(effort):
         "openrouter",
         "ollama",
     ]
+    openrouter_candidate = plan.candidates[2]
+    expected_stack = (
+        OPENROUTER_CODING_MAX if effort == "max" else OPENROUTER_CODING_HIGH
+    )
+    assert openrouter_candidate.models == expected_stack
+    assert openrouter_candidate.models[0] == "openai/gpt-5.3-codex"
+    assert "openrouter/auto" not in openrouter_candidate.models
+    assert "google/gemini-2.5-flash-lite" not in openrouter_candidate.models
     assert plan.tools == frozenset({"Read", "Grep", "Glob", "Edit", "Write", "Bash"})
     assert plan.sandbox == "none"
 


### PR DESCRIPTION
## Summary

Fixes #163.

High-effort code delegation now treats OpenRouter as an explicit coding fallback instead of sending repo-editing tool-use work to raw `openrouter/auto`.

## Changes

- Add an audited OpenRouter coding model stack, verified against `/models` on 2026-05-04.
- Wire high/max `ask --kind code` OpenRouter fallbacks to that stack.
- Update OpenRouter's own selector so `exec --with openrouter --tools ...` uses the same stack for `tool-use` best/balanced requests.
- Log candidate model stacks in fallback provider-start events.
- Add regression tests proving high-effort code and explicit OpenRouter tool-use do not select `openrouter/auto` or `google/gemini-2.5-flash-lite`.

## Validation

- `uv run ruff check src/ tests/`
- `uv run pytest`

Result: `786 passed, 16 skipped`.