### PR TITLE
fix: route code and review fallbacks through OpenRouter stacks

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -1001,6 +1001,7 @@ def _invoke_review_with_fallback(
     title: str | None,
     silent: bool,
     max_fallbacks: int = DEFAULT_REVIEW_MAX_FALLBACKS,
+    models_by_provider: dict[str, tuple[str, ...]] | None = None,
 ) -> tuple[CallResponse, list[str]]:
     """Try code-review providers in route order."""
     last_exc: Exception | None = None
@@ -1034,6 +1035,7 @@ def _invoke_review_with_fallback(
                         cwd=cwd,
                         include_patch=True,
                     ),
+                    models=(models_by_provider or {}).get(candidate.name),
                     effort=effort,
                     task_tags=list(decision.task_tags),
                     prefer=decision.prefer,
@@ -1855,12 +1857,14 @@ def ask(
         review_exclude, review_reasons = _review_exclude_set(
             frozenset()
         )
+        exclude_set = _semantic_candidate_exclude_set(plan, review_exclude)
         try:
             _provider, decision = pick(
                 list(plan.tags),
                 prefer=plan.prefer,
                 effort=effort_value,
-                exclude=review_exclude,
+                exclude=exclude_set,
+                priority=_semantic_priority(plan),
                 shadow=True,
             )
         except (NoConfiguredProvider, InvalidRouterRequest, MutedProvidersError) as e:
@@ -1882,6 +1886,11 @@ def ask(
                 uncommitted=uncommitted,
                 title=title,
                 silent=silent_route or as_json,
+                models_by_provider={
+                    candidate.provider: candidate.models
+                    for candidate in plan.candidates
+                    if candidate.models
+                },
             )
         except ProviderConfigError as e:
             click.echo(f"conductor: {e}", err=True)

--- a/src/conductor/semantic.py
+++ b/src/conductor/semantic.py
@@ -175,7 +175,6 @@ _CODE: dict[EffortBucket, SemanticPlan] = {
         tools=_CODE_EXEC_TOOLS,
         candidates=(
             SemanticCandidate("codex"),
-            SemanticCandidate("claude"),
             SemanticCandidate("openrouter", OPENROUTER_CODING_HIGH),
             SemanticCandidate("ollama"),
         ),
@@ -189,7 +188,6 @@ _CODE: dict[EffortBucket, SemanticPlan] = {
         tools=_CODE_EXEC_TOOLS,
         candidates=(
             SemanticCandidate("codex"),
-            SemanticCandidate("claude"),
             SemanticCandidate("openrouter", OPENROUTER_CODING_MAX),
             SemanticCandidate("ollama"),
         ),

--- a/src/conductor/semantic.py
+++ b/src/conductor/semantic.py
@@ -205,7 +205,12 @@ _REVIEW: dict[EffortBucket, SemanticPlan] = {
         candidates=(
             SemanticCandidate("codex"),
             SemanticCandidate("claude"),
-            SemanticCandidate("gemini"),
+            SemanticCandidate(
+                "openrouter",
+                OPENROUTER_CODING_MAX
+                if bucket == "max"
+                else OPENROUTER_CODING_HIGH,
+            ),
         ),
     )
     for bucket in EFFORT_BUCKETS

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -454,19 +454,19 @@ def test_ask_code_high_routes_to_codex_exec_with_default_tools(mocker):
     assert exec_mock.call_args.kwargs["sandbox"] == "none"
 
 
-def test_ask_code_high_falls_back_immediately_on_quota(mocker):
+def test_ask_code_high_falls_back_immediately_to_openrouter_on_quota(mocker):
     from conductor.providers.interface import ProviderHTTPError
 
-    _stub_all_configured(mocker, {"codex", "claude"})
+    _stub_all_configured(mocker, {"codex", "openrouter"})
     codex_exec = mocker.patch.object(
         CodexProvider,
         "exec",
         side_effect=ProviderHTTPError("codex reported rate limit: out of tokens"),
     )
-    claude_exec = mocker.patch.object(
-        ClaudeProvider,
+    openrouter_exec = mocker.patch.object(
+        OpenRouterProvider,
         "exec",
-        return_value=_fake_response("claude"),
+        return_value=_fake_response("openrouter"),
     )
 
     result = CliRunner().invoke(
@@ -485,10 +485,11 @@ def test_ask_code_high_falls_back_immediately_on_quota(mocker):
 
     assert result.exit_code == 0, result.output
     assert codex_exec.called
-    assert claude_exec.called
+    assert openrouter_exec.called
+    assert openrouter_exec.call_args.kwargs["models"] == OPENROUTER_CODING_HIGH
     assert "codex failed (rate-limit)" in result.stderr
     assert "falling back" in result.stderr
-    assert "→ claude" in result.stderr
+    assert "→ openrouter" in result.stderr
 
 
 def test_ask_code_high_falls_back_to_openrouter_exec_before_ollama(mocker):
@@ -524,11 +525,10 @@ def test_ask_code_high_falls_back_to_openrouter_exec_before_ollama(mocker):
     payload = json.loads(result.stdout)
     assert [candidate["provider"] for candidate in payload["semantic"]["candidates"]] == [
         "codex",
-        "claude",
         "openrouter",
         "ollama",
     ]
-    assert payload["semantic"]["candidates"][2]["models"] == list(
+    assert payload["semantic"]["candidates"][1]["models"] == list(
         OPENROUTER_CODING_HIGH
     )
 

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -795,6 +795,68 @@ def test_review_auto_generic_fallback_prompt_includes_diff(mocker, tmp_path):
     assert "+fallback diff marker" in prompt
 
 
+def test_ask_review_uses_openrouter_code_stack_instead_of_gemini(mocker, tmp_path):
+    from conductor.providers.interface import ProviderStalledError
+
+    repo = _make_diff_repo(tmp_path)
+    _stub_all_configured(mocker, {"codex", "claude", "gemini", "openrouter"})
+    mocker.patch.object(CodexProvider, "review_configured", return_value=(True, None))
+    mocker.patch.object(ClaudeProvider, "review_configured", return_value=(True, None))
+    mocker.patch.object(GeminiProvider, "review_configured", return_value=(True, None))
+    mocker.patch.object(
+        CodexProvider,
+        "review",
+        side_effect=ProviderStalledError("codex review stalled"),
+    )
+    mocker.patch.object(
+        ClaudeProvider,
+        "review",
+        side_effect=ProviderStalledError("claude review stalled"),
+    )
+    gemini_review = mocker.patch.object(
+        GeminiProvider,
+        "review",
+        return_value=_fake_response("gemini", "gemini-2.5-pro"),
+    )
+    openrouter_call = mocker.patch.object(
+        OpenRouterProvider,
+        "call",
+        return_value=_fake_response("openrouter", OPENROUTER_CODING_HIGH[0]),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "ask",
+            "--kind",
+            "review",
+            "--cwd",
+            str(repo),
+            "--base",
+            "HEAD~1",
+            "--brief",
+            "Review this merge using the project reviewer guide.",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert not gemini_review.called
+    assert openrouter_call.called
+    assert openrouter_call.call_args.kwargs["models"] == OPENROUTER_CODING_HIGH
+    prompt = openrouter_call.call_args.args[0]
+    assert "Patch context for generic review fallback" in prompt
+    payload = json.loads(result.stdout)
+    assert [candidate["provider"] for candidate in payload["semantic"]["candidates"]] == [
+        "codex",
+        "claude",
+        "openrouter",
+    ]
+    assert payload["semantic"]["candidates"][2]["models"] == list(
+        OPENROUTER_CODING_HIGH
+    )
+
+
 def test_review_auto_generic_fallback_repairs_requested_sentinel(mocker, tmp_path):
     from conductor.providers.interface import ProviderStalledError
 

--- a/tests/test_semantic.py
+++ b/tests/test_semantic.py
@@ -47,11 +47,10 @@ def test_high_code_escalates_to_agentic_coding_stack(effort):
     assert plan.mode == "exec"
     assert [candidate.provider for candidate in plan.candidates] == [
         "codex",
-        "claude",
         "openrouter",
         "ollama",
     ]
-    openrouter_candidate = plan.candidates[2]
+    openrouter_candidate = plan.candidates[1]
     expected_stack = (
         OPENROUTER_CODING_MAX if effort == "max" else OPENROUTER_CODING_HIGH
     )

--- a/tests/test_semantic.py
+++ b/tests/test_semantic.py
@@ -62,6 +62,22 @@ def test_high_code_escalates_to_agentic_coding_stack(effort):
     assert plan.sandbox == "none"
 
 
+@pytest.mark.parametrize("effort", ["minimal", "low", "medium", "high", "max"])
+def test_review_uses_openrouter_code_stack_after_native_reviewers(effort):
+    plan = plan_for("review", effort)
+
+    assert plan.mode == "review"
+    assert [candidate.provider for candidate in plan.candidates] == [
+        "codex",
+        "claude",
+        "openrouter",
+    ]
+    expected_stack = (
+        OPENROUTER_CODING_MAX if effort == "max" else OPENROUTER_CODING_HIGH
+    )
+    assert plan.candidates[2].models == expected_stack
+
+
 def test_integer_effort_maps_into_bucketed_matrix():
     assert plan_for("research", 0).effort_bucket == "minimal"
     assert plan_for("research", 1).effort_bucket == "low"


### PR DESCRIPTION
## Summary

High/max semantic code execution now falls back from Codex directly to the curated OpenRouter coding stack, then to Ollama. Semantic review now uses `codex > claude > openrouter:[coding stack]`, replacing Gemini as the default third reviewer fallback.

Claude remains available for review and explicit provider use, but it is no longer in the default repo-changing code execution stack. Gemini remains available for explicit `--with gemini`, but is no longer the semantic review fallback.

## Why

Claude quota/rate-limit behavior is already handled, but for autonomous coding delegation we want the high-quality OpenRouter coding stack to be the immediate remote fallback after Codex.

For review, OpenRouter's curated coding stack is a better default generic fallback than Gemini when Codex/Claude native review are unavailable.

## Validation

- `uv run ruff check src/ tests/`
- `uv run pytest`
- `uv run python` route smoke confirmed:
  - code high: `codex > openrouter > ollama`
  - review high: `codex > claude > openrouter`

Result: `792 passed, 16 skipped`.