### PR TITLE
fix: worktree-aware venv lookup in pre-push validation (#192)

### DIFF
--- a/scripts/run-pytest-in-venv.sh
+++ b/scripts/run-pytest-in-venv.sh
@@ -7,11 +7,22 @@
 #
 set -euo pipefail
 
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-cd "$REPO_ROOT"
+if [ "${RUN_PYTEST_IN_VENV_SOURCE_ONLY:-0}" = "1" ]; then
+  REPO_ROOT="${RUN_PYTEST_IN_VENV_TEST_REPO_ROOT:-$(pwd)}"
+else
+  REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  cd "$REPO_ROOT"
+fi
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
 
 find_python() {
-  local candidate
+  local candidate cwd parent_root parent_python
 
   if [ -n "${PYTEST_PYTHON:-}" ]; then
     if command -v "$PYTEST_PYTHON" >/dev/null 2>&1; then
@@ -30,11 +41,76 @@ find_python() {
     fi
   done
 
-  echo "ERROR: no project virtualenv found for pytest." >&2
-  echo "       Expected .venv/bin/python or agent/.venv/bin/python." >&2
-  echo "       Run: bash setup.sh" >&2
+  cwd="$(pwd)"
+  if parent_root="$(find_worktree_parent_root "$cwd")"; then
+    parent_python="$parent_root/.venv/bin/python"
+    if [ -x "$parent_python" ]; then
+      printf '%s\n' "$parent_python"
+      return 0
+    fi
+  fi
+
+  echo "ERROR: no project virtualenv found." >&2
+  echo "       Tried: $cwd/.venv/bin/python (this checkout)" >&2
+  if [ -n "${parent_root:-}" ]; then
+    echo "       Tried: $parent_root/.venv/bin/python (worktree parent)" >&2
+  fi
+  echo "       Run \`bash setup.sh\` in this checkout, OR push from the" >&2
+  echo "       parent checkout that has the venv set up." >&2
   return 1
 }
+
+find_worktree_parent_root() {
+  local checkout_root="$1" git_file gitdir gitdir_path search_dir
+
+  git_file="$checkout_root/.git"
+  if [ ! -f "$git_file" ]; then
+    return 1
+  fi
+  if [ ! -r "$git_file" ]; then
+    echo "       Worktree check failed: cannot read $git_file" >&2
+    return 1
+  fi
+
+  IFS= read -r gitdir < "$git_file" || {
+    echo "       Worktree check failed: cannot read gitdir from $git_file" >&2
+    return 1
+  }
+  case "$gitdir" in
+    gitdir:*) gitdir="${gitdir#gitdir:}" ;;
+    *) return 1 ;;
+  esac
+  gitdir="$(trim "$gitdir")"
+  if [ -z "$gitdir" ]; then
+    echo "       Worktree check failed: empty gitdir in $git_file" >&2
+    return 1
+  fi
+
+  case "$gitdir" in
+    /*) gitdir_path="$gitdir" ;;
+    *) gitdir_path="$checkout_root/$gitdir" ;;
+  esac
+  if [ ! -d "$gitdir_path" ]; then
+    echo "       Worktree check failed: gitdir does not exist: $gitdir_path" >&2
+    return 1
+  fi
+
+  search_dir="$(cd "$(dirname "$gitdir_path")" && pwd)"
+  while [ "$search_dir" != "/" ]; do
+    if [ "$(basename "$search_dir")" = ".git" ]; then
+      dirname "$search_dir"
+      return 0
+    fi
+    search_dir="$(dirname "$search_dir")"
+  done
+
+  echo "       Worktree check failed: no parent .git directory above $gitdir_path" >&2
+  return 1
+}
+
+if [ "${RUN_PYTEST_IN_VENV_SOURCE_ONLY:-0}" = "1" ]; then
+  return 0
+fi
 
 PYTHON_BIN="$(find_python)"
 exec "$PYTHON_BIN" -m pytest "$@"

--- a/scripts/touchstone-run.sh
+++ b/scripts/touchstone-run.sh
@@ -14,8 +14,12 @@ set -euo pipefail
 
 ACTION="${1:-validate}"
 
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-cd "$REPO_ROOT"
+if [ "${TOUCHSTONE_RUN_SOURCE_ONLY:-0}" = "1" ]; then
+  REPO_ROOT="${TOUCHSTONE_RUN_TEST_REPO_ROOT:-$(pwd)}"
+else
+  REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  cd "$REPO_ROOT"
+fi
 
 CONFIG_FILE="${TOUCHSTONE_CONFIG_FILE:-.touchstone-config}"
 
@@ -194,7 +198,17 @@ run_node_script() {
 }
 
 find_python_bin() {
-  local candidate
+  local candidate cwd parent_root parent_python
+
+  if [ -n "${PYTEST_PYTHON:-}" ]; then
+    if command -v "$PYTEST_PYTHON" >/dev/null 2>&1; then
+      command -v "$PYTEST_PYTHON"
+      return 0
+    fi
+
+    echo "ERROR: PYTEST_PYTHON is set but not executable: $PYTEST_PYTHON" >&2
+    return 1
+  fi
 
   for candidate in ".venv/bin/python" "agent/.venv/bin/python"; do
     if [ -x "$candidate" ]; then
@@ -203,17 +217,76 @@ find_python_bin() {
     fi
   done
 
-  if command -v python3 >/dev/null 2>&1; then
-    command -v python3
-    return 0
-  fi
-  if command -v python >/dev/null 2>&1; then
-    command -v python
-    return 0
+  cwd="$(pwd)"
+  if parent_root="$(find_worktree_parent_root "$cwd")"; then
+    parent_python="$parent_root/.venv/bin/python"
+    if [ -x "$parent_python" ]; then
+      printf '%s\n' "$parent_python"
+      return 0
+    fi
   fi
 
+  echo "ERROR: no project virtualenv found." >&2
+  echo "       Tried: $cwd/.venv/bin/python (this checkout)" >&2
+  if [ -n "${parent_root:-}" ]; then
+    echo "       Tried: $parent_root/.venv/bin/python (worktree parent)" >&2
+  fi
+  echo "       Run \`bash setup.sh\` in this checkout, OR push from the" >&2
+  echo "       parent checkout that has the venv set up." >&2
   return 1
 }
+
+find_worktree_parent_root() {
+  local checkout_root="$1" git_file gitdir gitdir_path search_dir
+
+  git_file="$checkout_root/.git"
+  if [ ! -f "$git_file" ]; then
+    return 1
+  fi
+  if [ ! -r "$git_file" ]; then
+    echo "       Worktree check failed: cannot read $git_file" >&2
+    return 1
+  fi
+
+  IFS= read -r gitdir < "$git_file" || {
+    echo "       Worktree check failed: cannot read gitdir from $git_file" >&2
+    return 1
+  }
+  case "$gitdir" in
+    gitdir:*) gitdir="${gitdir#gitdir:}" ;;
+    *) return 1 ;;
+  esac
+  gitdir="$(trim "$gitdir")"
+  if [ -z "$gitdir" ]; then
+    echo "       Worktree check failed: empty gitdir in $git_file" >&2
+    return 1
+  fi
+
+  case "$gitdir" in
+    /*) gitdir_path="$gitdir" ;;
+    *) gitdir_path="$checkout_root/$gitdir" ;;
+  esac
+  if [ ! -d "$gitdir_path" ]; then
+    echo "       Worktree check failed: gitdir does not exist: $gitdir_path" >&2
+    return 1
+  fi
+
+  search_dir="$(cd "$(dirname "$gitdir_path")" && pwd)"
+  while [ "$search_dir" != "/" ]; do
+    if [ "$(basename "$search_dir")" = ".git" ]; then
+      dirname "$search_dir"
+      return 0
+    fi
+    search_dir="$(dirname "$search_dir")"
+  done
+
+  echo "       Worktree check failed: no parent .git directory above $gitdir_path" >&2
+  return 1
+}
+
+if [ "${TOUCHSTONE_RUN_SOURCE_ONLY:-0}" = "1" ]; then
+  return 0
+fi
 
 run_node_action() {
   local action="$1"
@@ -275,7 +348,7 @@ run_python_action() {
           return "$pytest_rc"
         fi
       else
-        ok "python not found; skipped"
+        return 1
       fi
       ;;
     build_if_distinct)

--- a/tests/test-find-python-bin.sh
+++ b/tests/test-find-python-bin.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TOUCHSTONE_SCRIPT="$REPO_ROOT/scripts/touchstone-run.sh"
+PYTEST_SCRIPT="$REPO_ROOT/scripts/run-pytest-in-venv.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+
+  if [ "$actual" != "$expected" ]; then
+    printf 'FAIL: %s\nexpected: [%s]\nactual:   [%s]\n' "$name" "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+assert_contains() {
+  local name="$1" haystack="$2" needle="$3"
+
+  case "$haystack" in
+    *"$needle"*) ;;
+    *) fail "$name missing [$needle] in [$haystack]" ;;
+  esac
+}
+
+setup_worktree_fixture() {
+  local root="$1" parent worktree
+
+  parent="$root/parent"
+  worktree="$root/foo"
+
+  mkdir -p "$parent/.git/worktrees/foo" "$parent/.venv/bin" "$worktree"
+  printf '#!/usr/bin/env bash\n' > "$parent/.venv/bin/python"
+  chmod +x "$parent/.venv/bin/python"
+  printf 'gitdir: %s\n' "$parent/.git/worktrees/foo" > "$worktree/.git"
+}
+
+run_touchstone_lookup() {
+  local worktree="$1"
+  (
+    cd "$worktree"
+    # shellcheck source=/dev/null
+    TOUCHSTONE_RUN_SOURCE_ONLY=1 source "$TOUCHSTONE_SCRIPT"
+    find_python_bin
+  )
+}
+
+run_pytest_lookup() {
+  local worktree="$1"
+  (
+    cd "$worktree"
+    # shellcheck source=/dev/null
+    RUN_PYTEST_IN_VENV_SOURCE_ONLY=1 source "$PYTEST_SCRIPT"
+    find_python
+  )
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+setup_worktree_fixture "$tmp/with-venv"
+expected="$tmp/with-venv/parent/.venv/bin/python"
+
+actual="$(run_touchstone_lookup "$tmp/with-venv/foo")"
+assert_eq "touchstone worktree parent venv" "$expected" "$actual"
+
+actual="$(run_pytest_lookup "$tmp/with-venv/foo")"
+assert_eq "pytest helper worktree parent venv" "$expected" "$actual"
+
+mkdir -p "$tmp/no-venv/parent/.git/worktrees/foo" "$tmp/no-venv/foo"
+printf 'gitdir: %s\n' "$tmp/no-venv/parent/.git/worktrees/foo" > "$tmp/no-venv/foo/.git"
+
+err_file="$tmp/touchstone.err"
+if run_touchstone_lookup "$tmp/no-venv/foo" > "$tmp/touchstone.out" 2> "$err_file"; then
+  fail "touchstone lookup should fail without any project venv"
+fi
+err="$(cat "$err_file")"
+assert_contains "touchstone error" "$err" "ERROR: no project virtualenv found."
+assert_contains "touchstone checkout tried" "$err" "Tried: $tmp/no-venv/foo/.venv/bin/python (this checkout)"
+assert_contains "touchstone parent tried" "$err" "Tried: $tmp/no-venv/parent/.venv/bin/python (worktree parent)"
+
+err_file="$tmp/pytest.err"
+if run_pytest_lookup "$tmp/no-venv/foo" > "$tmp/pytest.out" 2> "$err_file"; then
+  fail "pytest helper lookup should fail without any project venv"
+fi
+err="$(cat "$err_file")"
+assert_contains "pytest error" "$err" "ERROR: no project virtualenv found."
+assert_contains "pytest checkout tried" "$err" "Tried: $tmp/no-venv/foo/.venv/bin/python (this checkout)"
+assert_contains "pytest parent tried" "$err" "Tried: $tmp/no-venv/parent/.venv/bin/python (worktree parent)"
+
+printf 'ok\n'


### PR DESCRIPTION
## Summary

`scripts/touchstone-run.sh` and `scripts/run-pytest-in-venv.sh` now look up the project Python correctly from inside a git worktree:

1. **`PYTEST_PYTHON` honored first** (explicit override).
2. **`<cwd>/.venv/bin/python`** still wins for the parent-checkout case (no behavior change).
3. **Worktree fallback** — if `<cwd>/.git` is a file pointer (worktree marker), parse it, walk to the parent repo's worktree root, and use that checkout's `.venv/bin/python`. The pinned deps are identical across worktrees, so this is correct.
4. **No silent system-Python fallback.** When no venv is found, the script errors with a message listing what was tried and how to fix it (`bash setup.sh`, or push from the parent checkout). Beats 31 pytest collection errors.

Adds `tests/test-find-python-bin.sh` exercising parent-checkout, worktree, and not-found paths.

The script is byte-shared with upstream touchstone (vendored). This patch intentionally diverges; commit body notes the divergence so a future re-vendor doesn't clobber it. Will file the same change against touchstone.

Closes #192.

## Test plan

- [x] `bash tests/test-find-python-bin.sh` passes
- [x] `uv run pytest tests/` — 853 passed, 15 skipped
- [x] `uv run ruff check src/ tests/` clean
- [x] Manual: `bash scripts/touchstone-run.sh validate` from a fresh worktree resolves the parent's `.venv/bin/python`