### PR TITLE
chore: sync merge-pr.sh from touchstone (worktree-aware) (#193)

### DIFF
--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -4,12 +4,14 @@
 #
 # Usage:
 #   bash scripts/merge-pr.sh <pr-number>
+#   bash scripts/merge-pr.sh <pr-number> --bypass-with-disclosure="<reason>"
 #
 # What this does:
 #   1. Verifies the PR is open and mergeable.
 #   2. Runs AI code review as a merge gate.
 #   3. Squash-merges and deletes the remote branch.
-#   4. Checks out the default branch and pulls the updated state.
+#   4. Checks out/syncs the default branch where the local topology permits.
+#   5. Deletes the verified-merged local feature branch when safe.
 #
 # Exit codes:
 #   0 — merged cleanly
@@ -18,13 +20,55 @@
 #
 set -euo pipefail
 
-PR_NUMBER="${1:-}"
+PR_NUMBER=""
+BYPASS_REASON=""
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REVIEW_SCRIPT="$SCRIPT_DIR/codex-review.sh"
 REVIEWED_HEAD_OID=""
+PR_HEAD_BRANCH=""
+BYPASS_REVIEW=false
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --bypass-with-disclosure=*)
+      BYPASS_REVIEW=true
+      BYPASS_REASON="${1#*=}"
+      shift
+      ;;
+    --bypass-with-disclosure)
+      echo "ERROR: --bypass-with-disclosure requires a non-empty reason." >&2
+      exit 2
+      ;;
+    --*)
+      echo "ERROR: Unknown option: $1" >&2
+      exit 2
+      ;;
+    *)
+      if [ -n "$PR_NUMBER" ]; then
+        echo "ERROR: Unexpected extra argument: $1" >&2
+        exit 2
+      fi
+      PR_NUMBER="$1"
+      shift
+      ;;
+  esac
+done
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+BYPASS_REASON="$(trim "$(printf '%s' "$BYPASS_REASON" | tr '\r\n\t' '   ')")"
 
 if [ -z "$PR_NUMBER" ] || ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
-  echo "Usage: bash scripts/merge-pr.sh <pr-number>" >&2
+  echo "Usage: bash scripts/merge-pr.sh <pr-number> [--bypass-with-disclosure=\"<reason>\"]" >&2
+  exit 2
+fi
+if [ "$BYPASS_REVIEW" = true ] && [ -z "$BYPASS_REASON" ]; then
+  echo "ERROR: --bypass-with-disclosure requires a non-empty reason." >&2
   exit 2
 fi
 
@@ -41,6 +85,210 @@ truthy() {
     true|1|yes|on) return 0 ;;
     *) return 1 ;;
   esac
+}
+
+review_clean_marker_key() {
+  local branch="$1"
+  printf '%s' "$branch" | sed 's/[^A-Za-z0-9._-]/_/g'
+}
+
+review_clean_marker_file() {
+  local branch="$1"
+  printf '%s/%s.clean' \
+    "$(git rev-parse --git-path touchstone/reviewer-clean)" \
+    "$(review_clean_marker_key "$branch")"
+}
+
+marker_field() {
+  local field="$1"
+  local marker="$2"
+  awk -F= -v key="$field" '$1 == key { sub(/^[^=]*=/, ""); print; exit }' "$marker"
+}
+
+worktree_path_for_branch() {
+  local branch="$1"
+  local current_path=""
+  local current_branch=""
+  local line key value
+
+  git worktree list --porcelain | while IFS= read -r line || [ -n "$line" ]; do
+    if [ -z "$line" ]; then
+      if [ "$current_branch" = "refs/heads/$branch" ]; then
+        printf '%s\n' "$current_path"
+        exit 0
+      fi
+      current_path=""
+      current_branch=""
+      continue
+    fi
+
+    key="${line%% *}"
+    value="${line#* }"
+    case "$key" in
+      worktree) current_path="$value" ;;
+      branch) current_branch="$value" ;;
+    esac
+  done
+
+  if [ "$current_branch" = "refs/heads/$branch" ]; then
+    printf '%s\n' "$current_path"
+  fi
+  return 0
+}
+
+branch_has_clean_review_marker() {
+  local branch="$1"
+  local head_oid="$2"
+  local merge_base="$3"
+  local marker marker_branch marker_head marker_merge_base
+  marker="$(review_clean_marker_file "$branch")"
+  [ -f "$marker" ] || return 1
+  grep -q '^result=CODEX_REVIEW_CLEAN$' "$marker" || return 1
+  marker_branch="$(marker_field branch "$marker")"
+  marker_head="$(marker_field head "$marker")"
+  marker_merge_base="$(marker_field merge_base "$marker")"
+  [ "$marker_branch" = "$branch" ] \
+    && [ "$marker_head" = "$head_oid" ] \
+    && [ "$marker_merge_base" = "$merge_base" ]
+}
+
+sync_default_branch_after_merge() {
+  local current_branch current_worktree default_worktree
+
+  echo "==> Merged. Updating local $DEFAULT_BRANCH ..."
+  current_branch="$(git rev-parse --abbrev-ref HEAD)"
+
+  if [ "$current_branch" = "$DEFAULT_BRANCH" ]; then
+    if ! git pull --rebase; then
+      echo "WARNING: PR #$PR_NUMBER merged remotely, but local $DEFAULT_BRANCH could not pull --rebase." >&2
+      echo "WARNING: Run this when convenient: git pull --rebase" >&2
+    fi
+    return 0
+  fi
+
+  current_worktree="$(git rev-parse --show-toplevel)"
+  default_worktree="$(worktree_path_for_branch "$DEFAULT_BRANCH" | head -n 1)"
+  if [ -n "$default_worktree" ] && [ "$default_worktree" != "$current_worktree" ]; then
+    if [ ! -d "$default_worktree" ]; then
+      echo "WARNING: $DEFAULT_BRANCH is recorded as checked out in a missing worktree: $default_worktree" >&2
+      echo "WARNING: This is stale git worktree metadata, usually from deleting the directory directly." >&2
+      echo "WARNING: Run 'git worktree prune' from a remaining checkout, then rerun local sync if needed." >&2
+      return 0
+    fi
+    echo "==> $DEFAULT_BRANCH is checked out in sibling worktree: $default_worktree"
+    echo "==> Fast-forwarding that worktree after remote merge ..."
+    if git -C "$default_worktree" pull --ff-only; then
+      return 0
+    fi
+    echo "WARNING: PR #$PR_NUMBER merged remotely, but sibling worktree '$default_worktree' could not fast-forward." >&2
+    echo "WARNING: Run this when convenient: git -C '$default_worktree' pull --ff-only" >&2
+    return 0
+  fi
+
+  if ! git checkout "$DEFAULT_BRANCH"; then
+    echo "WARNING: PR #$PR_NUMBER merged remotely, but this worktree could not check out $DEFAULT_BRANCH." >&2
+    echo "WARNING: Run this when convenient: git checkout '$DEFAULT_BRANCH' && git pull --rebase" >&2
+    return 0
+  fi
+  if ! git pull --rebase; then
+    echo "WARNING: PR #$PR_NUMBER merged remotely, but local $DEFAULT_BRANCH could not pull --rebase." >&2
+    echo "WARNING: Run this when convenient: git pull --rebase" >&2
+  fi
+}
+
+checkout_default_ref_for_cleanup() {
+  local branch="$1"
+  local reviewed_head="$2"
+  local current_branch current_head current_worktree default_worktree
+
+  current_branch="$(git rev-parse --abbrev-ref HEAD)"
+  current_head="$(git rev-parse HEAD 2>/dev/null || echo "")"
+  if [ "$current_branch" != "$branch" ]; then
+    if [ "$current_branch" != "HEAD" ] || [ "$current_head" != "$reviewed_head" ]; then
+      return 0
+    fi
+  fi
+
+  current_worktree="$(git rev-parse --show-toplevel)"
+  default_worktree="$(worktree_path_for_branch "$DEFAULT_BRANCH" | head -n 1)"
+  if [ -n "$default_worktree" ] && [ "$default_worktree" != "$current_worktree" ]; then
+    echo "==> $DEFAULT_BRANCH is checked out elsewhere; detaching this worktree at $DEFAULT_BRANCH before local branch cleanup ..."
+    if git checkout --detach "$DEFAULT_BRANCH"; then
+      return 0
+    fi
+    echo "WARNING: Could not detach this worktree at $DEFAULT_BRANCH; leaving local branch '$branch' intact." >&2
+    return 1
+  fi
+
+  if git checkout "$DEFAULT_BRANCH"; then
+    return 0
+  fi
+  if git checkout --detach "$DEFAULT_BRANCH"; then
+    echo "==> Detached this worktree at $DEFAULT_BRANCH before local branch cleanup."
+    return 0
+  fi
+  echo "WARNING: Could not move off local branch '$branch'; leaving it intact." >&2
+  return 1
+}
+
+cleanup_local_pr_branch_after_merge() {
+  local branch="$PR_HEAD_BRANCH"
+  local reviewed_head="$REVIEWED_HEAD_OID"
+  local local_head pr_state
+
+  if [ -z "$branch" ] || [ -z "$reviewed_head" ]; then
+    echo "WARNING: Missing reviewed PR head metadata; skipping local branch cleanup." >&2
+    return 0
+  fi
+  if [ "$branch" = "$DEFAULT_BRANCH" ] || [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+    echo "WARNING: Refusing to delete protected branch '$branch' after PR #$PR_NUMBER." >&2
+    return 0
+  fi
+  if ! git show-ref --verify --quiet "refs/heads/$branch"; then
+    echo "==> Local branch '$branch' is already absent."
+    return 0
+  fi
+  if ! local_head="$(git rev-parse "$branch" 2>/dev/null)"; then
+    echo "WARNING: Could not resolve local branch '$branch'; leaving it intact." >&2
+    return 0
+  fi
+  if [ "$local_head" != "$reviewed_head" ]; then
+    echo "WARNING: Local branch '$branch' is at $local_head, not reviewed PR head $reviewed_head; leaving it intact." >&2
+    return 0
+  fi
+  pr_state="$(gh pr view "$PR_NUMBER" --json state --jq '.state' 2>/dev/null || echo "")"
+  if [ "$pr_state" != "MERGED" ]; then
+    echo "WARNING: PR #$PR_NUMBER is not confirmed MERGED (state: ${pr_state:-unknown}); leaving local branch '$branch' intact." >&2
+    return 0
+  fi
+
+  if ! checkout_default_ref_for_cleanup "$branch" "$reviewed_head"; then
+    return 0
+  fi
+
+  echo "==> Deleting local branch '$branch' after verified squash merge of $reviewed_head ..."
+  if git branch -D "$branch"; then
+    echo "==> Local branch '$branch' deleted."
+  else
+    echo "WARNING: Could not delete local branch '$branch' after verified merge." >&2
+    echo "WARNING: Run this when convenient after moving off the branch: git branch -D '$branch'" >&2
+  fi
+}
+
+print_bypass_banner() {
+  cat <<EOF
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!! BYPASSING REVIEWER GATE
+!! reason: $BYPASS_REASON
+!! This bypass is recorded on the PR and squash commit.
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+EOF
+}
+
+record_bypass_comment() {
+  gh pr comment "$PR_NUMBER" --body "Reviewer bypassed via \`--bypass-with-disclosure\`. Reason: $BYPASS_REASON"
 }
 
 run_merge_review() {
@@ -63,7 +311,39 @@ run_merge_review() {
     exit 1
   fi
 
+  PR_HEAD_BRANCH="$pr_head_branch"
   REVIEWED_HEAD_OID="$pr_head_oid"
+  default_base_ref="origin/$DEFAULT_BRANCH"
+
+  if [ "$BYPASS_REVIEW" = true ]; then
+    echo "==> Refreshing $default_base_ref before reviewer bypass validation ..."
+    if ! git fetch origin "+refs/heads/$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH"; then
+      echo "ERROR: Failed to refresh $default_base_ref before reviewer bypass validation." >&2
+      exit 1
+    fi
+    if ! git rev-parse --verify --quiet "$default_base_ref^{commit}" >/dev/null; then
+      echo "ERROR: Could not verify $default_base_ref before reviewer bypass validation." >&2
+      exit 1
+    fi
+    if ! git cat-file -e "$pr_head_oid^{commit}" 2>/dev/null; then
+      echo "==> Checking out PR #$PR_NUMBER head ($pr_head_branch) for reviewer bypass validation ..."
+      gh pr checkout "$PR_NUMBER" --detach
+    fi
+    local current_merge_base
+    if ! current_merge_base="$(git merge-base "$default_base_ref" "$pr_head_oid" 2>/dev/null)"; then
+      echo "ERROR: Could not compute merge base for PR #$PR_NUMBER head against $default_base_ref." >&2
+      exit 1
+    fi
+    if ! branch_has_clean_review_marker "$pr_head_branch" "$pr_head_oid" "$current_merge_base"; then
+      echo "ERROR: Refusing reviewer bypass for PR #$PR_NUMBER." >&2
+      echo "       No prior clean review marker matches branch '$pr_head_branch' at head '$pr_head_oid' and merge base '$current_merge_base'." >&2
+      echo "       Run the reviewer cleanly once before using --bypass-with-disclosure." >&2
+      exit 1
+    fi
+    print_bypass_banner
+    record_bypass_comment
+    return 0
+  fi
 
   if truthy "${SKIP_REVIEW:-${SKIP_CODEX_REVIEW:-false}}"; then
     echo "==> Skipping merge review because SKIP_REVIEW is set."
@@ -75,7 +355,6 @@ run_merge_review() {
     return 0
   fi
 
-  default_base_ref="origin/$DEFAULT_BRANCH"
   echo "==> Refreshing $default_base_ref for merge review ..."
   if ! git fetch origin "+refs/heads/$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH"; then
     echo "ERROR: Failed to refresh $default_base_ref before merge review." >&2
@@ -108,6 +387,7 @@ run_merge_review() {
 
   echo "==> Running merge review ..."
   CODEX_REVIEW_BASE="$default_base_ref" \
+    CODEX_REVIEW_BRANCH_NAME="$pr_head_branch" \
     CODEX_REVIEW_FORCE=1 \
     CODEX_REVIEW_MODE=review-only \
     bash "$REVIEW_SCRIPT"
@@ -160,13 +440,64 @@ if [ -z "$REVIEWED_HEAD_OID" ]; then
   echo "ERROR: Cannot merge PR #$PR_NUMBER because no reviewed head commit was recorded." >&2
   exit 1
 fi
-gh pr merge "$PR_NUMBER" --squash --delete-branch --match-head-commit "$REVIEWED_HEAD_OID"
+gh_merge_exit=0
+if [ "$BYPASS_REVIEW" = true ]; then
+  gh pr merge "$PR_NUMBER" --squash --delete-branch --match-head-commit "$REVIEWED_HEAD_OID" \
+    --body "Reviewer-bypass: $BYPASS_REASON" || gh_merge_exit=$?
+else
+  gh pr merge "$PR_NUMBER" --squash --delete-branch --match-head-commit "$REVIEWED_HEAD_OID" \
+    || gh_merge_exit=$?
+fi
+
+# `gh pr merge --delete-branch` does the squash AND tries to delete the
+# local feature branch. The local-delete fails when the branch is checked
+# out in the current worktree (the common case for parallel-worktree work).
+# When that happens, the remote merge succeeded server-side — only the
+# local cleanup didn't. Verify by asking the API; if MERGED, treat as
+# success with a warning so the script doesn't claim the PR failed.
+if [ "$gh_merge_exit" -ne 0 ]; then
+  pr_state="$(gh pr view "$PR_NUMBER" --json state --jq '.state' 2>/dev/null || echo "")"
+  if [ "$pr_state" = "MERGED" ]; then
+    echo "WARNING: gh pr merge exited $gh_merge_exit, but PR #$PR_NUMBER is MERGED on GitHub."
+    echo "         Likely cause: local feature branch is checked out in a worktree,"
+    echo "         or stale worktree metadata still records it there. Remote branch is gone."
+    echo "         Use 'git worktree remove <path>' or 'bash scripts/cleanup-worktrees.sh --execute' for normal cleanup."
+    echo "         If the directory was deleted directly, run 'git worktree prune' from a remaining checkout."
+  else
+    echo "ERROR: gh pr merge exited $gh_merge_exit and PR #$PR_NUMBER is not MERGED." >&2
+    exit "$gh_merge_exit"
+  fi
+fi
 
 # 5. Sync local default branch.
-echo "==> Merged. Updating local $DEFAULT_BRANCH ..."
-CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-if [ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]; then
-  git checkout "$DEFAULT_BRANCH"
+sync_default_branch_after_merge
+
+# 6. Cortex post-merge hook (T1.9). Fires only when the project meets the
+# activation criteria documented in scripts/cortex-pr-merged-hook.sh.
+# Activation is the hook's job — we always invoke and let it self-gate.
+# The hook may produce a follow-up commit on the default branch; that
+# commit is created with --no-verify so it doesn't recurse through this
+# script's review gates. Failures inside the hook surface as visible
+# stderr; we don't fail the overall merge over a journal-write hiccup.
+CORTEX_HOOK_SCRIPT=""
+for candidate_hook in \
+  "$SCRIPT_DIR/cortex-pr-merged-hook.sh" \
+  "$(git rev-parse --show-toplevel 2>/dev/null)/scripts/cortex-pr-merged-hook.sh"; do
+  if [ -n "$candidate_hook" ] && [ -f "$candidate_hook" ]; then
+    CORTEX_HOOK_SCRIPT="$candidate_hook"
+    break
+  fi
+done
+
+if [ -n "$CORTEX_HOOK_SCRIPT" ]; then
+  hook_status=0
+  TOUCHSTONE_MERGED_PR="$PR_NUMBER" bash "$CORTEX_HOOK_SCRIPT" || hook_status=$?
+  if [ "$hook_status" -ne 0 ]; then
+    echo "WARNING: cortex-pr-merged-hook exited $hook_status (see above)." >&2
+    echo "         The PR merged cleanly; only the auto-draft journal step had a problem." >&2
+  fi
 fi
-git pull --rebase
+
+cleanup_local_pr_branch_after_merge
+
 echo "==> Done."

--- a/tests/test-merge-pr-worktree-handling.sh
+++ b/tests/test-merge-pr-worktree-handling.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MERGE_SCRIPT="$REPO_ROOT/scripts/merge-pr.sh"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/merge-pr-worktree.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+extract_function() {
+  local name="$1"
+  local source_file="$2"
+  local output_file="$3"
+
+  sed -n "/^${name}()/,/^}/p" "$source_file" > "$output_file"
+  if ! grep -q "^${name}()" "$output_file"; then
+    printf 'FAIL: could not extract %s from %s\n' "$name" "$source_file" >&2
+    exit 1
+  fi
+}
+
+TEST_REPO="$TMP_ROOT/repo"
+FEATURE_WORKTREE="$TMP_ROOT/feature-worktree"
+FUNCTIONS_FILE="$TMP_ROOT/functions.sh"
+
+git init -q -b main "$TEST_REPO"
+git -C "$TEST_REPO" config commit.gpgsign false
+git -C "$TEST_REPO" config user.name test
+git -C "$TEST_REPO" config user.email test@example.invalid
+printf 'base\n' > "$TEST_REPO/README"
+git -C "$TEST_REPO" add README
+git -C "$TEST_REPO" commit -q -m base
+git -C "$TEST_REPO" branch feature
+git -C "$TEST_REPO" worktree add -q "$FEATURE_WORKTREE" feature
+
+extract_function "worktree_path_for_branch" "$MERGE_SCRIPT" "$FUNCTIONS_FILE"
+# shellcheck source=/dev/null
+source "$FUNCTIONS_FILE"
+
+expected="$(git -C "$TEST_REPO" rev-parse --show-toplevel)"
+actual="$(cd "$FEATURE_WORKTREE" && worktree_path_for_branch main)"
+
+if [ "$actual" != "$expected" ]; then
+  printf 'FAIL: worktree_path_for_branch main returned wrong path\n' >&2
+  printf 'expected: %s\n' "$expected" >&2
+  printf 'actual:   %s\n' "$actual" >&2
+  exit 1
+fi
+
+printf 'ok\n'

--- a/tests/test_merge_pr_worktree_handling.py
+++ b/tests/test_merge_pr_worktree_handling.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(shutil.which("git") is None, reason="git not installed")
+
+
+def test_merge_pr_worktree_path_shell_regression() -> None:
+    repo = Path(__file__).resolve().parent.parent
+    test_script = repo / "tests" / "test-merge-pr-worktree-handling.sh"
+    subprocess.run(["bash", str(test_script)], cwd=repo, check=True)


### PR DESCRIPTION
## Summary

- Replaced `scripts/merge-pr.sh` with the upstream Touchstone copy, which already handles worktrees via `worktree_path_for_branch` (plus sibling/default worktree detection and a post-merge `git pull --rebase` fallback path).
- The conductor copy was an older shape that did `git checkout main` post-merge — which fails with `'main' is already used by worktree at '...'` whenever `open-pr.sh --auto-merge` is run from a worktree. Hit this 6× in the morning's batch.
- Confirmed the codex-review wiring is preserved: same `CODEX_REVIEW_BASE` / `CODEX_REVIEW_FORCE` / `CODEX_REVIEW_MODE` env names and `scripts/codex-review.sh` invocation.
- Adds a shell regression test (`tests/test-merge-pr-worktree-handling.sh`) and a pytest wrapper that exercises the worktree code path so the next drift is caught.

Closes #193.

## Test plan

- [x] `bash tests/test-merge-pr-worktree-handling.sh` passes
- [x] `bash scripts/merge-pr.sh` exits 2 with usage
- [x] `uv run pytest tests/` — 854 passed, 15 skipped
- [x] `uv run ruff check src/ tests/` clean
- [x] `shellcheck` via pre-commit clean