### PR TITLE
[codex] audit curated OpenRouter model stacks

### DIFF
--- a/.github/workflows/nightly-smoke.yml
+++ b/.github/workflows/nightly-smoke.yml
@@ -18,6 +18,87 @@ permissions:
   issues: write
 
 jobs:
+  openrouter-stack-audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Audit curated OpenRouter stacks
+        id: stack_audit
+        shell: bash
+        run: |
+          set +e
+          uv run conductor models validate-stacks --json \
+            > openrouter-stack-audit.json \
+            2> openrouter-stack-audit.err
+          status=$?
+          cat openrouter-stack-audit.json
+          cat openrouter-stack-audit.err
+          exit "$status"
+
+      - name: Open failure issue
+        if: failure() && steps.stack_audit.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          {
+            echo "Curated OpenRouter model stack audit failed."
+            echo
+            echo "Run: $RUN_URL"
+            echo
+            echo '```json'
+            cat openrouter-stack-audit.json
+            echo '```'
+            if [ -s openrouter-stack-audit.err ]; then
+              echo
+              echo '```'
+              cat openrouter-stack-audit.err
+              echo '```'
+            fi
+          } > openrouter-stack-audit-issue.md
+
+          if ! gh label list --search openrouter-stack-audit --json name --jq '.[].name' \
+            | grep -qx openrouter-stack-audit; then
+            gh label create openrouter-stack-audit \
+              --description "Curated OpenRouter stack audit failure" \
+              --color 6A4C93
+          fi
+          existing_issue="$(
+            gh issue list \
+              --state open \
+              --label openrouter-stack-audit \
+              --json number \
+              --jq '.[0].number // empty'
+          )"
+          if [ -n "$existing_issue" ]; then
+            gh issue comment "$existing_issue" --body-file openrouter-stack-audit-issue.md
+          else
+            gh issue create \
+              --title "OpenRouter coding stack audit failed: $(date -u +%Y-%m-%d)" \
+              --label openrouter-stack-audit \
+              --body-file openrouter-stack-audit-issue.md
+          fi
+
+      - name: Log heartbeat
+        if: success()
+        run: |
+          echo "OpenRouter stack audit passed at $(date -u --iso-8601=seconds)." >> "$GITHUB_STEP_SUMMARY"
+
   subprocess-adapter-live-smoke:
     runs-on: ubuntu-latest
 

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -38,6 +38,10 @@ from conductor.muted_providers import (
     muted_providers_file_path,
     unmute_provider_ids,
 )
+from conductor.openrouter_stack_audit import (
+    StackAuditReport,
+    audit_openrouter_coding_stacks,
+)
 from conductor.profiles import ProfileError, ProfileSpec, get_profile, load_profiles
 from conductor.providers import (
     QUALITY_TIERS,
@@ -4099,6 +4103,33 @@ def models_refresh() -> None:
     )
 
 
+@models.command("validate-stacks")
+@click.option(
+    "--no-refresh",
+    is_flag=True,
+    help="Use the cached OpenRouter catalog instead of fetching the live catalog.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit machine-readable JSON.")
+def models_validate_stacks(no_refresh: bool, as_json: bool) -> None:
+    """Validate curated OpenRouter stacks against the catalog."""
+    try:
+        snapshot = openrouter_catalog.load_catalog_snapshot(
+            force_refresh=not no_refresh,
+            allow_stale_on_error=no_refresh,
+        )
+    except ProviderHTTPError as e:
+        raise click.ClickException(str(e)) from e
+
+    report = audit_openrouter_coding_stacks(snapshot)
+    if as_json:
+        click.echo(json.dumps(report.to_dict(), indent=2, sort_keys=True))
+    else:
+        _emit_stack_audit_report(report)
+
+    if report.has_errors:
+        sys.exit(1)
+
+
 @models.command("list")
 def models_list() -> None:
     """Print the cached OpenRouter catalog summary."""
@@ -4165,6 +4196,30 @@ def models_show(slug: str) -> None:
         f"tools={'yes' if model.supports_tools else 'no'} · "
         f"vision={'yes' if model.supports_vision else 'no'}"
     )
+
+
+def _emit_stack_audit_report(report: StackAuditReport) -> None:
+    click.echo(
+        "OpenRouter coding stack audit "
+        f"(version {report.stack_version}, catalog "
+        f"{openrouter_catalog.format_timestamp(report.catalog_fetched_at)})"
+    )
+    click.echo(report.policy)
+    click.echo("")
+    if not report.findings:
+        click.echo("No stack issues found.")
+        return
+
+    errors = [finding for finding in report.findings if finding.severity == "error"]
+    warnings = [
+        finding for finding in report.findings if finding.severity == "warning"
+    ]
+    click.echo(f"{len(errors)} error(s), {len(warnings)} warning(s)")
+    for finding in report.findings:
+        click.echo(
+            f"- {finding.severity.upper()} {finding.stack} {finding.model}: "
+            f"{finding.code} - {finding.message}"
+        )
 
 
 # --------------------------------------------------------------------------- #

--- a/src/conductor/openrouter_model_stacks.py
+++ b/src/conductor/openrouter_model_stacks.py
@@ -7,6 +7,25 @@ OPENROUTER_CODING_STACK_VERSION = "2026-05-04"
 # Verified against OpenRouter's /models catalog on 2026-05-04. This is an
 # explicit quality policy for repo-editing tool-use work: do not delegate these
 # tasks to raw openrouter/auto, where upstream may choose cheap or flash models.
+OPENROUTER_CODING_STACK_POLICY = (
+    "Manual quality policy for repo-editing tool-use work. Catalog validation "
+    "can prove availability/capabilities, but ordering still requires human "
+    "judgment from coding benchmarks, dogfood runs, and provider reliability."
+)
+
+OPENROUTER_CODING_MODEL_EVIDENCE: dict[str, str] = {
+    "openai/gpt-5.3-codex": "Primary coding-agent fallback; optimized for repo edits and tool use.",
+    "openai/gpt-5.5": "Frontier general reasoning model kept as a broad coding fallback.",
+    "openai/gpt-5.5-pro": "Max-effort OpenAI reasoning fallback for the hardest coding briefs.",
+    "anthropic/claude-opus-4.7": "Max-effort cross-vendor reasoning fallback.",
+    "anthropic/claude-sonnet-4.6": "Fast frontier coding fallback with strong tool-use behavior.",
+    "google/gemini-3.1-pro-preview": (
+        "High-context cross-vendor fallback; preview status requires monitoring."
+    ),
+    "qwen/qwen3-coder-plus": "Specialized coding model included for implementation breadth.",
+    "deepseek/deepseek-v4-pro": "Specialized coding/reasoning fallback for stack diversity.",
+}
+
 OPENROUTER_CODING_HIGH: tuple[str, ...] = (
     "openai/gpt-5.3-codex",
     "openai/gpt-5.5",

--- a/src/conductor/openrouter_stack_audit.py
+++ b/src/conductor/openrouter_stack_audit.py
@@ -1,0 +1,261 @@
+"""Audit curated OpenRouter model stacks against the live catalog.
+
+The audit is deliberately a report, not an auto-updater. It validates catalog
+availability and capabilities while keeping quality ordering in the explicit
+policy file.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING, Literal
+
+from conductor import openrouter_model_stacks
+
+if TYPE_CHECKING:
+    from conductor.providers.openrouter_catalog import CatalogSnapshot, ModelEntry
+
+STACK_CONTEXT_WARNING_THRESHOLD = 100_000
+
+Severity = Literal["error", "warning"]
+
+
+@dataclass(frozen=True)
+class StackDefinition:
+    name: str
+    effort: str
+    models: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class StackFinding:
+    severity: Severity
+    stack: str
+    model: str
+    code: str
+    message: str
+
+
+@dataclass(frozen=True)
+class StackModelAudit:
+    stack: str
+    position: int
+    model: str
+    catalog_available: bool
+    direct_sendable: bool
+    supports_tools: bool | None
+    supports_thinking: bool | None
+    context_length: int | None
+    caveats: tuple[str, ...]
+    rationale: str | None
+
+
+@dataclass(frozen=True)
+class StackAuditReport:
+    stack_version: str
+    policy: str
+    catalog_fetched_at: int
+    models: tuple[StackModelAudit, ...]
+    findings: tuple[StackFinding, ...]
+
+    @property
+    def has_errors(self) -> bool:
+        return any(finding.severity == "error" for finding in self.findings)
+
+    @property
+    def has_warnings(self) -> bool:
+        return any(finding.severity == "warning" for finding in self.findings)
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def default_openrouter_coding_stacks() -> tuple[StackDefinition, ...]:
+    return (
+        StackDefinition(
+            name="OPENROUTER_CODING_HIGH",
+            effort="high",
+            models=openrouter_model_stacks.OPENROUTER_CODING_HIGH,
+        ),
+        StackDefinition(
+            name="OPENROUTER_CODING_MAX",
+            effort="max",
+            models=openrouter_model_stacks.OPENROUTER_CODING_MAX,
+        ),
+    )
+
+
+def audit_openrouter_coding_stacks(
+    snapshot: CatalogSnapshot,
+    *,
+    stacks: tuple[StackDefinition, ...] | None = None,
+) -> StackAuditReport:
+    by_id = {model.id: model for model in snapshot.models}
+    stack_defs = stacks or default_openrouter_coding_stacks()
+    audited_models: list[StackModelAudit] = []
+    findings: list[StackFinding] = []
+
+    for stack in stack_defs:
+        for position, model_id in enumerate(stack.models, start=1):
+            catalog_model = by_id.get(model_id)
+            direct_sendable = model_id in by_id and not model_id.startswith("~")
+            caveats = _model_caveats(model_id, catalog_model)
+            audited_models.append(
+                StackModelAudit(
+                    stack=stack.name,
+                    position=position,
+                    model=model_id,
+                    catalog_available=catalog_model is not None,
+                    direct_sendable=direct_sendable,
+                    supports_tools=(
+                        None if catalog_model is None else catalog_model.supports_tools
+                    ),
+                    supports_thinking=(
+                        None if catalog_model is None else catalog_model.supports_thinking
+                    ),
+                    context_length=(
+                        None if catalog_model is None else catalog_model.context_length
+                    ),
+                    caveats=tuple(caveats),
+                    rationale=openrouter_model_stacks.OPENROUTER_CODING_MODEL_EVIDENCE.get(
+                        model_id
+                    ),
+                )
+            )
+            findings.extend(_findings_for_model(stack, model_id, catalog_model))
+
+    return StackAuditReport(
+        stack_version=openrouter_model_stacks.OPENROUTER_CODING_STACK_VERSION,
+        policy=openrouter_model_stacks.OPENROUTER_CODING_STACK_POLICY,
+        catalog_fetched_at=snapshot.fetched_at,
+        models=tuple(audited_models),
+        findings=tuple(findings),
+    )
+
+
+def _findings_for_model(
+    stack: StackDefinition,
+    model_id: str,
+    catalog_model: ModelEntry | None,
+) -> list[StackFinding]:
+    findings: list[StackFinding] = []
+    if model_id.startswith("~"):
+        findings.append(
+            _finding(
+                "error",
+                stack,
+                model_id,
+                "alias-not-sendable",
+                "moving OpenRouter aliases are policy labels, not direct request slugs",
+            )
+        )
+        return findings
+
+    if catalog_model is None:
+        findings.append(
+            _finding(
+                "error",
+                stack,
+                model_id,
+                "missing-from-catalog",
+                "model is absent from the live OpenRouter catalog",
+            )
+        )
+        return findings
+
+    if _is_free_tier(model_id):
+        findings.append(
+            _finding(
+                "error",
+                stack,
+                model_id,
+                "free-tier-model",
+                "free-tier models are not eligible for curated coding fallback stacks",
+            )
+        )
+    if not catalog_model.supports_tools:
+        findings.append(
+            _finding(
+                "error",
+                stack,
+                model_id,
+                "missing-tool-support",
+                "model does not advertise OpenRouter tools support",
+            )
+        )
+    if not catalog_model.supports_thinking:
+        findings.append(
+            _finding(
+                "warning",
+                stack,
+                model_id,
+                "missing-reasoning-support",
+                "model does not advertise reasoning/reasoning_effort support",
+            )
+        )
+    if catalog_model.context_length < STACK_CONTEXT_WARNING_THRESHOLD:
+        findings.append(
+            _finding(
+                "warning",
+                stack,
+                model_id,
+                "short-context",
+                f"context length is below {STACK_CONTEXT_WARNING_THRESHOLD:,}",
+            )
+        )
+    if "preview" in model_id.lower():
+        findings.append(
+            _finding(
+                "warning",
+                stack,
+                model_id,
+                "preview-model",
+                "preview models can change behavior or disappear without notice",
+            )
+        )
+    if model_id not in openrouter_model_stacks.OPENROUTER_CODING_MODEL_EVIDENCE:
+        findings.append(
+            _finding(
+                "warning",
+                stack,
+                model_id,
+                "missing-policy-evidence",
+                "curated stack entry has no recorded quality-policy rationale",
+            )
+        )
+    return findings
+
+
+def _finding(
+    severity: Severity,
+    stack: StackDefinition,
+    model_id: str,
+    code: str,
+    message: str,
+) -> StackFinding:
+    return StackFinding(
+        severity=severity,
+        stack=stack.name,
+        model=model_id,
+        code=code,
+        message=message,
+    )
+
+
+def _model_caveats(model_id: str, catalog_model: ModelEntry | None) -> list[str]:
+    caveats: list[str] = []
+    if model_id.startswith("~"):
+        caveats.append("alias")
+    if _is_free_tier(model_id):
+        caveats.append("free-tier")
+    if "preview" in model_id.lower():
+        caveats.append("preview")
+    if catalog_model is not None and not catalog_model.supports_tools:
+        caveats.append("no-tools")
+    if catalog_model is not None and not catalog_model.supports_thinking:
+        caveats.append("no-reasoning")
+    return caveats
+
+
+def _is_free_tier(model_id: str) -> bool:
+    return model_id.lower().endswith(":free") or ":free/" in model_id.lower()

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -6,8 +6,10 @@ import httpx
 import respx
 from click.testing import CliRunner
 
+import conductor.openrouter_stack_audit as openrouter_stack_audit
 import conductor.providers.openrouter_catalog as openrouter_catalog
 from conductor.cli import main
+from conductor.openrouter_stack_audit import StackDefinition
 
 
 def _patch_catalog_cache(monkeypatch, tmp_path):
@@ -99,6 +101,31 @@ def test_models_show_prints_one_model(monkeypatch, tmp_path):
     assert "Claude Sonnet 4.6" in result.output
     assert "context length: 200,000" in result.output
     assert "thinking=yes" in result.output
+
+
+def test_models_validate_stacks_reports_curated_stack(monkeypatch, tmp_path):
+    _patch_catalog_cache(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        openrouter_stack_audit,
+        "default_openrouter_coding_stacks",
+        lambda: (
+            StackDefinition(
+                name="TEST_STACK",
+                effort="high",
+                models=("anthropic/claude-sonnet-4.6",),
+            ),
+        ),
+    )
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.get("/models").mock(
+            return_value=httpx.Response(200, json=_catalog_response())
+        )
+        result = CliRunner().invoke(main, ["models", "validate-stacks", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert '"stack_version"' in result.output
+    assert "anthropic/claude-sonnet-4.6" in result.output
 
 
 def test_models_list_errors_when_cache_is_missing(monkeypatch, tmp_path):

--- a/tests/test_openrouter_stack_audit.py
+++ b/tests/test_openrouter_stack_audit.py
@@ -1,0 +1,126 @@
+"""Tests for audited OpenRouter model stack validation."""
+
+from __future__ import annotations
+
+from conductor.openrouter_stack_audit import (
+    StackDefinition,
+    audit_openrouter_coding_stacks,
+)
+from conductor.providers.openrouter_catalog import CatalogSnapshot, ModelEntry
+
+
+def _model(
+    model_id: str,
+    *,
+    supports_tools: bool = True,
+    supports_thinking: bool = True,
+    context_length: int = 200_000,
+    pricing_prompt: float = 0.001,
+    pricing_completion: float = 0.002,
+) -> ModelEntry:
+    return ModelEntry(
+        id=model_id,
+        name=model_id,
+        created=1_710_000_000,
+        context_length=context_length,
+        pricing_prompt=pricing_prompt,
+        pricing_completion=pricing_completion,
+        pricing_thinking=0.001 if supports_thinking else None,
+        supports_thinking=supports_thinking,
+        supports_tools=supports_tools,
+        supports_vision=False,
+    )
+
+
+def _snapshot(*models: ModelEntry) -> CatalogSnapshot:
+    return CatalogSnapshot(fetched_at=1_710_000_000, models=list(models))
+
+
+def _stack(*models: str) -> tuple[StackDefinition, ...]:
+    return (
+        StackDefinition(
+            name="TEST_STACK",
+            effort="high",
+            models=tuple(models),
+        ),
+    )
+
+
+def _codes(report) -> set[str]:
+    return {finding.code for finding in report.findings}
+
+
+def test_valid_frontier_coding_stack_has_no_errors():
+    report = audit_openrouter_coding_stacks(
+        _snapshot(_model("openai/gpt-5.3-codex")),
+        stacks=_stack("openai/gpt-5.3-codex"),
+    )
+
+    assert report.has_errors is False
+    assert _codes(report) == set()
+    assert report.models[0].catalog_available is True
+    assert report.models[0].direct_sendable is True
+
+
+def test_stale_slug_is_error():
+    report = audit_openrouter_coding_stacks(
+        _snapshot(_model("openai/gpt-5.3-codex")),
+        stacks=_stack("missing/model"),
+    )
+
+    assert report.has_errors is True
+    assert "missing-from-catalog" in _codes(report)
+
+
+def test_alias_slug_is_not_directly_sendable():
+    report = audit_openrouter_coding_stacks(
+        _snapshot(),
+        stacks=_stack("~openai/gpt-latest"),
+    )
+
+    assert report.has_errors is True
+    assert "alias-not-sendable" in _codes(report)
+    assert report.models[0].direct_sendable is False
+    assert "alias" in report.models[0].caveats
+
+
+def test_missing_tool_support_is_error():
+    report = audit_openrouter_coding_stacks(
+        _snapshot(_model("openai/gpt-5.3-codex", supports_tools=False)),
+        stacks=_stack("openai/gpt-5.3-codex"),
+    )
+
+    assert report.has_errors is True
+    assert "missing-tool-support" in _codes(report)
+
+
+def test_free_tier_models_are_not_eligible_for_coding_stack():
+    report = audit_openrouter_coding_stacks(
+        _snapshot(_model("qwen/qwen3-coder:free")),
+        stacks=_stack("qwen/qwen3-coder:free"),
+    )
+
+    assert report.has_errors is True
+    assert "free-tier-model" in _codes(report)
+    assert "free-tier" in report.models[0].caveats
+
+
+def test_preview_and_missing_reasoning_are_warnings_not_errors():
+    report = audit_openrouter_coding_stacks(
+        _snapshot(
+            _model(
+                "google/gemini-3.1-pro-preview",
+                supports_thinking=False,
+                context_length=64_000,
+            )
+        ),
+        stacks=_stack("google/gemini-3.1-pro-preview"),
+    )
+
+    assert report.has_errors is False
+    assert report.has_warnings is True
+    assert {
+        "preview-model",
+        "missing-reasoning-support",
+        "short-context",
+    }.issubset(_codes(report))


### PR DESCRIPTION
## Summary

Fixes #166.

Adds a repeatable audit path for curated OpenRouter coding stacks without delegating quality policy to `openrouter/auto` or silently rewriting model policy at runtime.

## What changed

- Added `conductor models validate-stacks` with JSON and human-readable output.
- Added structured stack audit data for catalog availability, direct sendability, tool support, reasoning support, context length, and caveats such as aliases, free-tier, preview, and missing policy evidence.
- Recorded explicit stack policy and per-model rationale next to the curated coding stacks.
- Added a nightly workflow job that runs the live stack audit and opens or updates an `openrouter-stack-audit` issue on failure.
- Added regression tests for valid stacks, stale slugs, alias slugs, missing tool support, free-tier models, and preview/reasoning/context warnings.

## Validation

- `uv run ruff check .`
- `uv run pre-commit run check-yaml --files .github/workflows/nightly-smoke.yml`
- `uv run pytest tests/test_openrouter_stack_audit.py tests/test_cli_models.py -q`
- `uv run mypy .`
- `uv run pytest -q`