### PR TITLE
fix: align codex heartbeat session-log progress (#183)

### DIFF
--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -43,6 +43,14 @@ from conductor.providers.terminal_signals import (
     append_recent_text,
     detect_retriable_provider_failure,
 )
+from conductor.session_log import (
+    SESSION_DATA_TOKEN_COUNT,
+    SESSION_DATA_USAGE,
+    SESSION_EVENT_SUBAGENT_MESSAGE,
+    SESSION_EVENT_TOOL_CALL,
+    SESSION_EVENT_USAGE,
+    SESSION_USAGE_OUTPUT_TOKENS,
+)
 
 if TYPE_CHECKING:
     from conductor.session_log import SessionLog
@@ -90,6 +98,12 @@ def _format_compact_count(value: int) -> str:
     if value < 10_000:
         return f"{value / 1_000:.1f}k"
     return f"{value // 1_000}k"
+
+
+def _as_token_count(value: object) -> int | None:
+    if isinstance(value, int) and not isinstance(value, bool):
+        return max(0, value)
+    return None
 
 
 def _codex_error_dict_message(error: dict[str, object]) -> str | None:
@@ -538,20 +552,32 @@ class CodexProvider:
                 or event.get("output_tokens")
             )
             session_log.emit(
-                "subagent_message",
+                SESSION_EVENT_SUBAGENT_MESSAGE,
                 {
                     "provider": self.name,
-                    "token_count": token_count,
+                    SESSION_DATA_TOKEN_COUNT: _as_token_count(token_count),
                     "text": item.get("text", ""),
                 },
             )
+            return
+
+        if kind == "turn.completed":
+            usage = event.get("usage") or {}
+            if isinstance(usage, dict):
+                session_log.emit(
+                    SESSION_EVENT_USAGE,
+                    {
+                        "provider": self.name,
+                        SESSION_DATA_USAGE: usage,
+                    },
+                )
             return
 
         if item_type and (
             "tool" in str(item_type) or str(item_type) in {"function_call", "tool_use"}
         ):
             session_log.emit(
-                "tool_call",
+                SESSION_EVENT_TOOL_CALL,
                 {
                     "provider": self.name,
                     "item_type": item_type,
@@ -592,6 +618,7 @@ class CodexProvider:
             end_offset -= len(incomplete)
 
         tool_calls = 0
+        subagent_messages = 0
         tokens_received = 0
         for line in lines:
             try:
@@ -599,18 +626,32 @@ class CodexProvider:
             except json.JSONDecodeError:
                 continue
 
-            if event.get("event") == "tool_call":
+            event_name = event.get("event")
+            data = event.get("data") or {}
+            if not isinstance(data, dict):
+                data = {}
+            if event_name == SESSION_EVENT_TOOL_CALL:
                 tool_calls += 1
                 continue
 
-            if event.get("event") != "subagent_message":
+            if event_name == SESSION_EVENT_SUBAGENT_MESSAGE:
+                subagent_messages += 1
+                token_count = _as_token_count(data.get(SESSION_DATA_TOKEN_COUNT))
+                if token_count is not None:
+                    tokens_received += token_count
                 continue
 
-            token_count = (event.get("data") or {}).get("token_count")
-            if isinstance(token_count, int):
+            if event_name != SESSION_EVENT_USAGE:
+                continue
+
+            usage = data.get(SESSION_DATA_USAGE) or {}
+            if not isinstance(usage, dict):
+                continue
+            token_count = _as_token_count(usage.get(SESSION_USAGE_OUTPUT_TOKENS))
+            if token_count is not None:
                 tokens_received += token_count
 
-        if tool_calls == 0 and tokens_received == 0:
+        if tool_calls == 0 and subagent_messages == 0 and tokens_received == 0:
             return (
                 "[conductor] no output from codex for {silent_sec:.0f}s"
                 " · 0 tool calls, 0 tokens — possibly stalled",
@@ -618,9 +659,13 @@ class CodexProvider:
             )
 
         tool_label = "tool call" if tool_calls == 1 else "tool calls"
+        message_label = (
+            "subagent message" if subagent_messages == 1 else "subagent messages"
+        )
         return (
             "[conductor] no output from codex for {silent_sec:.0f}s"
             f" · {tool_calls} {tool_label}"
+            f" · {subagent_messages} {message_label}"
             f" · {_format_compact_count(tokens_received)} tokens received since last heartbeat",
             end_offset,
         )

--- a/src/conductor/session_log.py
+++ b/src/conductor/session_log.py
@@ -24,6 +24,14 @@ class SessionLogError(RuntimeError):
     """Raised when conductor cannot create or update a session log."""
 
 
+SESSION_EVENT_TOOL_CALL = "tool_call"
+SESSION_EVENT_SUBAGENT_MESSAGE = "subagent_message"
+SESSION_EVENT_USAGE = "usage"
+SESSION_DATA_TOKEN_COUNT = "token_count"
+SESSION_DATA_USAGE = "usage"
+SESSION_USAGE_OUTPUT_TOKENS = "output_tokens"
+
+
 def _iso8601_now() -> str:
     return datetime.now(UTC).isoformat()
 

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -34,7 +34,15 @@ from conductor.providers.interface import (
     ProviderStalledError,
     ProviderStartupStalledError,
 )
-from conductor.session_log import SessionLog
+from conductor.session_log import (
+    SESSION_DATA_TOKEN_COUNT,
+    SESSION_DATA_USAGE,
+    SESSION_EVENT_SUBAGENT_MESSAGE,
+    SESSION_EVENT_TOOL_CALL,
+    SESSION_EVENT_USAGE,
+    SESSION_USAGE_OUTPUT_TOKENS,
+    SessionLog,
+)
 
 
 def _strip_gemini_auth_env(monkeypatch) -> None:
@@ -1851,6 +1859,72 @@ def test_codex_exec_heartbeat_reports_subagent_tokens_from_session_log(
 
     err = capsys.readouterr().err
     assert "1.2k tokens received since last heartbeat" in err
+
+
+def test_codex_heartbeat_reader_matches_canonical_session_log_shape(tmp_path):
+    session_log = SessionLog(path=tmp_path / "heartbeat-canonical.ndjson")
+    session_log.emit(
+        SESSION_EVENT_TOOL_CALL,
+        {"provider": "codex", "item_type": "function_call", "name": "Read"},
+    )
+    session_log.emit(
+        SESSION_EVENT_SUBAGENT_MESSAGE,
+        {"provider": "codex", "text": "working"},
+    )
+    session_log.emit(
+        SESSION_EVENT_USAGE,
+        {
+            "provider": "codex",
+            SESSION_DATA_USAGE: {SESSION_USAGE_OUTPUT_TOKENS: 1200},
+        },
+    )
+
+    template, offset = CodexProvider()._read_session_log_progress(
+        session_log=session_log,
+        offset=0,
+    )
+
+    assert offset == session_log.log_path.stat().st_size
+    assert template is not None
+    assert "1 tool call" in template
+    assert "1 subagent message" in template
+    assert "1.2k tokens received since last heartbeat" in template
+
+
+def test_codex_stream_writer_emits_usage_shape_heartbeat_reader_counts(tmp_path):
+    session_log = SessionLog(path=tmp_path / "heartbeat-stream-usage.ndjson")
+    provider = CodexProvider()
+
+    provider._emit_stream_event(
+        (
+            '{"type":"item.completed","item":{"type":"agent_message",'
+            '"text":"working"}}\n'
+        ),
+        session_log=session_log,
+    )
+    provider._emit_stream_event(
+        '{"type":"turn.completed","usage":{"input_tokens":5,"output_tokens":1200}}\n',
+        session_log=session_log,
+    )
+
+    events = [
+        json.loads(line)
+        for line in session_log.log_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert events[0]["event"] == SESSION_EVENT_SUBAGENT_MESSAGE
+    assert events[0]["data"][SESSION_DATA_TOKEN_COUNT] is None
+    assert events[1]["event"] == SESSION_EVENT_USAGE
+    assert events[1]["data"][SESSION_DATA_USAGE][SESSION_USAGE_OUTPUT_TOKENS] == 1200
+
+    template, _offset = provider._read_session_log_progress(
+        session_log=session_log,
+        offset=0,
+    )
+
+    assert template is not None
+    assert "1 subagent message" in template
+    assert "1.2k tokens received since last heartbeat" in template
+    assert "0 tool calls, 0 tokens" not in template
 
 
 def test_codex_exec_heartbeat_marks_zero_progress_as_possibly_stalled(


### PR DESCRIPTION
## Summary

- Heartbeat reader and codex stream writer disagreed on which event/field carried token usage. `subagent_message` events without a top-level `token_count` looked like \"0 tool calls, 0 tokens\" to the reader even while codex was producing dozens of tool calls and thousands of output tokens.
- Introduces shared `SESSION_EVENT_*` / `SESSION_DATA_*` constants in `session_log.py` so writer and reader can't drift again.
- Writer now emits a canonical `usage` event from codex `turn.completed`. Reader counts tool calls, subagent messages, AND output tokens; only reports the \"possibly stalled\" line when all three are zero.

Closes #183.

## Test plan

- [x] `uv run pytest tests/` — 835 passed, 15 skipped
- [x] `uv run ruff check src/ tests/` — clean
- [x] New regression tests exercise canonical session-log shape and writer/reader agreement.