### PR TITLE
Fix Codex stream teardown after process exit

### DIFF
--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -56,6 +56,8 @@ CODEX_STARTUP_PROBE_CONFIG = (
     "features.image_gen=false",
     "features.web_search=false",
 )
+CODEX_STREAM_POLL_INTERVAL_SEC = 0.05
+CODEX_STREAM_EXIT_READER_JOIN_SEC = 0.2
 
 # Sentinel distinguishing "caller didn't specify a timeout" from "caller
 # explicitly asked for no timeout (None)". The constructor default applies
@@ -939,6 +941,9 @@ class CodexProvider:
         try:
             while True:
                 now = time.monotonic()
+                if process.poll() is not None and stream_q.empty():
+                    break
+
                 if timeout_fired.is_set() or (
                     timeout is not None and now - start > timeout
                 ):
@@ -1016,9 +1021,11 @@ class CodexProvider:
                     last_liveness = now
 
                 try:
-                    stream_name, item = stream_q.get(timeout=0.05)
+                    stream_name, item = stream_q.get(
+                        timeout=CODEX_STREAM_POLL_INTERVAL_SEC
+                    )
                 except queue.Empty:
-                    if stdout_done and stderr_done and process.poll() is not None:
+                    if process.poll() is not None:
                         break
                     continue
 
@@ -1170,7 +1177,11 @@ class CodexProvider:
             )
 
         returncode = process.wait()
-        self._join_reader_threads(stdout_thread, stderr_thread)
+        self._join_reader_threads(
+            stdout_thread,
+            stderr_thread,
+            timeout=CODEX_STREAM_EXIT_READER_JOIN_SEC,
+        )
         self._drain_stream_queue(stream_q, stdout_parts, stderr_parts, auth_tracker)
         duration_ms = int((time.monotonic() - start) * 1000)
         stdout = "".join(stdout_parts)
@@ -1225,9 +1236,11 @@ class CodexProvider:
         self,
         stdout_thread: threading.Thread,
         stderr_thread: threading.Thread,
+        *,
+        timeout: float = 1.0,
     ) -> None:
-        stdout_thread.join(timeout=1)
-        stderr_thread.join(timeout=1)
+        stdout_thread.join(timeout=timeout)
+        stderr_thread.join(timeout=timeout)
 
     def _emit_watchdog_stderr(self, text: str) -> None:
         """Best-effort operator output that cannot stop watchdog checks."""

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -889,12 +889,15 @@ class _FakeScheduledPipe:
         terminated: threading.Event,
         on_eof,
         raise_after_schedule: BaseException | None = None,
+        on_schedule_exhausted=None,
     ) -> None:
         self._schedule = schedule
         self._hang_after_schedule = hang_after_schedule
         self._terminated = terminated
         self._on_eof = on_eof
         self._raise_after_schedule = raise_after_schedule
+        self._on_schedule_exhausted = on_schedule_exhausted
+        self._schedule_exhausted = False
         self._idx = 0
 
     def readline(self) -> str:
@@ -904,6 +907,10 @@ class _FakeScheduledPipe:
             if self._terminated.wait(delay):
                 return ""
             return line
+        if not self._schedule_exhausted:
+            self._schedule_exhausted = True
+            if self._on_schedule_exhausted is not None:
+                self._on_schedule_exhausted()
         if self._raise_after_schedule is not None:
             raise self._raise_after_schedule
         if self._hang_after_schedule:
@@ -925,6 +932,7 @@ class _FakePopen:
         stdout_schedule: list[tuple[float, str]],
         stderr_schedule: list[tuple[float, str]] | None = None,
         hang_after_stdout: bool = False,
+        exit_after_stdout_schedule: bool = False,
         returncode: int = 0,
         stdout_reader_error: BaseException | None = None,
         stderr_reader_error: BaseException | None = None,
@@ -943,6 +951,9 @@ class _FakePopen:
             terminated=self._terminated_event,
             on_eof=self._finish_success,
             raise_after_schedule=stdout_reader_error,
+            on_schedule_exhausted=(
+                self._finish_success if exit_after_stdout_schedule else None
+            ),
         )
         self.stderr = _FakeScheduledPipe(
             stderr_schedule or [],
@@ -1616,6 +1627,39 @@ def test_codex_exec_streams_output_resets_stall_clock(mocker):
     assert response.text == "done"
     assert response.session_id == "sess-streaming-1"
     assert fake.terminated is False
+
+
+def test_codex_exec_returns_after_process_exit_when_stdout_reader_lingers(
+    mocker, capsys
+):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    lines = [
+        '{"type":"session.created","session_id":"sess-exited-reader"}\n',
+        '{"type":"item.started","item":{"type":"agent_message"}}\n',
+        '{"type":"item.completed","item":{"type":"agent_message","text":"done"}}\n',
+        '{"type":"turn.completed","usage":{"input_tokens":5,"output_tokens":2}}\n',
+    ]
+    fake = _FakePopen(
+        stdout_schedule=[(0, line) for line in lines],
+        hang_after_stdout=True,
+        exit_after_stdout_schedule=True,
+    )
+    _patch_codex_popen(mocker, fake)
+
+    started = time.monotonic()
+    response = CodexProvider().exec(
+        "hi",
+        timeout_sec=0.4,
+        max_stall_sec=None,
+        liveness_interval_sec=0.01,
+    )
+    elapsed = time.monotonic() - started
+
+    assert response.text == "done"
+    assert response.session_id == "sess-exited-reader"
+    assert fake.terminated is False
+    assert elapsed < 0.8
+    assert "[conductor] no output from codex for " not in capsys.readouterr().err
 
 
 def test_codex_exec_no_stall_watchdog_by_default(mocker):


### PR DESCRIPTION
## Summary

Fixes #152 by allowing the Codex exec stream loop to finish promptly once the child process has exited, even if a reader thread is still blocked on an inherited/open pipe and has not emitted its EOF sentinel.

## Changes

- Break the streaming loop when `process.poll()` reports exit and the stream queue is empty.
- Use a named stream-poll interval constant instead of an inline timeout.
- Bound the normal post-exit reader-thread join to a short timeout before draining any queued output.
- Add a regression test covering final Codex events plus process exit while stdout reader lingers.

## Validation

- `uv run pytest tests/test_adapters_subprocess.py -k 'codex_exec_returns_after_process_exit_when_stdout_reader_lingers or codex_exec'`
- `uv run pytest tests/test_adapters_subprocess.py`
- `uv run ruff check src/conductor/providers/codex.py tests/test_adapters_subprocess.py`
- `uv run mypy src/conductor/providers/codex.py`

Closes #152.