### PR TITLE
fix: avoid codex probe minimal+tool conflict (#184)

### DIFF
--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -52,9 +52,7 @@ CODEX_REVIEW_MODEL = "codex-review"
 CODEX_REQUEST_TIMEOUT_SEC = 180.0
 CODEX_STARTUP_PROBE_TIMEOUT_SEC = 8.0
 CODEX_STARTUP_PROBE_CONFIG = (
-    "model_reasoning_effort=minimal",
-    "features.image_gen=false",
-    "features.web_search=false",
+    "model_reasoning_effort=low",
 )
 CODEX_STREAM_POLL_INTERVAL_SEC = 0.05
 CODEX_STREAM_EXIT_READER_JOIN_SEC = 0.2

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -1095,13 +1095,49 @@ def test_codex_configured_false_when_exec_startup_probe_times_out(mocker):
     assert startup_call.kwargs["input"] == "Reply with OK."
 
 
-def test_codex_startup_probe_disables_minimal_reasoning_tool_conflicts(mocker):
+def test_codex_startup_probe_avoids_minimal_reasoning_tool_conflicts(mocker):
     mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
 
     def run(args, **kwargs):
         if args == ["codex", "login", "status"]:
             return _fake_completed(stdout="Logged in using ChatGPT")
         if args[:3] == ["codex", "exec", "-"]:
+            config_values = [
+                args[idx + 1] for idx, value in enumerate(args) if value == "-c"
+            ]
+            if "model_reasoning_effort=minimal" in config_values:
+                web_search_disabled = (
+                    "web_search='disabled'" in config_values
+                    or 'web_search="disabled"' in config_values
+                )
+                tools_disabled = (
+                    web_search_disabled
+                    and "features.image_generation=false" in config_values
+                )
+                if not tools_disabled:
+                    return _fake_completed(
+                        stdout=json.dumps(
+                            {
+                                "type": "error",
+                                "message": json.dumps(
+                                    {
+                                        "type": "error",
+                                        "error": {
+                                            "type": "invalid_request_error",
+                                            "message": (
+                                                "The following tools cannot be used with "
+                                                "reasoning.effort 'minimal': "
+                                                "image_gen, web_search."
+                                            ),
+                                            "param": "tools",
+                                        },
+                                        "status": 400,
+                                    },
+                                ),
+                            },
+                        ),
+                        returncode=1,
+                    )
             return _fake_completed(stdout='{"type":"turn.completed"}\n')
         raise AssertionError(f"unexpected command: {args!r}")
 
@@ -1117,6 +1153,10 @@ def test_codex_startup_probe_disables_minimal_reasoning_tool_conflicts(mocker):
         if value == "-c"
     ]
     assert config_values == list(CODEX_STARTUP_PROBE_CONFIG)
+    assert "model_reasoning_effort=low" in config_values
+    assert "model_reasoning_effort=minimal" not in config_values
+    assert "features.web_search=false" not in config_values
+    assert "features.image_gen=false" not in config_values
 
 
 def test_codex_startup_probe_reports_api_error_instead_of_first_event(mocker):


### PR DESCRIPTION
## Summary

- The startup probe was setting `model_reasoning_effort=minimal` while the codex API rejects that combo whenever the default tool set includes `image_gen` / `web_search` (the `features.image_gen=false` / `features.web_search=false` overrides did not actually strip those tools from the request).
- Probe now uses `model_reasoning_effort=low` — the next-cheapest valid effort that's compatible with the default tool set — and drops the ineffective feature flags.
- Regression test asserts the old minimal+tools combo would fail and the new low config passes.

Closes #184.

## Test plan

- [x] `uv run pytest tests/` — 833 passed, 15 skipped
- [x] `uv run ruff check src/ tests/` — clean
- [x] Live: `CodexProvider().configured()` → `(True, None)`