### PR TITLE
Fix Codex startup probe diagnostics

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -760,9 +760,16 @@ def _echo_preflight_failure(provider_or_name, reason: str | None) -> None:
     provider = _provider_for_preflight(provider_or_name)
     detail = reason or "provider health probe failed"
     click.echo(f"[conductor] preflight failed for {provider.name}: {detail}", err=True)
-    fix = getattr(provider, "fix_command", None)
+    fix = _provider_fix_command(provider, reason)
     if fix:
         click.echo(f"[conductor] try: {fix}", err=True)
+
+
+def _provider_fix_command(provider, reason: str | None) -> str | None:
+    fix_for_reason = getattr(provider, "fix_command_for_reason", None)
+    if callable(fix_for_reason):
+        return fix_for_reason(reason)
+    return getattr(provider, "fix_command", None)
 
 
 def _echo_offline_hint(failed_name: str, *, silent: bool) -> None:
@@ -3601,7 +3608,7 @@ def _provider_rows() -> list[dict]:
                 # without a canonical recipe (e.g. user-defined shell
                 # providers).
                 "fix_command": (
-                    None if ok else getattr(provider, "fix_command", None)
+                    None if ok else _provider_fix_command(provider, reason)
                 ),
                 "default_model": _provider_default_model(provider),
                 "tags": list(provider.tags),
@@ -3838,7 +3845,7 @@ def _diagnostic_payload() -> dict:
                 "configured": ok,
                 "reason": None if ok else reason,
                 "fix_command": (
-                    None if ok else getattr(provider, "fix_command", None)
+                    None if ok else _provider_fix_command(provider, reason)
                 ),
                 "default_model": _provider_default_model(provider),
                 "tags": list(provider.tags),

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -51,6 +51,11 @@ CODEX_DEFAULT_MODEL = "gpt-5.4"
 CODEX_REVIEW_MODEL = "codex-review"
 CODEX_REQUEST_TIMEOUT_SEC = 180.0
 CODEX_STARTUP_PROBE_TIMEOUT_SEC = 8.0
+CODEX_STARTUP_PROBE_CONFIG = (
+    "model_reasoning_effort=minimal",
+    "features.image_gen=false",
+    "features.web_search=false",
+)
 
 # Sentinel distinguishing "caller didn't specify a timeout" from "caller
 # explicitly asked for no timeout (None)". The constructor default applies
@@ -83,6 +88,61 @@ def _format_compact_count(value: int) -> str:
     if value < 10_000:
         return f"{value / 1_000:.1f}k"
     return f"{value // 1_000}k"
+
+
+def _codex_error_dict_message(error: dict[str, object]) -> str | None:
+    detail = error.get("message")
+    if not isinstance(detail, str) or not detail.strip():
+        return None
+    error_type = error.get("type")
+    param = error.get("param")
+    parts = []
+    if isinstance(error_type, str) and error_type:
+        parts.append(error_type)
+    parts.append(detail.strip())
+    if isinstance(param, str) and param:
+        parts.append(f"param={param}")
+    return ": ".join(parts)
+
+
+def _codex_nested_error_message(message: str | dict[str, object]) -> str:
+    if isinstance(message, dict):
+        return _codex_error_dict_message(message) or str(message)
+    try:
+        payload = json.loads(message)
+    except json.JSONDecodeError:
+        return message.strip()
+    error = payload.get("error")
+    if not isinstance(error, dict):
+        return message.strip()
+    return _codex_error_dict_message(error) or message.strip()
+
+
+def _codex_startup_probe_failure_detail(stdout: str, stderr: str) -> str:
+    """Prefer semantic Codex error events over noisy startup NDJSON."""
+    for line in stdout.splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        if event.get("type") == "error":
+            message = event.get("message")
+            if isinstance(message, str) and message.strip():
+                return _codex_nested_error_message(message)
+        if event.get("type") == "turn.failed":
+            message = event.get("message") or event.get("error")
+            if isinstance(message, str) and message.strip():
+                return _codex_nested_error_message(message)
+            if isinstance(message, dict):
+                return _codex_nested_error_message(message)
+            return "codex turn failed"
+    return (stderr or stdout).strip()
+
+
+def _codex_startup_probe_failure(reason: str | None) -> bool:
+    return bool(reason and "`codex exec` startup probe" in reason)
 
 
 class CodexProvider:
@@ -139,6 +199,11 @@ class CodexProvider:
             )
         return True, None
 
+    def fix_command_for_reason(self, reason: str | None) -> str | None:
+        if _codex_startup_probe_failure(reason):
+            return None
+        return self.fix_command
+
     def _auth_probe(self) -> tuple[bool, str | None]:
         """Verify auth via `codex login status` (exit 0 = logged in)."""
         try:
@@ -193,9 +258,9 @@ class CodexProvider:
                 "--ephemeral",
                 "--sandbox",
                 "danger-full-access",
-                "-c",
-                "model_reasoning_effort=minimal",
             ]
+            for config in CODEX_STARTUP_PROBE_CONFIG:
+                args.extend(["-c", config])
             try:
                 result = subprocess.run(
                     args,
@@ -216,7 +281,10 @@ class CodexProvider:
             except (FileNotFoundError, OSError) as e:
                 return False, f"could not run `{self._cli} exec` startup probe: {e}"
         if result.returncode != 0:
-            detail = (result.stderr or result.stdout).strip()
+            detail = _codex_startup_probe_failure_detail(
+                result.stdout or "",
+                result.stderr or "",
+            )
             return False, (
                 f"`{self._cli} exec` startup probe exited {result.returncode}: "
                 f"{detail[:200]}"

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -24,7 +24,7 @@ from conductor.providers.claude import (
     CLAUDE_EXEC_FIRST_OUTPUT_TIMEOUT_SEC,
     ClaudeProvider,
 )
-from conductor.providers.codex import CodexProvider
+from conductor.providers.codex import CODEX_STARTUP_PROBE_CONFIG, CodexProvider
 from conductor.providers.gemini import GEMINI_AUTH_ENV_VARS, GeminiProvider
 from conductor.providers.interface import (
     CallResponse,
@@ -1082,6 +1082,106 @@ def test_codex_configured_false_when_exec_startup_probe_times_out(mocker):
     assert startup_call.args[0][:3] == ["codex", "exec", "-"]
     assert startup_call.kwargs["timeout"] == 8
     assert startup_call.kwargs["input"] == "Reply with OK."
+
+
+def test_codex_startup_probe_disables_minimal_reasoning_tool_conflicts(mocker):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+
+    def run(args, **kwargs):
+        if args == ["codex", "login", "status"]:
+            return _fake_completed(stdout="Logged in using ChatGPT")
+        if args[:3] == ["codex", "exec", "-"]:
+            return _fake_completed(stdout='{"type":"turn.completed"}\n')
+        raise AssertionError(f"unexpected command: {args!r}")
+
+    captured = mocker.patch("conductor.providers.codex.subprocess.run", side_effect=run)
+
+    ok, reason = CodexProvider().configured()
+
+    assert ok is True and reason is None
+    startup_args = captured.call_args_list[1].args[0]
+    config_values = [
+        startup_args[idx + 1]
+        for idx, value in enumerate(startup_args)
+        if value == "-c"
+    ]
+    assert config_values == list(CODEX_STARTUP_PROBE_CONFIG)
+
+
+def test_codex_startup_probe_reports_api_error_instead_of_first_event(mocker):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    stdout = "\n".join(
+        [
+            '{"type":"thread.started","thread_id":"thread-123"}',
+            '{"type":"turn.started"}',
+            json.dumps(
+                {
+                    "type": "error",
+                    "message": json.dumps(
+                        {
+                            "type": "error",
+                            "error": {
+                                "type": "invalid_request_error",
+                                "message": (
+                                    "The following tools cannot be used with "
+                                    "reasoning.effort 'minimal': image_gen, web_search."
+                                ),
+                                "param": "tools",
+                            },
+                            "status": 400,
+                        }
+                    ),
+                }
+            ),
+            '{"type":"turn.failed"}',
+        ]
+    )
+
+    def run(args, **kwargs):
+        if args == ["codex", "login", "status"]:
+            return _fake_completed(stdout="Logged in using ChatGPT")
+        if args[:3] == ["codex", "exec", "-"]:
+            return _fake_completed(stdout=stdout, returncode=1)
+        raise AssertionError(f"unexpected command: {args!r}")
+
+    mocker.patch("conductor.providers.codex.subprocess.run", side_effect=run)
+
+    ok, reason = CodexProvider().configured()
+
+    assert ok is False
+    assert "`codex exec` startup probe exited 1" in reason
+    assert "invalid_request_error" in reason
+    assert "The following tools cannot be used" in reason
+    assert "param=tools" in reason
+    assert "thread.started" not in reason
+
+
+def test_codex_startup_probe_reports_turn_failed_error_dict(mocker):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    stdout = json.dumps(
+        {
+            "type": "turn.failed",
+            "error": {
+                "type": "invalid_request_error",
+                "message": "The request was rejected.",
+                "param": "tools",
+            },
+        }
+    )
+
+    def run(args, **kwargs):
+        if args == ["codex", "login", "status"]:
+            return _fake_completed(stdout="Logged in using ChatGPT")
+        if args[:3] == ["codex", "exec", "-"]:
+            return _fake_completed(stdout=stdout, returncode=1)
+        raise AssertionError(f"unexpected command: {args!r}")
+
+    mocker.patch("conductor.providers.codex.subprocess.run", side_effect=run)
+
+    ok, reason = CodexProvider().configured()
+
+    assert ok is False
+    assert "invalid_request_error: The request was rejected.: param=tools" in reason
 
 
 def test_codex_call_parses_ndjson_and_usage(mocker):

--- a/tests/test_cli_phase5.py
+++ b/tests/test_cli_phase5.py
@@ -122,6 +122,56 @@ def test_list_text_output_shows_fix_command_under_unconfigured_provider(mocker):
     assert "→ fix: conductor init --only openrouter" in result.output
 
 
+def test_list_text_output_suppresses_codex_fix_for_probe_api_config_error(mocker):
+    from conductor.providers import CodexProvider
+
+    _stub_all_unconfigured(mocker)
+    mocker.patch.object(
+        CodexProvider,
+        "configured",
+        lambda self: (
+            False,
+            "`codex exec` startup probe exited 1: invalid_request_error: "
+            "The following tools cannot be used with reasoning.effort "
+            "'minimal': image_gen, web_search.: param=tools",
+        ),
+    )
+
+    result = CliRunner().invoke(main, ["list"])
+
+    assert result.exit_code == 0, result.output
+    assert "invalid_request_error" in result.output
+    assert "brew install codex && codex login" not in result.output
+
+
+def test_doctor_suppresses_codex_fix_for_startup_probe_failure(mocker):
+    from conductor.providers import CodexProvider
+
+    _stub_all_unconfigured(mocker)
+    mocker.patch.object(
+        CodexProvider,
+        "configured",
+        lambda self: (
+            False,
+            "`codex exec` startup probe exited 1: invalid_request_error: "
+            "The request was rejected.: param=tools",
+        ),
+    )
+
+    text_result = CliRunner().invoke(main, ["doctor"])
+    assert text_result.exit_code == 0, text_result.output
+    assert "invalid_request_error" in text_result.output
+    assert "→ fix: brew install codex && codex login" not in text_result.output
+
+    json_result = CliRunner().invoke(main, ["doctor", "--json"])
+    assert json_result.exit_code == 0, json_result.output
+    providers = {
+        row["provider"]: row for row in json.loads(json_result.output)["providers"]
+    }
+    assert providers["codex"]["reason"].startswith("`codex exec` startup probe")
+    assert providers["codex"]["fix_command"] is None
+
+
 def test_list_no_fix_line_for_configured_provider(mocker):
     from conductor.providers import (
         ClaudeProvider,

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -1533,6 +1533,32 @@ def test_exec_cli_preflight_blocks_exec_and_surfaces_fix_hint(mocker):
     assert "[conductor] try: brew install codex && codex login" in result.stderr
 
 
+def test_exec_cli_preflight_suppresses_codex_fix_for_startup_probe_failure(mocker):
+    _stub_all_configured(mocker, {"codex"})
+    mocker.patch.object(
+        CodexProvider,
+        "health_probe",
+        return_value=(
+            False,
+            "`codex exec` startup probe exited 1: invalid_request_error: "
+            "The request was rejected.: param=tools",
+        ),
+    )
+    exec_mock = mocker.patch.object(
+        CodexProvider, "exec", return_value=_fake_response("codex")
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["exec", "--with", "codex", "--task", "do it"],
+    )
+
+    assert result.exit_code == 2
+    assert not exec_mock.called
+    assert "[conductor] preflight failed for codex:" in result.stderr
+    assert "[conductor] try: brew install codex && codex login" not in result.stderr
+
+
 def test_exec_auto_preflight_failure_does_not_attribute_error_on_str_provider(mocker):
     """Regression: auto-mode `pick()` may return the provider name as a string
     (test fixtures, and some legacy callers); when preflight fails the cli used


### PR DESCRIPTION
## Summary

Fixes the Codex readiness/startup-probe failure described in #155 where Conductor forced `model_reasoning_effort=minimal` and newer Codex rejected the probe when default image/web tools were enabled.

## Changes

- Add explicit startup-probe config to keep the fast minimal-reasoning probe while disabling `features.image_gen` and `features.web_search` for the probe only.
- Parse Codex NDJSON `error` / `turn.failed` events so readiness failures surface the actual API error instead of the first startup event.
- Make provider fix hints reason-aware so `conductor list`, `doctor`, and exec preflight do not recommend `brew install codex && codex login` after PATH/auth already passed and the `codex exec` startup probe failed.

## Validation

- `uv run ruff check src/conductor/providers/codex.py src/conductor/cli.py tests/test_adapters_subprocess.py tests/test_cli_phase5.py tests/test_cli_v02.py`
- `uv run mypy src/conductor/providers/codex.py src/conductor/cli.py`
- `uv run pytest tests/test_adapters_subprocess.py tests/test_cli_phase5.py tests/test_cli_v02.py`
- `uv run pytest`

Refs #155.