### PR TITLE
[codex] tolerate empty council member responses

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -1216,7 +1216,8 @@ def _council_synthesis_prompt(task: str, member_responses: list[CallResponse]) -
     sections = []
     for i, response in enumerate(member_responses, start=1):
         sections.append(
-            f"## Member {i}: {response.model}\n\n{response.text.strip()}"
+            f"## Member {i}: {response.model}\n\n"
+            f"{_council_member_response_text(response)}"
         )
     return (
         "You are synthesizing a multi-model council. Compare the independent "
@@ -1228,6 +1229,16 @@ def _council_synthesis_prompt(task: str, member_responses: list[CallResponse]) -
         "Council member responses:\n\n"
         + "\n\n".join(sections)
     )
+
+
+def _council_member_response_text(response: CallResponse) -> str:
+    text = getattr(response, "text", None)
+    if text is None:
+        return "[empty response]"
+    if not isinstance(text, str):
+        text = str(text)
+    stripped = text.strip()
+    return stripped if stripped else "[empty response]"
 
 
 def _emit_call(

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -642,6 +642,24 @@ def test_ask_council_fans_out_through_openrouter_only(mocker):
     assert payload["semantic"]["candidates"][0]["provider"] == "openrouter"
 
 
+def test_council_synthesis_prompt_handles_empty_member_text():
+    from conductor.cli import _council_synthesis_prompt
+
+    response = CallResponse(
+        text=None,
+        provider="openrouter",
+        model="member-a",
+        duration_ms=10,
+        usage={},
+        raw={},
+    )
+
+    prompt = _council_synthesis_prompt("Debate this.", [response])
+
+    assert "## Member 1: member-a\n\n[empty response]" in prompt
+    assert "None" not in prompt
+
+
 def test_ask_council_rejects_offline():
     result = CliRunner().invoke(
         main,


### PR DESCRIPTION
## Summary

Fixes #161.

Prevents `ask --kind council` from crashing during synthesis when a council member returns an empty response or a response object with `text=None`.

## What changed

- Added a small council-member text normalizer for synthesis prompts.
- Empty or `None` member text now renders as `[empty response]` so synthesis can continue without hiding that the member produced no usable text.
- Added a regression test for `None` member text.

## Validation

- `uv run ruff check src/conductor/cli.py tests/test_cli_v02.py`
- `uv run pytest tests/test_cli_v02.py -q`
- `uv run mypy .`
- `uv run pytest -q`