### PR TITLE
Use prompt size in route cost estimates

### DIFF
--- a/docs/consumers.md
+++ b/docs/consumers.md
@@ -174,6 +174,9 @@ When `--auto` is used, the JSON adds a `route` field with the same `RouteDecisio
     "matched_tags": ["code-review"],
     "tools_requested": [],
     "sandbox": "none",
+    "estimated_input_tokens": 1250,
+    "estimated_output_tokens": 500,
+    "estimated_thinking_tokens": 8000,
     "ranked": [
       {
         "name": "claude",
@@ -185,7 +188,10 @@ When `--auto` is used, the JSON adds a `route` field with the same `RouteDecisio
         "latency_ms": 7000,
         "health_penalty": 0.0,
         "combined_score": 4001.0,
-        "unconfigured_reason": null
+        "unconfigured_reason": null,
+        "estimated_input_tokens": 1250,
+        "estimated_output_tokens": 500,
+        "estimated_thinking_tokens": 8000
       }
     ],
     "candidates_skipped": [],
@@ -195,6 +201,8 @@ When `--auto` is used, the JSON adds a `route` field with the same `RouteDecisio
   }
 }
 ```
+
+Route estimates are pre-call assumptions used only for routing and dry-run previews. Observed provider usage stays in the top-level `usage` object after a call returns. `call`, `ask`, `review`, and `exec` estimate input tokens from the current brief; review also includes patch context when a base, commit, or uncommitted target is supplied. Dry-run callers such as Touchstone can pass `conductor route --estimated-input-tokens <n> --estimated-output-tokens <n>` to score the current prompt or diff size without reaching a model. When omitted, Conductor uses its legacy typical-request assumptions: 4,000 input tokens and 500 output tokens.
 
 For human diagnostics without `--json`, use `--verbose-route` to print the full ranking table on stderr. In `--json` mode, route logging is suppressed so stdout stays machine-parseable; read the `route` field instead.
 

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -61,10 +61,13 @@ from conductor.providers import (
 )
 from conductor.providers.review_contract import (
     ReviewContextError,
+    build_review_patch_context,
     build_review_task_prompt,
     ensure_requested_review_sentinel,
 )
 from conductor.router import (
+    DEFAULT_ESTIMATED_INPUT_TOKENS,
+    DEFAULT_ESTIMATED_OUTPUT_TOKENS,
     VALID_PREFER_MODES,
     InvalidRouterRequest,
     NoConfiguredProvider,
@@ -120,6 +123,7 @@ GIT_RECOVERY_MAX_STATUS_PATHS = 8
 NATIVE_REVIEW_TAG = "code-review"
 DEFAULT_REVIEW_MAX_FALLBACKS = 3
 DEFAULT_COUNCIL_ROUNDS = 1
+ESTIMATED_CHARS_PER_TOKEN = 4
 
 
 @dataclass(frozen=True)
@@ -311,6 +315,34 @@ def _validate_tools(raw: str | None) -> frozenset[str]:
             f"Known: {list(VALID_TOOLS)}."
         )
     return frozenset(tools)
+
+
+def _estimate_text_tokens(text: str) -> int:
+    return max(1, (len(text) + ESTIMATED_CHARS_PER_TOKEN - 1) // ESTIMATED_CHARS_PER_TOKEN)
+
+
+def _estimate_review_input_tokens(
+    task: str,
+    *,
+    base: str | None,
+    commit: str | None,
+    uncommitted: bool,
+    cwd: str | None,
+) -> int:
+    estimated = _estimate_text_tokens(task)
+    if not (base or commit or uncommitted):
+        return estimated
+    try:
+        patch_context = build_review_patch_context(
+            base=base,
+            commit=commit,
+            uncommitted=uncommitted,
+            cwd=cwd,
+        )
+    except ReviewContextError as e:
+        click.echo(f"[conductor] could not estimate review patch size: {e}", err=True)
+        return estimated
+    return estimated + _estimate_text_tokens(patch_context)
 
 
 def _ordered_tools_csv(tools: frozenset[str]) -> str:
@@ -1536,7 +1568,9 @@ def _format_route_log_line(decision: RouteDecision) -> str:
     )
     return (
         f"[conductor] {decision.prefer} (effort={effort_str}) → {decision.provider} "
-        f"(tier: {decision.tier} · matched: {tags_matched})"
+        f"(tier: {decision.tier} · matched: {tags_matched} · "
+        f"est: {decision.estimated_input_tokens:,} in/"
+        f"{decision.estimated_output_tokens:,} out)"
     )
 
 
@@ -1577,7 +1611,10 @@ def _format_route_ranking(decision: RouteDecision) -> list[str]:
             f"  {i}. {c.name:<8} "
             f"(tier={c.tier}[{c.tier_rank}] "
             f"tags=+{c.tag_score}:{tags} "
-            f"cost≈${c.cost_score:.4f}/1k "
+            f"cost≈${c.cost_score:.4f} "
+            f"tokens≈{c.estimated_input_tokens:,}in/"
+            f"{c.estimated_output_tokens:,}out/"
+            f"{c.estimated_thinking_tokens:,}think "
             f"p50={c.latency_ms}ms"
             f"){marker}"
         )
@@ -1588,7 +1625,10 @@ def _format_route_ranking(decision: RouteDecision) -> list[str]:
             f"  ?  {c.name:<8} "
             f"(tier={c.tier}[{c.tier_rank}] "
             f"tags=+{c.tag_score}:{tags} "
-            f"cost≈${c.cost_score:.4f}/1k "
+            f"cost≈${c.cost_score:.4f} "
+            f"tokens≈{c.estimated_input_tokens:,}in/"
+            f"{c.estimated_output_tokens:,}out/"
+            f"{c.estimated_thinking_tokens:,}think "
             f"p50={c.latency_ms}ms"
             f") ← would rank if installed: {c.unconfigured_reason}"
         )
@@ -1685,6 +1725,9 @@ def _emit_session_route_decision(
             "matched_tags": list(decision.matched_tags),
             "tools_requested": list(decision.tools_requested),
             "sandbox": decision.sandbox,
+            "estimated_input_tokens": decision.estimated_input_tokens,
+            "estimated_output_tokens": decision.estimated_output_tokens,
+            "estimated_thinking_tokens": decision.estimated_thinking_tokens,
             "tag_default_applied": decision.tag_default_applied,
             "tag_default_considered": [
                 {"tag": tag, "provider": provider, "status": status}
@@ -1955,6 +1998,7 @@ def ask(
         _warn_if_short_exec_brief(brief_input, allow_short_brief=allow_short_brief)
     body = brief_input.body
     attachments = brief_input.attachments
+    estimated_input_tokens = _estimate_text_tokens(body)
 
     # `ask --kind {review,council}` doesn't have a path for attachments —
     # review forwards a diff to the provider's native review mode (no attach
@@ -2002,6 +2046,13 @@ def ask(
                 exclude=exclude_set,
                 priority=_semantic_priority(plan),
                 shadow=True,
+                estimated_input_tokens=_estimate_review_input_tokens(
+                    body,
+                    base=base,
+                    commit=commit,
+                    uncommitted=uncommitted,
+                    cwd=cwd,
+                ),
             )
         except (NoConfiguredProvider, InvalidRouterRequest, MutedProvidersError) as e:
             click.echo(f"conductor: {_native_review_unavailable_message(review_reasons)}", err=True)
@@ -2052,6 +2103,7 @@ def ask(
             priority=_semantic_priority(plan),
             shadow=True,
             attachments_required=bool(attachments),
+            estimated_input_tokens=estimated_input_tokens,
         )
     except (NoConfiguredProvider, InvalidRouterRequest, MutedProvidersError) as e:
         click.echo(f"conductor: {e}", err=True)
@@ -2322,6 +2374,7 @@ def call(
     body = brief_input.body
     attachments = brief_input.attachments
     effort_value = _parse_effort(effort)
+    estimated_input_tokens = _estimate_text_tokens(body)
 
     decision: RouteDecision | None = None
     if auto:
@@ -2333,6 +2386,7 @@ def call(
                 exclude=frozenset(_parse_csv(exclude)),
                 shadow=True,
                 attachments_required=bool(attachments),
+                estimated_input_tokens=estimated_input_tokens,
             )
         except (NoConfiguredProvider, InvalidRouterRequest, MutedProvidersError) as e:
             click.echo(f"conductor: {e}", err=True)
@@ -2620,6 +2674,13 @@ def review(
     )
     body = brief_input.body
     effort_value = _parse_effort(effort)
+    estimated_input_tokens = _estimate_review_input_tokens(
+        body,
+        base=base,
+        commit=commit,
+        uncommitted=uncommitted,
+        cwd=cwd,
+    )
     max_stall_sec = _normalize_max_stall_sec(max_stall_sec)
     max_fallbacks = _validate_max_fallbacks(max_fallbacks)
     prefer_value = _validate_prefer(prefer) if prefer is not None else "best"
@@ -2635,6 +2696,7 @@ def review(
                 effort=effort_value,
                 exclude=review_exclude,
                 shadow=True,
+                estimated_input_tokens=estimated_input_tokens,
             )
         except (NoConfiguredProvider, InvalidRouterRequest, MutedProvidersError) as e:
             click.echo(f"conductor: {_native_review_unavailable_message(review_reasons)}", err=True)
@@ -2965,6 +3027,7 @@ def exec_cmd(
     )
     body = brief_input.body
     attachments = brief_input.attachments
+    estimated_input_tokens = _estimate_text_tokens(body)
     permission_profile_value = _validate_permission_profile(permission_profile)
     tools_set = _resolve_exec_tools(
         tools,
@@ -2991,6 +3054,7 @@ def exec_cmd(
                 ),
                 shadow=True,
                 attachments_required=bool(attachments),
+                estimated_input_tokens=estimated_input_tokens,
             )
         except (NoConfiguredProvider, InvalidRouterRequest, MutedProvidersError) as e:
             click.echo(f"conductor: {e}", err=True)
@@ -3234,6 +3298,24 @@ def exec_cmd(
 )
 @click.option("--sandbox", default=None, help="Deprecated and ignored.")
 @click.option("--exclude", default=None, help="Comma-separated providers to exclude.")
+@click.option(
+    "--estimated-input-tokens",
+    default=None,
+    type=click.IntRange(min=0),
+    help=(
+        "Estimated prompt/diff input tokens for cost scoring. "
+        f"Default: {DEFAULT_ESTIMATED_INPUT_TOKENS}."
+    ),
+)
+@click.option(
+    "--estimated-output-tokens",
+    default=None,
+    type=click.IntRange(min=0),
+    help=(
+        "Estimated output tokens for cost scoring. "
+        f"Default: {DEFAULT_ESTIMATED_OUTPUT_TOKENS}."
+    ),
+)
 @click.option("--json", "as_json", is_flag=True, default=False)
 def route(
     tags: str | None,
@@ -3243,6 +3325,8 @@ def route(
     permission_profile: str | None,
     sandbox: str | None,
     exclude: str | None,
+    estimated_input_tokens: int | None,
+    estimated_output_tokens: int | None,
     as_json: bool,
 ) -> None:
     """Dry-run the router: show which provider would be picked and why.
@@ -3270,6 +3354,8 @@ def route(
                 permission_profile=permission_profile_value,
             ),
             shadow=True,
+            estimated_input_tokens=estimated_input_tokens,
+            estimated_output_tokens=estimated_output_tokens,
         )
     except (NoConfiguredProvider, InvalidRouterRequest, MutedProvidersError) as e:
         if as_json:
@@ -3288,6 +3374,12 @@ def route(
         f"  ·  prefer: {decision.prefer}"
         f"  ·  effort: {decision.effort}"
         f" (thinking budget: {decision.thinking_budget} tokens)"
+    )
+    click.echo(
+        "  cost estimate: "
+        f"{decision.estimated_input_tokens:,} input tokens · "
+        f"{decision.estimated_output_tokens:,} output tokens · "
+        f"{decision.estimated_thinking_tokens:,} thinking tokens"
     )
     if decision.matched_tags:
         click.echo(f"  matched tags: {','.join(decision.matched_tags)}")

--- a/src/conductor/router.py
+++ b/src/conductor/router.py
@@ -5,6 +5,7 @@ v0.2 router. Axes:
   - ``tags``        — capability tags for soft matching (code-review, long-context, ...)
   - ``prefer``      — which dimension dominates scoring: best | cheapest | fastest | balanced
   - ``effort``      — thinking-depth dial applied to the chosen provider
+  - ``estimated_*`` — optional prompt/output token estimates for cost scoring
   - ``tools``       — hard filter: provider.supported_tools ⊇ requested
   - ``exclude``     — blacklist; router must never pick these
 
@@ -49,6 +50,8 @@ from conductor.router_defaults import load_tag_defaults
 # Priority (v0.1 carry-over, tiebreak only).
 # --------------------------------------------------------------------------- #
 DEFAULT_PRIORITY: tuple[str, ...] = ("kimi", "claude", "mistral", "codex", "gemini", "ollama")
+DEFAULT_ESTIMATED_INPUT_TOKENS = 4_000
+DEFAULT_ESTIMATED_OUTPUT_TOKENS = 500
 
 PreferMode = Literal["best", "cheapest", "fastest", "balanced"]
 VALID_PREFER_MODES: tuple[str, ...] = ("best", "cheapest", "fastest", "balanced")
@@ -157,11 +160,14 @@ class RankedCandidate:
     tier_rank: int
     matched_tags: tuple[str, ...]
     tag_score: int
-    cost_score: float           # estimated total cost/1k at requested effort
+    cost_score: float           # estimated request cost at requested effort/size
     latency_ms: int
     health_penalty: float
     combined_score: float       # the key used by the current prefer mode (higher=better)
     unconfigured_reason: str | None = None
+    estimated_input_tokens: int = DEFAULT_ESTIMATED_INPUT_TOKENS
+    estimated_output_tokens: int = DEFAULT_ESTIMATED_OUTPUT_TOKENS
+    estimated_thinking_tokens: int = 0
 
 
 @dataclass(frozen=True)
@@ -189,6 +195,9 @@ class RouteDecision:
     tag_default_applied: dict[str, str] = field(default_factory=dict)
     tag_default_considered: tuple[tuple[str, str, str], ...] = ()
     unconfigured_shadow: tuple[RankedCandidate, ...] = ()  # descending; never winners
+    estimated_input_tokens: int = DEFAULT_ESTIMATED_INPUT_TOKENS
+    estimated_output_tokens: int = DEFAULT_ESTIMATED_OUTPUT_TOKENS
+    estimated_thinking_tokens: int = 0
 
     # Legacy fields retained for v0.1 callers that destructured these.
     @property
@@ -213,6 +222,8 @@ def _score_one(
     prefer: str,
     effort: str | int,
     priority_index: int,
+    estimated_input_tokens: int,
+    estimated_output_tokens: int,
     tag_default_boost: int = 0,
     unconfigured_reason: str | None = None,
 ) -> RankedCandidate:
@@ -231,13 +242,10 @@ def _score_one(
     tag_score = len(matched)
     tier_rank = TIER_RANK.get(provider.quality_tier, 0)
 
-    # Expected total cost per 1k tokens at the requested effort.
-    # We don't know the actual token count yet; use a per-request estimate
-    # assuming ~4k input and ~500 output (typical review sizes).
     thinking_tokens = resolve_effort_tokens(effort, provider.effort_to_thinking)
     cost_estimate = (
-        provider.cost_per_1k_in * 4
-        + provider.cost_per_1k_out * 0.5
+        provider.cost_per_1k_in * (estimated_input_tokens / 1_000)
+        + provider.cost_per_1k_out * (estimated_output_tokens / 1_000)
         + provider.cost_per_1k_thinking * (thinking_tokens / 1_000)
     )
 
@@ -263,7 +271,18 @@ def _score_one(
         health_penalty=penalty,
         combined_score=combined,
         unconfigured_reason=unconfigured_reason,
+        estimated_input_tokens=estimated_input_tokens,
+        estimated_output_tokens=estimated_output_tokens,
+        estimated_thinking_tokens=thinking_tokens,
     )
+
+
+def _normalize_estimated_tokens(raw: int | None, *, default: int, label: str) -> int:
+    if raw is None:
+        return default
+    if raw < 0:
+        raise InvalidRouterRequest(f"{label} must be >= 0, got {raw}.")
+    return raw
 
 
 def pick(
@@ -277,6 +296,8 @@ def pick(
     priority: tuple[str, ...] = DEFAULT_PRIORITY,
     shadow: bool = False,
     attachments_required: bool = False,
+    estimated_input_tokens: int | None = None,
+    estimated_output_tokens: int | None = None,
 ) -> tuple[Provider, RouteDecision]:
     """Pick the best provider for ``task_tags`` under the given preferences.
 
@@ -301,6 +322,16 @@ def pick(
 
     task_tag_set = set(task_tags or [])
     tools_set = frozenset(tools or ())
+    input_estimate = _normalize_estimated_tokens(
+        estimated_input_tokens,
+        default=DEFAULT_ESTIMATED_INPUT_TOKENS,
+        label="estimated_input_tokens",
+    )
+    output_estimate = _normalize_estimated_tokens(
+        estimated_output_tokens,
+        default=DEFAULT_ESTIMATED_OUTPUT_TOKENS,
+        label="estimated_output_tokens",
+    )
     persisted_muted = frozenset(load_muted_provider_ids(known=set(known_providers())))
     exclude_set = frozenset(exclude or ()) | persisted_muted
     tag_defaults = load_tag_defaults()
@@ -376,6 +407,8 @@ def pick(
                 prefer=prefer,
                 effort=effort,
                 priority_index=priority_index[name],
+                estimated_input_tokens=input_estimate,
+                estimated_output_tokens=output_estimate,
             )
         )
 
@@ -423,6 +456,8 @@ def pick(
                     prefer=prefer,
                     effort=effort,
                     priority_index=priority_index[candidate.name],
+                    estimated_input_tokens=input_estimate,
+                    estimated_output_tokens=output_estimate,
                     tag_default_boost=tag_default_boosts.get(candidate.name, 0),
                 )
                 for candidate in ranked
@@ -445,6 +480,8 @@ def pick(
                 prefer=prefer,
                 effort=effort,
                 priority_index=priority_index[name],
+                estimated_input_tokens=input_estimate,
+                estimated_output_tokens=output_estimate,
                 tag_default_boost=tag_default_boosts.get(name, 0),
                 unconfigured_reason=reason,
             )
@@ -468,6 +505,9 @@ def pick(
         tag_default_applied=tag_default_applied,
         tag_default_considered=tuple(tag_default_considered),
         unconfigured_shadow=shadow_ranked,
+        estimated_input_tokens=winner.estimated_input_tokens,
+        estimated_output_tokens=winner.estimated_output_tokens,
+        estimated_thinking_tokens=winner.estimated_thinking_tokens,
     )
     return winner_provider, decision
 

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -163,6 +163,9 @@ ROUTE_REQUIRED_FIELDS: frozenset[str] = frozenset(
         "matched_tags",
         "tools_requested",
         "sandbox",
+        "estimated_input_tokens",
+        "estimated_output_tokens",
+        "estimated_thinking_tokens",
         "ranked",
     }
 )

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -192,6 +192,25 @@ def test_call_auto_prefer_best_routes_to_frontier(mocker):
     assert "tier: frontier" in result.stderr
 
 
+def test_call_auto_route_json_includes_prompt_size_estimate(mocker):
+    _stub_all_configured(mocker, {"claude"})
+    mocker.patch.object(ClaudeProvider, "call", return_value=_fake_response("claude"))
+    prompt = "x" * 1000
+
+    result = CliRunner().invoke(
+        main,
+        ["call", "--auto", "--prefer", "best", "--task", prompt, "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["usage"]["input_tokens"] == 50
+    assert payload["route"]["estimated_input_tokens"] == 250
+    assert payload["route"]["estimated_output_tokens"] == 500
+    assert payload["route"]["estimated_thinking_tokens"] == 8_000
+    assert payload["route"]["ranked"][0]["estimated_input_tokens"] == 250
+
+
 def test_call_auto_effort_max_flows_to_provider(mocker):
     _stub_all_configured(mocker, {"claude"})
     call_mock = mocker.patch.object(
@@ -1724,6 +1743,76 @@ def test_route_json_mode(mocker):
     payload = json.loads(result.output)
     assert payload["provider"] == "claude"
     assert payload["prefer"] == "best"
+
+
+def test_route_json_accepts_explicit_size_estimate(mocker):
+    _stub_all_configured(mocker, {"claude"})
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "route",
+            "--prefer",
+            "best",
+            "--estimated-input-tokens",
+            "123",
+            "--estimated-output-tokens",
+            "45",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["estimated_input_tokens"] == 123
+    assert payload["estimated_output_tokens"] == 45
+    assert payload["estimated_thinking_tokens"] == 8_000
+    assert payload["ranked"][0]["estimated_input_tokens"] == 123
+
+
+def test_ask_call_mode_routes_with_prompt_size_estimate(mocker):
+    _stub_all_configured(mocker, {"ollama"})
+    mocker.patch.object(OllamaProvider, "call", return_value=_fake_response("ollama"))
+    prompt = "x" * 2000
+
+    result = CliRunner().invoke(
+        main,
+        ["ask", "--kind", "code", "--effort", "low", "--task", prompt, "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["route"]["estimated_input_tokens"] == 500
+    assert payload["route"]["estimated_output_tokens"] == 500
+
+
+def test_review_auto_route_includes_patch_size_estimate(mocker, tmp_path):
+    repo = _make_diff_repo(tmp_path)
+    _stub_all_configured(mocker, {"claude"})
+    mocker.patch.object(ClaudeProvider, "review_configured", return_value=(True, None))
+    mocker.patch.object(
+        ClaudeProvider, "review", return_value=_fake_response("claude")
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "review",
+            "--auto",
+            "--base",
+            "HEAD~1",
+            "--cwd",
+            str(repo),
+            "--brief",
+            "review",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["route"]["estimated_input_tokens"] > 2
+    assert payload["route"]["estimated_output_tokens"] == 500
 
 
 def test_route_no_configured_provider_exits_nonzero(mocker):

--- a/tests/test_consumer_contract.py
+++ b/tests/test_consumer_contract.py
@@ -62,6 +62,9 @@ ROUTE_REQUIRED_KEYS = {
     "matched_tags",
     "tools_requested",
     "sandbox",
+    "estimated_input_tokens",
+    "estimated_output_tokens",
+    "estimated_thinking_tokens",
     "ranked",
     "candidates_skipped",
     "tag_default_applied",
@@ -188,6 +191,9 @@ def _assert_route_payload_contract(route: dict[str, Any]) -> None:
     assert isinstance(route["task_tags"], list)
     assert isinstance(route["matched_tags"], list)
     assert isinstance(route["tools_requested"], list)
+    assert isinstance(route["estimated_input_tokens"], int)
+    assert isinstance(route["estimated_output_tokens"], int)
+    assert isinstance(route["estimated_thinking_tokens"], int)
     assert isinstance(route["ranked"], list)
     assert route["ranked"], "route contract includes the full ranked candidate list"
 
@@ -301,6 +307,8 @@ def test_consumer_doc_names_the_guarded_contract_edges():
     assert '"input_tokens": "integer | null"' in docs
     assert "conductor call --offline" in docs
     assert "multi-line `Usage` / `Try` / `Error` output" in docs
+    assert '"estimated_input_tokens": 1250' in docs
+    assert "--estimated-input-tokens" in docs
     assert "tests/test_consumer_contract.py" in docs
 
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import pytest
 
 from conductor.router import (
+    DEFAULT_ESTIMATED_INPUT_TOKENS,
+    DEFAULT_ESTIMATED_OUTPUT_TOKENS,
     DEFAULT_PRIORITY,
     InvalidRouterRequest,
     NoConfiguredProvider,
@@ -185,6 +187,57 @@ def test_prefer_cheapest_picks_lowest_cost(mocker):
     provider, decision = pick([], prefer="cheapest")
     assert provider.name == "ollama"
     assert decision.prefer == "cheapest"
+
+
+@pytest.mark.parametrize(
+    ("input_tokens", "output_tokens"),
+    [
+        (250, 100),
+        (DEFAULT_ESTIMATED_INPUT_TOKENS, DEFAULT_ESTIMATED_OUTPUT_TOKENS),
+        (120_000, 4_000),
+    ],
+)
+def test_cost_estimate_uses_requested_prompt_size(mocker, input_tokens, output_tokens):
+    _stub_configured(mocker, {"claude": True})
+
+    _provider, decision = pick(
+        [],
+        prefer="cheapest",
+        effort="medium",
+        estimated_input_tokens=input_tokens,
+        estimated_output_tokens=output_tokens,
+    )
+
+    candidate = decision.ranked[0]
+    expected_cost = (
+        candidate.estimated_input_tokens / 1_000 * 0.003
+        + candidate.estimated_output_tokens / 1_000 * 0.015
+        + candidate.estimated_thinking_tokens / 1_000 * 0.003
+    )
+    assert candidate.estimated_input_tokens == input_tokens
+    assert candidate.estimated_output_tokens == output_tokens
+    assert candidate.estimated_thinking_tokens == 8_000
+    assert candidate.cost_score == pytest.approx(expected_cost)
+    assert decision.estimated_input_tokens == input_tokens
+    assert decision.estimated_output_tokens == output_tokens
+    assert decision.estimated_thinking_tokens == 8_000
+
+
+def test_cost_estimate_defaults_preserve_legacy_typical_request(mocker):
+    _stub_configured(mocker, {"claude": True})
+
+    _provider, decision = pick([], prefer="cheapest", effort="medium")
+
+    assert decision.estimated_input_tokens == DEFAULT_ESTIMATED_INPUT_TOKENS
+    assert decision.estimated_output_tokens == DEFAULT_ESTIMATED_OUTPUT_TOKENS
+    assert decision.ranked[0].cost_score == pytest.approx(0.0435)
+
+
+def test_negative_cost_estimate_errors():
+    with pytest.raises(InvalidRouterRequest) as exc:
+        pick([], estimated_input_tokens=-1)
+
+    assert "estimated_input_tokens must be >= 0" in str(exc.value)
 
 
 def test_prefer_fastest_picks_lowest_latency(mocker):


### PR DESCRIPTION
## Summary
- let router cost scoring use explicit input/output token estimates instead of only the fixed typical request shape
- pass prompt-size estimates from ask, call, review, and exec auto routes; review includes patch context when available
- expose estimate assumptions in route JSON and add route dry-run flags for Touchstone-style callers

## Tests
- uv run ruff check .
- uv run mypy .
- PYTEST_ADDOPTS='-m "not integration"' uv run pytest

Closes #158