### PR TITLE
Add hard caps for council fan-out

### DIFF
--- a/docs/consumers.md
+++ b/docs/consumers.md
@@ -62,7 +62,11 @@ Use `conductor review` for code review. It only routes to providers with native 
 | `council` | `medium` | `council` | OpenRouter fan-out: `~google/gemini-pro-latest`, `~moonshotai/kimi-latest`, `deepseek/deepseek-v4-pro`; synthesize with `~google/gemini-pro-latest` → `~openai/gpt-latest` |
 | `council` | `high`, `max` | `council` | OpenRouter fan-out: `~google/gemini-pro-latest`, `~anthropic/claude-sonnet-latest`, `~openai/gpt-latest`, `deepseek/deepseek-v4-pro`, `qwen/qwen3.6-max-preview`; synthesize with `~openai/gpt-latest` → `~anthropic/claude-sonnet-latest` |
 
-`council` is intentionally OpenRouter-only. It runs independent member calls through OpenRouter, then sends those outputs to an OpenRouter synthesis model. `--offline` is rejected for council because it violates that invariant.
+`council` is intentionally OpenRouter-only and is not the cheap default delegation path. It runs independent member calls through OpenRouter, then sends those outputs to an OpenRouter synthesis model. Use `research` or `code` for routine single-model delegation; reserve `council` for explicit multi-model judgment.
+
+Council has conservative default caps: 180 seconds total wall-clock, 6,000 reported output tokens across members plus synthesis, and $0.25 total known OpenRouter cost. Override them with `--council-timeout`, `--council-max-output-tokens`, and `--council-max-cost-usd`. When a cap stops the council before synthesis, the command exits nonzero and emits a partial `CallResponse`; `raw.conductor_council.cap_hit` includes the cap kind, requested/observed limit, elapsed time, completed member count, completed member models, and skipped member models. `--timeout` remains the per-call provider timeout and is bounded by the remaining council wall-clock cap.
+
+`--offline` is rejected for council because it violates the OpenRouter-only invariant.
 
 ## Input
 
@@ -127,7 +131,7 @@ The canonical reference is `conductor call --help`. The contract-level commitmen
 | `--offline` / `--no-offline` | bool | stable | Force/clear local-only routing |
 | `--profile <name>` | string | stable | Apply named profile defaults |
 
-`conductor ask --help` is the canonical reference for the semantic API. Its stable flags are: --kind, --effort, --cwd, --timeout, --max-stall-seconds, --base, --commit, --uncommitted, --title, --brief, --brief-file, --task, --task-file, --log-file, --json, --verbose-route, --silent-route, --offline, --no-offline, --preflight, --no-preflight, and --allow-short-brief.
+`conductor ask --help` is the canonical reference for the semantic API. Its stable flags are: --kind, --effort, --cwd, --timeout, --max-stall-seconds, --council-timeout, --council-max-output-tokens, --council-max-cost-usd, --base, --commit, --uncommitted, --title, --brief, --brief-file, --task, --task-file, --log-file, --json, --verbose-route, --silent-route, --offline, --no-offline, --preflight, --no-preflight, and --allow-short-brief.
 
 ## Output (`--json`)
 
@@ -257,6 +261,14 @@ Agents that do not need provider-level control should prefer `ask`:
 conductor ask --kind research --effort medium --brief-file /tmp/brief.md --json
 conductor ask --kind code --effort high --brief-file /tmp/brief.md --json
 conductor ask --kind council --effort medium --brief-file /tmp/brief.md --json
+```
+
+`council` is multi-call OpenRouter fan-out. For budget-sensitive routine delegation, use `research` or `code`; when using `council`, set tighter caps explicitly if the caller owns a smaller budget:
+
+```bash
+conductor ask --kind council --effort medium --brief-file /tmp/brief.md \
+  --council-timeout 90 --council-max-output-tokens 3000 \
+  --council-max-cost-usd 0.10 --json
 ```
 
 For merge review, Touchstone should continue to use `conductor review` or `conductor ask --kind review`; both must trigger native review mode, not generic code chat.

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -123,6 +123,9 @@ GIT_RECOVERY_MAX_STATUS_PATHS = 8
 NATIVE_REVIEW_TAG = "code-review"
 DEFAULT_REVIEW_MAX_FALLBACKS = 3
 DEFAULT_COUNCIL_ROUNDS = 1
+DEFAULT_COUNCIL_TIMEOUT_SEC = 180
+DEFAULT_COUNCIL_MAX_OUTPUT_TOKENS = 6_000
+DEFAULT_COUNCIL_MAX_COST_USD = 0.25
 ESTIMATED_CHARS_PER_TOKEN = 4
 
 
@@ -131,6 +134,13 @@ class BriefInput:
     body: str
     source: str
     attachments: tuple[Path, ...] = ()
+
+
+@dataclass(frozen=True)
+class CouncilCaps:
+    timeout_sec: int | None
+    max_output_tokens: int | None
+    max_cost_usd: float | None
 
 
 # --------------------------------------------------------------------------- #
@@ -1263,12 +1273,22 @@ def _invoke_review_with_fallback(
     raise last_exc
 
 
+class CouncilCapError(ProviderError):
+    """Raised when council caps stop fan-out before a complete synthesis."""
+
+    def __init__(self, response: CallResponse) -> None:
+        self.response = response
+        council_raw = (response.raw or {}).get("conductor_council") or {}
+        super().__init__(_format_council_cap_hit(council_raw.get("cap_hit") or {}))
+
+
 def _invoke_council(
     plan: SemanticPlan,
     *,
     task: str,
     effort: str | int,
     timeout_sec: int | None,
+    caps: CouncilCaps,
     rounds: int,
     silent: bool,
 ) -> CallResponse:
@@ -1276,6 +1296,8 @@ def _invoke_council(
 
     Council is intentionally OpenRouter-only: it fans out to the policy's
     member model stack, then asks a synthesis model to reconcile disagreements.
+    Caps are checked before starting each upstream call so a known-over-budget
+    council cannot silently continue spending time, tokens, or money.
     """
     if plan.candidates[0].provider != "openrouter":
         raise ProviderConfigError(
@@ -1291,78 +1313,564 @@ def _invoke_council(
         raise ProviderConfigError(
             "provider registry invariant violated: openrouter is not OpenRouterProvider."
         )
-    if timeout_sec is not None:
-        provider = OpenRouterProvider(timeout_sec=float(timeout_sec))
 
+    started_at = time.monotonic()
     member_responses: list[CallResponse] = []
     member_prompt = _council_member_prompt(task, rounds=rounds)
+    synthesis_models = plan.council_synthesis_models or plan.council_member_models[:1]
+
     for idx, model in enumerate(plan.council_member_models, start=1):
+        elapsed_ms = _council_elapsed_ms(started_at)
+        _raise_if_council_cap_hit(
+            plan=plan,
+            caps=caps,
+            effort=effort,
+            rounds=rounds,
+            member_responses=member_responses,
+            synthesis=None,
+            synthesis_models=synthesis_models,
+            stage="before_member",
+            model=model,
+            elapsed_ms=elapsed_ms,
+        )
         if not silent:
             click.echo(f"[conductor] council member {idx}: {model}", err=True)
-        response = provider.call(
+        response = _openrouter_council_provider(
+            provider=provider,
+            timeout_sec=timeout_sec,
+            remaining_sec=_council_remaining_sec(caps, elapsed_ms),
+        ).call(
             member_prompt,
             model=model,
             effort=effort,
             task_tags=list(plan.tags),
             prefer=plan.prefer,
             log_selection=False,
+            max_tokens=_council_remaining_output_tokens(caps, member_responses),
         )
         member_responses.append(response)
+        _raise_if_council_cap_hit(
+            plan=plan,
+            caps=caps,
+            effort=effort,
+            rounds=rounds,
+            member_responses=member_responses,
+            synthesis=None,
+            synthesis_models=synthesis_models,
+            stage="after_member",
+            model=model,
+            elapsed_ms=_council_elapsed_ms(started_at),
+        )
 
-    synthesis_models = plan.council_synthesis_models or plan.council_member_models[:1]
+    elapsed_ms = _council_elapsed_ms(started_at)
+    _raise_if_council_cap_hit(
+        plan=plan,
+        caps=caps,
+        effort=effort,
+        rounds=rounds,
+        member_responses=member_responses,
+        synthesis=None,
+        synthesis_models=synthesis_models,
+        stage="before_synthesis",
+        model=",".join(synthesis_models),
+        elapsed_ms=elapsed_ms,
+    )
     if not silent:
         click.echo(
             "[conductor] council synthesis: " + ",".join(synthesis_models),
             err=True,
         )
-    synthesis = provider.call(
+    synthesis = _openrouter_council_provider(
+        provider=provider,
+        timeout_sec=timeout_sec,
+        remaining_sec=_council_remaining_sec(caps, elapsed_ms),
+    ).call(
         _council_synthesis_prompt(task, member_responses),
         models=synthesis_models,
         effort=effort,
         task_tags=list(plan.tags),
         prefer=plan.prefer,
         log_selection=False,
+        max_tokens=_council_remaining_output_tokens(caps, member_responses),
     )
 
+    raw, usage, cost_usd = _council_response_metadata(
+        plan=plan,
+        caps=caps,
+        effort=effort,
+        rounds=rounds,
+        member_responses=member_responses,
+        synthesis=synthesis,
+        synthesis_models=synthesis_models,
+        elapsed_ms=_council_elapsed_ms(started_at),
+        cap_hit=None,
+    )
+    return replace(
+        synthesis,
+        usage=usage,
+        cost_usd=cost_usd,
+        raw={**(synthesis.raw or {}), **raw},
+    )
+
+
+def _openrouter_council_provider(
+    *,
+    provider: OpenRouterProvider,
+    timeout_sec: int | None,
+    remaining_sec: float | None,
+) -> OpenRouterProvider:
+    timeout_limits: list[float] = []
+    if timeout_sec is not None:
+        timeout_limits.append(float(timeout_sec))
+    if remaining_sec is not None:
+        timeout_limits.append(remaining_sec)
+    if not timeout_limits:
+        return provider
+    return OpenRouterProvider(timeout_sec=max(0.001, min(timeout_limits)))
+
+
+def _council_elapsed_ms(started_at: float) -> int:
+    return int(max(0.0, time.monotonic() - started_at) * 1000)
+
+
+def _council_remaining_sec(caps: CouncilCaps, elapsed_ms: int) -> float | None:
+    if caps.timeout_sec is None:
+        return None
+    return max(0.0, float(caps.timeout_sec) - (elapsed_ms / 1000))
+
+
+def _council_remaining_output_tokens(
+    caps: CouncilCaps,
+    member_responses: list[CallResponse],
+) -> int | None:
+    if caps.max_output_tokens is None:
+        return None
+    known_output_tokens, output_complete, _missing, _member_tokens, _synthesis_tokens = (
+        _council_output_token_accounting(member_responses, None)
+    )
+    if not output_complete:
+        return None
+    return max(1, caps.max_output_tokens - known_output_tokens)
+
+
+def _raise_if_council_cap_hit(
+    *,
+    plan: SemanticPlan,
+    caps: CouncilCaps,
+    effort: str | int,
+    rounds: int,
+    member_responses: list[CallResponse],
+    synthesis: CallResponse | None,
+    synthesis_models: tuple[str, ...],
+    stage: str,
+    model: str,
+    elapsed_ms: int,
+) -> None:
+    cap_hit = _council_cap_hit_payload(
+        plan=plan,
+        caps=caps,
+        member_responses=member_responses,
+        synthesis=synthesis,
+        stage=stage,
+        model=model,
+        elapsed_ms=elapsed_ms,
+    )
+    if cap_hit is None:
+        return
+
+    raw, usage, cost_usd = _council_response_metadata(
+        plan=plan,
+        caps=caps,
+        effort=effort,
+        rounds=rounds,
+        member_responses=member_responses,
+        synthesis=synthesis,
+        synthesis_models=synthesis_models,
+        elapsed_ms=elapsed_ms,
+        cap_hit=cap_hit,
+    )
+    response = CallResponse(
+        text=_council_partial_text(member_responses, cap_hit),
+        provider="openrouter",
+        model=_council_partial_model(member_responses, model),
+        duration_ms=elapsed_ms,
+        usage=usage,
+        cost_usd=cost_usd,
+        raw=raw,
+    )
+    raise CouncilCapError(response)
+
+
+def _council_cap_hit_payload(
+    *,
+    plan: SemanticPlan,
+    caps: CouncilCaps,
+    member_responses: list[CallResponse],
+    synthesis: CallResponse | None,
+    stage: str,
+    model: str,
+    elapsed_ms: int,
+) -> dict[str, object] | None:
+    if caps.timeout_sec is not None and elapsed_ms >= caps.timeout_sec * 1000:
+        return _council_cap_payload(
+            "wall_clock",
+            limit=caps.timeout_sec,
+            observed=elapsed_ms / 1000,
+            plan=plan,
+            member_responses=member_responses,
+            stage=stage,
+            model=model,
+            elapsed_ms=elapsed_ms,
+        )
+
+    if caps.max_output_tokens is not None:
+        known_output_tokens, output_complete, _missing, _member_tokens, _synthesis_tokens = (
+            _council_output_token_accounting(member_responses, synthesis)
+        )
+        if not output_complete:
+            return _council_cap_payload(
+                "output_tokens_unknown",
+                limit=caps.max_output_tokens,
+                observed=known_output_tokens,
+                plan=plan,
+                member_responses=member_responses,
+                stage=stage,
+                model=model,
+                elapsed_ms=elapsed_ms,
+            )
+        if known_output_tokens >= caps.max_output_tokens:
+            return _council_cap_payload(
+                "output_tokens",
+                limit=caps.max_output_tokens,
+                observed=known_output_tokens,
+                plan=plan,
+                member_responses=member_responses,
+                stage=stage,
+                model=model,
+                elapsed_ms=elapsed_ms,
+            )
+
+    if caps.max_cost_usd is not None:
+        known_cost_usd = _council_known_cost_value(member_responses, synthesis)
+        if known_cost_usd >= caps.max_cost_usd:
+            return _council_cap_payload(
+                "known_cost_usd",
+                limit=caps.max_cost_usd,
+                observed=known_cost_usd,
+                plan=plan,
+                member_responses=member_responses,
+                stage=stage,
+                model=model,
+                elapsed_ms=elapsed_ms,
+            )
+    return None
+
+
+def _council_cap_payload(
+    kind: str,
+    *,
+    limit: int | float,
+    observed: int | float,
+    plan: SemanticPlan,
+    member_responses: list[CallResponse],
+    stage: str,
+    model: str,
+    elapsed_ms: int,
+) -> dict[str, object]:
+    completed_member_calls = len(member_responses)
+    return {
+        "kind": kind,
+        "limit": limit,
+        "observed": observed,
+        "stage": stage,
+        "model": model,
+        "elapsed_ms": elapsed_ms,
+        "elapsed_sec": elapsed_ms / 1000,
+        "completed_member_calls": completed_member_calls,
+        "total_member_calls": len(plan.council_member_models),
+        "completed_member_models": [response.model for response in member_responses],
+        "requested_completed_member_models": list(
+            plan.council_member_models[:completed_member_calls]
+        ),
+        "skipped_member_models": list(
+            plan.council_member_models[completed_member_calls:]
+        ),
+        "synthesis_skipped": stage != "after_synthesis",
+    }
+
+
+def _council_response_metadata(
+    *,
+    plan: SemanticPlan,
+    caps: CouncilCaps,
+    effort: str | int,
+    rounds: int,
+    member_responses: list[CallResponse],
+    synthesis: CallResponse | None,
+    synthesis_models: tuple[str, ...],
+    elapsed_ms: int,
+    cap_hit: dict[str, object] | None,
+) -> tuple[dict[str, object], dict[str, object], float | None]:
+    (
+        known_cost_usd,
+        cost_accounting_complete,
+        missing_costs,
+        member_costs,
+        synthesis_cost_usd,
+    ) = _council_cost_accounting(member_responses, synthesis)
+    (
+        known_output_tokens,
+        output_accounting_complete,
+        missing_output_tokens,
+        member_output_tokens,
+        synthesis_output_tokens,
+    ) = _council_output_token_accounting(member_responses, synthesis)
+    council_raw = {
+        "member_models": [response.model for response in member_responses],
+        "requested_member_models": list(plan.council_member_models),
+        "requested_synthesis_models": list(synthesis_models),
+        "rounds": rounds,
+        "member_usage": [response.usage for response in member_responses],
+        "member_cost_usd": member_costs,
+        "synthesis_cost_usd": synthesis_cost_usd,
+        "known_cost_usd": known_cost_usd,
+        "cost_accounting_complete": cost_accounting_complete,
+        "missing_costs": missing_costs,
+        "member_duration_ms": [response.duration_ms for response in member_responses],
+        "elapsed_ms": elapsed_ms,
+        "caps": _council_caps_payload(caps),
+        "cap_hit": cap_hit,
+        "complete": cap_hit is None and synthesis is not None,
+        "known_output_tokens": known_output_tokens,
+        "output_accounting_complete": output_accounting_complete,
+        "missing_output_tokens": missing_output_tokens,
+        "member_output_tokens": member_output_tokens,
+        "synthesis_output_tokens": synthesis_output_tokens,
+    }
+    usage = _council_usage_payload(
+        effort=effort,
+        rounds=rounds,
+        member_responses=member_responses,
+        synthesis=synthesis,
+        cap_hit=cap_hit,
+        known_cost_usd=known_cost_usd,
+        cost_accounting_complete=cost_accounting_complete,
+        missing_costs=missing_costs,
+        known_output_tokens=known_output_tokens,
+        output_accounting_complete=output_accounting_complete,
+        missing_output_tokens=missing_output_tokens,
+        caps=caps,
+    )
+    cost_usd = known_cost_usd if cost_accounting_complete else None
+    return {"conductor_council": council_raw}, usage, cost_usd
+
+
+def _council_usage_payload(
+    *,
+    effort: str | int,
+    rounds: int,
+    member_responses: list[CallResponse],
+    synthesis: CallResponse | None,
+    cap_hit: dict[str, object] | None,
+    known_cost_usd: float | None,
+    cost_accounting_complete: bool,
+    missing_costs: list[str],
+    known_output_tokens: int,
+    output_accounting_complete: bool,
+    missing_output_tokens: list[str],
+    caps: CouncilCaps,
+) -> dict[str, object]:
+    if synthesis is not None:
+        usage: dict[str, object] = dict(synthesis.usage)
+    else:
+        usage = {
+            "input_tokens": _council_known_usage_sum(member_responses, "input_tokens"),
+            "output_tokens": (
+                known_output_tokens if output_accounting_complete else None
+            ),
+            "cached_tokens": _council_known_usage_sum(member_responses, "cached_tokens"),
+            "thinking_tokens": _council_known_usage_sum(
+                member_responses,
+                "thinking_tokens",
+            ),
+            "effort": effort if isinstance(effort, str) else None,
+            "thinking_budget": None,
+        }
+    usage.update(
+        {
+            "council_members": len(member_responses),
+            "council_rounds": rounds,
+            "council_complete": cap_hit is None and synthesis is not None,
+            "council_cap_hit": cap_hit,
+            "council_caps": _council_caps_payload(caps),
+            "cost_accounting_complete": cost_accounting_complete,
+            "known_cost_usd": known_cost_usd,
+            "missing_costs": missing_costs,
+            "council_known_output_tokens": known_output_tokens,
+            "council_output_accounting_complete": output_accounting_complete,
+            "council_missing_output_tokens": missing_output_tokens,
+        }
+    )
+    return usage
+
+
+def _council_cost_accounting(
+    member_responses: list[CallResponse],
+    synthesis: CallResponse | None,
+) -> tuple[float | None, bool, list[str], list[float | None], float | None]:
     member_costs = [response.cost_usd for response in member_responses]
-    all_costs = [*member_costs, synthesis.cost_usd]
     missing_costs = [
         f"member[{idx}]"
         for idx, cost in enumerate(member_costs, start=1)
         if cost is None
     ]
-    if synthesis.cost_usd is None:
+    synthesis_cost = synthesis.cost_usd if synthesis is not None else None
+    if synthesis is not None and synthesis_cost is None:
         missing_costs.append("synthesis")
-    known_costs = [cost for cost in all_costs if cost is not None]
+    known_costs = [cost for cost in [*member_costs, synthesis_cost] if cost is not None]
     known_cost_usd = sum(known_costs) if known_costs else None
-    cost_accounting_complete = not missing_costs
+    return (
+        known_cost_usd,
+        not missing_costs,
+        missing_costs,
+        member_costs,
+        synthesis_cost,
+    )
 
-    raw = {
-        **(synthesis.raw or {}),
-        "conductor_council": {
-            "member_models": [response.model for response in member_responses],
-            "requested_member_models": list(plan.council_member_models),
-            "requested_synthesis_models": list(synthesis_models),
-            "rounds": rounds,
-            "member_usage": [response.usage for response in member_responses],
-            "member_cost_usd": member_costs,
-            "synthesis_cost_usd": synthesis.cost_usd,
-            "known_cost_usd": known_cost_usd,
-            "cost_accounting_complete": cost_accounting_complete,
-            "missing_costs": missing_costs,
-            "member_duration_ms": [response.duration_ms for response in member_responses],
-        },
+
+def _council_known_cost_value(
+    member_responses: list[CallResponse],
+    synthesis: CallResponse | None,
+) -> float:
+    known_cost_usd, _complete, _missing, _member_costs, _synthesis_cost = (
+        _council_cost_accounting(member_responses, synthesis)
+    )
+    return known_cost_usd or 0.0
+
+
+def _council_output_token_accounting(
+    member_responses: list[CallResponse],
+    synthesis: CallResponse | None,
+) -> tuple[int, bool, list[str], list[int | None], int | None]:
+    known_output_tokens = 0
+    missing_output_tokens: list[str] = []
+    member_output_tokens: list[int | None] = []
+    for idx, response in enumerate(member_responses, start=1):
+        output_tokens = _response_output_tokens(response)
+        member_output_tokens.append(output_tokens)
+        if output_tokens is None:
+            missing_output_tokens.append(f"member[{idx}]")
+        else:
+            known_output_tokens += output_tokens
+
+    synthesis_output_tokens = None
+    if synthesis is not None:
+        synthesis_output_tokens = _response_output_tokens(synthesis)
+        if synthesis_output_tokens is None:
+            missing_output_tokens.append("synthesis")
+        else:
+            known_output_tokens += synthesis_output_tokens
+
+    return (
+        known_output_tokens,
+        not missing_output_tokens,
+        missing_output_tokens,
+        member_output_tokens,
+        synthesis_output_tokens,
+    )
+
+
+def _response_output_tokens(response: CallResponse) -> int | None:
+    output_tokens = (response.usage or {}).get("output_tokens")
+    if isinstance(output_tokens, int) and not isinstance(output_tokens, bool):
+        return max(0, output_tokens)
+    return None
+
+
+def _council_known_usage_sum(
+    responses: list[CallResponse],
+    key: str,
+) -> int | None:
+    values: list[int] = []
+    for response in responses:
+        value = (response.usage or {}).get(key)
+        if isinstance(value, int) and not isinstance(value, bool):
+            values.append(value)
+    return sum(values) if values else None
+
+
+def _council_caps_payload(caps: CouncilCaps) -> dict[str, int | float | None]:
+    return {
+        "timeout_sec": caps.timeout_sec,
+        "max_output_tokens": caps.max_output_tokens,
+        "max_cost_usd": caps.max_cost_usd,
     }
-    usage = {
-        **synthesis.usage,
-        "council_members": len(member_responses),
-        "council_rounds": rounds,
-        "cost_accounting_complete": cost_accounting_complete,
-        "known_cost_usd": known_cost_usd,
-        "missing_costs": missing_costs,
+
+
+def _council_partial_model(member_responses: list[CallResponse], model: str) -> str:
+    if member_responses:
+        return member_responses[-1].model
+    return model or "council-partial"
+
+
+def _council_partial_text(
+    member_responses: list[CallResponse],
+    cap_hit: dict[str, object],
+) -> str:
+    lines = [
+        _format_council_cap_hit(cap_hit) + ".",
+        (
+            "Completed member calls: "
+            f"{cap_hit.get('completed_member_calls', 0)}/"
+            f"{cap_hit.get('total_member_calls', 0)}."
+        ),
+    ]
+    if not member_responses:
+        lines.append("No member calls completed before the cap was reached.")
+        return "\n".join(lines)
+
+    lines.append("Partial member responses:")
+    for idx, response in enumerate(member_responses, start=1):
+        lines.append(
+            f"\n## Member {idx}: {response.model}\n\n"
+            f"{_council_member_response_text(response)}"
+        )
+    return "\n".join(lines)
+
+
+def _format_council_cap_hit(cap_hit: dict[str, object]) -> str:
+    kind = str(cap_hit.get("kind", "unknown"))
+    labels = {
+        "wall_clock": "wall-clock cap",
+        "output_tokens": "output-token cap",
+        "output_tokens_unknown": "output-token accounting cap",
+        "known_cost_usd": "known cost cap",
     }
-    cost_usd = known_cost_usd if cost_accounting_complete else None
-    return replace(synthesis, usage=usage, cost_usd=cost_usd, raw=raw)
+    label = labels.get(kind, "cap")
+    elapsed_raw = cap_hit.get("elapsed_sec")
+    elapsed_sec = (
+        float(elapsed_raw)
+        if isinstance(elapsed_raw, int | float) and not isinstance(elapsed_raw, bool)
+        else 0.0
+    )
+    stage = str(cap_hit.get("stage") or "council")
+    model = str(cap_hit.get("model") or "unknown model")
+    completed_raw = cap_hit.get("completed_member_calls")
+    total_raw = cap_hit.get("total_member_calls")
+    completed = (
+        int(completed_raw)
+        if isinstance(completed_raw, int | float) and not isinstance(completed_raw, bool)
+        else 0
+    )
+    total = (
+        int(total_raw)
+        if isinstance(total_raw, int | float) and not isinstance(total_raw, bool)
+        else 0
+    )
+    return (
+        f"council {label} hit at {elapsed_sec:.1f}s during {stage} ({model}); "
+        f"completed {completed}/{total} member calls"
+    )
 
 
 def _council_member_prompt(task: str, *, rounds: int) -> str:
@@ -1876,7 +2384,10 @@ def main(ctx: click.Context) -> None:
     "--kind",
     required=True,
     type=click.Choice(SEMANTIC_KINDS),
-    help="Semantic work category: research, code, review, or council.",
+    help=(
+        "Semantic work category. research/code are cheap single-model defaults; "
+        "council is capped OpenRouter multi-model fan-out."
+    ),
 )
 @click.option(
     "--effort",
@@ -1897,6 +2408,34 @@ def main(ctx: click.Context) -> None:
     default=DEFAULT_EXEC_MAX_STALL_SEC,
     type=int,
     help="Kill streaming exec/review providers after this many silent seconds. Set 0 to disable.",
+)
+@click.option(
+    "--council-timeout",
+    "council_timeout_sec",
+    default=DEFAULT_COUNCIL_TIMEOUT_SEC,
+    type=click.IntRange(min=1),
+    show_default=True,
+    help=(
+        "For council: total wall-clock cap in seconds across members and synthesis. "
+        "--timeout remains the per-call provider timeout."
+    ),
+)
+@click.option(
+    "--council-max-output-tokens",
+    default=DEFAULT_COUNCIL_MAX_OUTPUT_TOKENS,
+    type=click.IntRange(min=1),
+    show_default=True,
+    help="For council: stop before more calls once reported output tokens reach this total.",
+)
+@click.option(
+    "--council-max-cost-usd",
+    default=DEFAULT_COUNCIL_MAX_COST_USD,
+    type=click.FloatRange(min=0.0),
+    show_default=True,
+    help=(
+        "For council: stop before more calls once total known OpenRouter cost "
+        "reaches this USD budget."
+    ),
 )
 @click.option("--base", default=None, help="For review: compare changes against this ref.")
 @click.option("--commit", default=None, help="For review: review one commit.")
@@ -1957,6 +2496,9 @@ def ask(
     cwd: str | None,
     timeout_sec: int | None,
     max_stall_sec: int | None,
+    council_timeout_sec: int,
+    council_max_output_tokens: int,
+    council_max_cost_usd: float,
     base: str | None,
     commit: str | None,
     uncommitted: bool,
@@ -1978,6 +2520,11 @@ def ask(
     effort_value = _parse_effort(effort)
     plan = plan_for(kind, effort_value)
     max_stall_sec = _normalize_max_stall_sec(max_stall_sec)
+    council_caps = CouncilCaps(
+        timeout_sec=council_timeout_sec,
+        max_output_tokens=council_max_output_tokens,
+        max_cost_usd=council_max_cost_usd,
+    )
 
     if offline is False:
         offline_mode.clear()
@@ -2027,9 +2574,15 @@ def ask(
                 task=body,
                 effort=effort_value,
                 timeout_sec=timeout_sec,
+                caps=council_caps,
                 rounds=DEFAULT_COUNCIL_ROUNDS,
                 silent=silent_route or as_json,
             )
+        except CouncilCapError as e:
+            click.echo(f"conductor: {e}", err=True)
+            _emit_usage_log(e.response, silent=silent_route or as_json)
+            _emit_call(e.response, as_json=as_json, semantic_plan=plan)
+            sys.exit(1)
         except ProviderConfigError as e:
             click.echo(f"conductor: {e}", err=True)
             sys.exit(2)

--- a/src/conductor/providers/openrouter.py
+++ b/src/conductor/providers/openrouter.py
@@ -267,6 +267,7 @@ class OpenRouterProvider:
         prefer: str = "balanced",
         exclude: set[str] | frozenset[str] | None = None,
         log_selection: bool = True,
+        max_tokens: int | None = None,
         resume_session_id: str | None = None,
     ) -> CallResponse:
         if resume_session_id:
@@ -293,6 +294,8 @@ class OpenRouterProvider:
             **target_payload,
             "messages": [{"role": "user", "content": task}],
         }
+        if max_tokens is not None:
+            payload["max_tokens"] = max(1, max_tokens)
 
         start = time.monotonic()
         body = self._post_chat(payload)

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -82,6 +82,7 @@ def _fake_response(
     model: str = "sonnet",
     *,
     cost_usd: float | None = 0.01,
+    output_tokens: int | None = 10,
 ) -> CallResponse:
     return CallResponse(
         text="hello",
@@ -90,7 +91,7 @@ def _fake_response(
         duration_ms=1234,
         usage={
             "input_tokens": 50,
-            "output_tokens": 10,
+            "output_tokens": output_tokens,
             "thinking_tokens": 4_000,
             "cached_tokens": 0,
         },
@@ -750,6 +751,132 @@ def test_ask_council_marks_incomplete_cost_accounting(mocker):
         None,
         0.03,
     ]
+
+
+def test_ask_council_known_cost_cap_returns_partial_error(mocker):
+    _stub_all_configured(mocker, {"openrouter"})
+    responses = [
+        _fake_response("openrouter", "member-a", cost_usd=0.02),
+        _fake_response("openrouter", "member-b", cost_usd=0.02),
+        _fake_response("openrouter", "member-c", cost_usd=0.02),
+        _fake_response("openrouter", "synthesis", cost_usd=0.02),
+    ]
+    call_mock = mocker.patch.object(OpenRouterProvider, "call", side_effect=responses)
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "ask",
+            "--kind",
+            "council",
+            "--effort",
+            "medium",
+            "--council-max-cost-usd",
+            "0.03",
+            "--brief",
+            "Debate this architecture decision.",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 1, result.output
+    assert "known cost cap" in result.stderr
+    assert call_mock.call_count == 2
+    assert "models" not in call_mock.call_args_list[-1].kwargs
+    payload = json.loads(result.stdout)
+    council = payload["raw"]["conductor_council"]
+    assert payload["usage"]["council_complete"] is False
+    assert payload["usage"]["known_cost_usd"] == pytest.approx(0.04)
+    assert council["complete"] is False
+    assert council["cap_hit"]["kind"] == "known_cost_usd"
+    assert council["cap_hit"]["completed_member_calls"] == 2
+    assert council["cap_hit"]["total_member_calls"] == 3
+    assert council["cap_hit"]["skipped_member_models"] == ["deepseek/deepseek-v4-pro"]
+    assert council["synthesis_cost_usd"] is None
+    assert "## Member 2: member-b" in payload["text"]
+
+
+def test_ask_council_output_token_cap_returns_partial_error(mocker):
+    _stub_all_configured(mocker, {"openrouter"})
+    responses = [
+        _fake_response("openrouter", "member-a", output_tokens=12),
+        _fake_response("openrouter", "member-b", output_tokens=12),
+        _fake_response("openrouter", "member-c", output_tokens=12),
+        _fake_response("openrouter", "synthesis", output_tokens=12),
+    ]
+    call_mock = mocker.patch.object(OpenRouterProvider, "call", side_effect=responses)
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "ask",
+            "--kind",
+            "council",
+            "--effort",
+            "medium",
+            "--council-max-output-tokens",
+            "12",
+            "--brief",
+            "Debate this architecture decision.",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 1, result.output
+    assert "output-token cap" in result.stderr
+    assert call_mock.call_count == 1
+    assert call_mock.call_args_list[0].kwargs["max_tokens"] == 12
+    payload = json.loads(result.stdout)
+    council = payload["raw"]["conductor_council"]
+    assert payload["usage"]["council_known_output_tokens"] == 12
+    assert council["cap_hit"]["kind"] == "output_tokens"
+    assert council["cap_hit"]["observed"] == 12
+    assert council["cap_hit"]["completed_member_calls"] == 1
+    assert council["member_output_tokens"] == [12]
+    assert council["requested_synthesis_models"] == [
+        "~google/gemini-pro-latest",
+        "~openai/gpt-latest",
+    ]
+
+
+def test_ask_council_wall_clock_cap_returns_partial_error(mocker):
+    _stub_all_configured(mocker, {"openrouter"})
+    mocker.patch("conductor.cli.time.monotonic", side_effect=[0.0, 0.0, 2.0])
+    responses = [
+        _fake_response("openrouter", "member-a"),
+        _fake_response("openrouter", "member-b"),
+        _fake_response("openrouter", "member-c"),
+        _fake_response("openrouter", "synthesis"),
+    ]
+    call_mock = mocker.patch.object(OpenRouterProvider, "call", side_effect=responses)
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "ask",
+            "--kind",
+            "council",
+            "--effort",
+            "medium",
+            "--council-timeout",
+            "1",
+            "--brief",
+            "Debate this architecture decision.",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 1, result.output
+    assert "wall-clock cap" in result.stderr
+    assert call_mock.call_count == 1
+    payload = json.loads(result.stdout)
+    council = payload["raw"]["conductor_council"]
+    assert payload["duration_ms"] == 2000
+    assert council["elapsed_ms"] == 2000
+    assert council["cap_hit"]["kind"] == "wall_clock"
+    assert council["cap_hit"]["elapsed_sec"] == 2.0
+    assert council["cap_hit"]["completed_member_calls"] == 1
+    assert council["cap_hit"]["model"] == "~google/gemini-pro-latest"
 
 
 def test_council_synthesis_prompt_handles_empty_member_text():


### PR DESCRIPTION
## Summary

Fixes #157 by adding explicit wall-clock, output-token, and known-cost caps to `conductor ask --kind council`.

## Changes

- Add conservative default council caps: 180s total wall-clock, 6,000 reported output tokens, and $0.25 known OpenRouter cost.
- Add `--council-timeout`, `--council-max-output-tokens`, and `--council-max-cost-usd` CLI flags.
- Stop before additional member/synthesis calls when a cap is hit and return a visible partial `CallResponse` with cap kind, elapsed time, completed member count, completed/skipped models, and partial member responses.
- Bound per-call OpenRouter timeout by remaining council wall-clock budget.
- Pass remaining output budget through to OpenRouter as `max_tokens` where output accounting is complete.
- Preserve and extend council cost/output accounting metadata in `raw.conductor_council` and response `usage`.
- Document council as an expensive OpenRouter-only path distinct from routine `research`/`code` delegation.

## Validation

- `uv run pytest tests/test_cli_v02.py -k 'council'`
- `uv run pytest tests/test_cli_v02.py tests/test_openrouter.py tests/test_openrouter_selector.py`
- `uv run ruff check src/conductor/cli.py src/conductor/providers/openrouter.py tests/test_cli_v02.py`
- `uv run mypy src/conductor/cli.py src/conductor/providers/openrouter.py`
- `uv run pytest`

Closes #157.