### PR TITLE
Cover balanced OpenRouter exec coding stack

### DIFF
--- a/tests/test_openrouter.py
+++ b/tests/test_openrouter.py
@@ -514,6 +514,46 @@ def test_exec_with_tools_uses_curated_coding_stack_by_default(configured, tmp_pa
     assert "google/gemini-2.5-flash-lite" not in captured["payload"]["models"]
 
 
+def test_exec_with_tools_and_balanced_prefer_uses_curated_coding_stack(
+    configured,
+    tmp_path,
+):
+    captured: dict[str, object] = {}
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        captured["payload"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "model": OPENROUTER_CODING_HIGH[0],
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "implementation complete",
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 3},
+            },
+        )
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.post("/chat/completions").mock(side_effect=_record)
+        response = OpenRouterProvider().exec(
+            "Implement the change.",
+            prefer="balanced",
+            tools=frozenset({"Read", "Grep", "Edit", "Write", "Bash"}),
+            sandbox="workspace-write",
+            cwd=str(tmp_path),
+        )
+
+    assert response.model == OPENROUTER_CODING_HIGH[0]
+    assert captured["payload"]["models"] == list(OPENROUTER_CODING_HIGH)
+    assert "model" not in captured["payload"]
+
+
 def test_exec_code_task_no_tool_calls_raises_noop_status(configured, tmp_path):
     _init_clean_git_repo(tmp_path)
 


### PR DESCRIPTION
## Summary

Adds regression coverage for #145: direct `OpenRouterProvider.exec()` with repo-editing tools and `prefer="balanced"` must send the curated frontier coding stack, not raw `openrouter/auto` or an obscure/free-tier shortlist.

The behavior is already implemented on `main`; this pins the specific direct-exec path that regressed in #145.

## Validation

- `uv run pytest tests/test_openrouter.py tests/test_openrouter_selector.py`
- `uv run ruff check tests/test_openrouter.py`

Closes #145.