### PR TITLE
[codex] normalize OpenRouter and council costs

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -1187,6 +1187,19 @@ def _invoke_council(
         log_selection=False,
     )
 
+    member_costs = [response.cost_usd for response in member_responses]
+    all_costs = [*member_costs, synthesis.cost_usd]
+    missing_costs = [
+        f"member[{idx}]"
+        for idx, cost in enumerate(member_costs, start=1)
+        if cost is None
+    ]
+    if synthesis.cost_usd is None:
+        missing_costs.append("synthesis")
+    known_costs = [cost for cost in all_costs if cost is not None]
+    known_cost_usd = sum(known_costs) if known_costs else None
+    cost_accounting_complete = not missing_costs
+
     raw = {
         **(synthesis.raw or {}),
         "conductor_council": {
@@ -1195,6 +1208,11 @@ def _invoke_council(
             "requested_synthesis_models": list(synthesis_models),
             "rounds": rounds,
             "member_usage": [response.usage for response in member_responses],
+            "member_cost_usd": member_costs,
+            "synthesis_cost_usd": synthesis.cost_usd,
+            "known_cost_usd": known_cost_usd,
+            "cost_accounting_complete": cost_accounting_complete,
+            "missing_costs": missing_costs,
             "member_duration_ms": [response.duration_ms for response in member_responses],
         },
     }
@@ -1202,12 +1220,11 @@ def _invoke_council(
         **synthesis.usage,
         "council_members": len(member_responses),
         "council_rounds": rounds,
+        "cost_accounting_complete": cost_accounting_complete,
+        "known_cost_usd": known_cost_usd,
+        "missing_costs": missing_costs,
     }
-    cost_usd = synthesis.cost_usd
-    if cost_usd is not None and all(
-        response.cost_usd is not None for response in member_responses
-    ):
-        cost_usd += sum(response.cost_usd or 0 for response in member_responses)
+    cost_usd = known_cost_usd if cost_accounting_complete else None
     return replace(synthesis, usage=usage, cost_usd=cost_usd, raw=raw)
 
 

--- a/src/conductor/providers/openrouter.py
+++ b/src/conductor/providers/openrouter.py
@@ -305,6 +305,7 @@ class OpenRouterProvider:
             ) from e
 
         usage = body.get("usage") or {}
+        cost_usd = _usage_cost_usd(usage)
         return CallResponse(
             text=text,
             provider=self.name,
@@ -322,6 +323,7 @@ class OpenRouterProvider:
                 "effort": effort if isinstance(effort, str) else None,
                 "thinking_budget": thinking_budget,
             },
+            cost_usd=cost_usd,
             raw=body,
         )
 
@@ -394,6 +396,8 @@ class OpenRouterProvider:
             "cached_tokens": 0,
             "thinking_tokens": 0,
         }
+        cost_usd_total = 0.0
+        cost_usd_seen = False
         iterations_log: list[dict] = []
         final_text = ""
         final_body: dict = {}
@@ -430,6 +434,10 @@ class OpenRouterProvider:
                 usage.get("completion_tokens_details") or {},
                 "reasoning_tokens",
             )
+            usage_cost_usd = _usage_cost_usd(usage)
+            if usage_cost_usd is not None:
+                cost_usd_total += usage_cost_usd
+                cost_usd_seen = True
             totals["input_tokens"] += prompt_tokens
             totals["output_tokens"] += completion_tokens
             totals["cached_tokens"] += cached_tokens
@@ -441,6 +449,7 @@ class OpenRouterProvider:
                     "completion_tokens": completion_tokens,
                     "cached_tokens": cached_tokens,
                     "thinking_tokens": thinking_tokens,
+                    "cost_usd": usage_cost_usd,
                 }
             )
 
@@ -581,6 +590,7 @@ class OpenRouterProvider:
                 "execution_status": execution_status,
                 "iterations": iterations_log,
             },
+            cost_usd=cost_usd_total if cost_usd_seen else None,
             raw=final_body,
         )
 
@@ -1010,6 +1020,16 @@ def _usage_int(usage: dict, key: str) -> int:
         return int(value)
     except (TypeError, ValueError):
         return 0
+
+
+def _usage_cost_usd(usage: dict) -> float | None:
+    value = usage.get("cost")
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def _parse_tool_call(call: dict) -> tuple[str, dict | None, str | None]:

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -77,7 +77,12 @@ def _stub_all_configured(mocker, configured_names: set[str]) -> None:
         )
 
 
-def _fake_response(provider: str = "claude", model: str = "sonnet") -> CallResponse:
+def _fake_response(
+    provider: str = "claude",
+    model: str = "sonnet",
+    *,
+    cost_usd: float | None = 0.01,
+) -> CallResponse:
     return CallResponse(
         text="hello",
         provider=provider,
@@ -89,7 +94,7 @@ def _fake_response(provider: str = "claude", model: str = "sonnet") -> CallRespo
             "thinking_tokens": 4_000,
             "cached_tokens": 0,
         },
-        cost_usd=0.01,
+        cost_usd=cost_usd,
         raw={},
     )
 
@@ -680,6 +685,52 @@ def test_ask_council_fans_out_through_openrouter_only(mocker):
     payload = json.loads(result.stdout)
     assert payload["semantic"]["kind"] == "council"
     assert payload["semantic"]["candidates"][0]["provider"] == "openrouter"
+    assert payload["cost_usd"] == pytest.approx(0.04)
+    assert payload["usage"]["cost_accounting_complete"] is True
+    assert payload["raw"]["conductor_council"]["member_cost_usd"] == [
+        0.01,
+        0.01,
+        0.01,
+    ]
+    assert payload["raw"]["conductor_council"]["synthesis_cost_usd"] == 0.01
+    assert payload["raw"]["conductor_council"]["known_cost_usd"] == pytest.approx(0.04)
+
+
+def test_ask_council_marks_incomplete_cost_accounting(mocker):
+    _stub_all_configured(mocker, {"openrouter"})
+    responses = [
+        _fake_response("openrouter", "member-a", cost_usd=0.01),
+        _fake_response("openrouter", "member-b", cost_usd=None),
+        _fake_response("openrouter", "member-c", cost_usd=0.03),
+        _fake_response("openrouter", "synthesis", cost_usd=0.04),
+    ]
+    mocker.patch.object(OpenRouterProvider, "call", side_effect=responses)
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "ask",
+            "--kind",
+            "council",
+            "--effort",
+            "medium",
+            "--brief",
+            "Debate this architecture decision.",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["cost_usd"] is None
+    assert payload["usage"]["cost_accounting_complete"] is False
+    assert payload["usage"]["known_cost_usd"] == pytest.approx(0.08)
+    assert payload["usage"]["missing_costs"] == ["member[2]"]
+    assert payload["raw"]["conductor_council"]["member_cost_usd"] == [
+        0.01,
+        None,
+        0.03,
+    ]
 
 
 def test_council_synthesis_prompt_handles_empty_member_text():

--- a/tests/test_openrouter.py
+++ b/tests/test_openrouter.py
@@ -88,6 +88,7 @@ def test_call_returns_normalized_response(configured):
         "usage": {
             "prompt_tokens": 7,
             "completion_tokens": 1,
+            "cost": 0.00123,
             "prompt_tokens_details": {"cached_tokens": 0},
             "completion_tokens_details": {"reasoning_tokens": 3},
         },
@@ -111,6 +112,7 @@ def test_call_returns_normalized_response(configured):
     assert response.usage["thinking_tokens"] == 3
     assert response.usage["effort"] == "medium"
     assert response.usage["thinking_budget"] == 8_000
+    assert response.cost_usd == pytest.approx(0.00123)
     assert response.duration_ms >= 0
     assert response.raw == body
 
@@ -425,7 +427,7 @@ def test_exec_with_tools_runs_openai_tool_loop(configured, tmp_path):
                     "finish_reason": "tool_calls",
                 }
             ],
-            "usage": {"prompt_tokens": 10, "completion_tokens": 2},
+            "usage": {"prompt_tokens": 10, "completion_tokens": 2, "cost": 0.001},
         },
         {
             "model": "openai/gpt-5.5",
@@ -438,7 +440,7 @@ def test_exec_with_tools_runs_openai_tool_loop(configured, tmp_path):
                     "finish_reason": "stop",
                 }
             ],
-            "usage": {"prompt_tokens": 20, "completion_tokens": 7},
+            "usage": {"prompt_tokens": 20, "completion_tokens": 7, "cost": 0.002},
         },
     ]
 
@@ -461,6 +463,9 @@ def test_exec_with_tools_runs_openai_tool_loop(configured, tmp_path):
     assert response.usage["input_tokens"] == 30
     assert response.usage["output_tokens"] == 9
     assert response.usage["tool_iterations"] == 2
+    assert response.usage["iterations"][0]["cost_usd"] == pytest.approx(0.001)
+    assert response.usage["iterations"][1]["cost_usd"] == pytest.approx(0.002)
+    assert response.cost_usd == pytest.approx(0.003)
     assert requests[0]["tools"][0]["function"]["name"] == "Read"
     assert requests[1]["messages"][1]["tool_calls"][0]["id"] == "call_read"
     assert requests[1]["messages"][2] == {


### PR DESCRIPTION
## Summary

Fixes #156.

Normalizes OpenRouter `usage.cost` into `CallResponse.cost_usd` and makes council cost accounting explicit and aggregatable.

## What changed

- OpenRouter `call()` now maps `usage.cost` to `cost_usd`.
- OpenRouter tool-loop `exec()` now records per-iteration `cost_usd` and aggregates a top-level cost when usage cost is present.
- Council responses now include member costs, synthesis cost, known total cost, missing-cost labels, and a `cost_accounting_complete` flag in `raw.conductor_council` and normalized `usage`.
- Council top-level `cost_usd` is the full member-plus-synthesis total only when all component costs are available; otherwise it remains `null` with explicit missing-cost diagnostics.

## Validation

- `uv run ruff check src/conductor/providers/openrouter.py src/conductor/cli.py tests/test_openrouter.py tests/test_cli_v02.py`
- `uv run pytest tests/test_openrouter.py tests/test_cli_v02.py -q`
- `uv run mypy .`
- `uv run pytest -q`
- Pre-push Touchstone passed with `PYTEST_ADDOPTS='-m "not integration"'` to skip the local live Claude contract test, which timed out independently of this change.