### PR TITLE
feat: scale dispatch timeouts on slow networks (#147)

### DIFF
--- a/docs/consumers.md
+++ b/docs/consumers.md
@@ -118,6 +118,8 @@ The canonical reference is `conductor call --help`. The contract-level commitmen
 | `--tags <csv>` | string | stable | For `--auto` routing |
 | `--prefer <mode>` | string | stable | One of: best, cheapest, fastest, balanced. Default: balanced |
 | `--effort <level>` | string \| int | stable | One of: minimal, low, medium, high, max. Or integer token budget. Default: medium |
+| `--timeout <sec>` | int | stable | Wall-clock timeout. Default: 1800, scaled up on slow networks unless explicitly set |
+| `--max-stall-seconds <sec>` | int | stable | Streaming CLI stall watchdog. Default: 600, scaled up on slow networks unless explicitly set. `0` disables |
 | `--exclude <csv>` | string | stable | Providers to skip in `--auto` |
 | `--brief <text>` | string | stable | Inline delegation brief / prompt |
 | `--brief-file <path>` | string | stable | File path, `-` for stdin |

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -19,14 +19,17 @@ v0.2 additions:
 from __future__ import annotations
 
 import json
+import math
 import os
 import subprocess
 import sys
 import time
 from dataclasses import asdict, dataclass, replace
 from pathlib import Path
+from urllib.parse import urlparse
 
 import click
+from click.core import ParameterSource
 
 import conductor.providers.openrouter_catalog as openrouter_catalog
 from conductor import __version__, credentials, offline_mode
@@ -37,6 +40,13 @@ from conductor.muted_providers import (
     mute_provider_ids,
     muted_providers_file_path,
     unmute_provider_ids,
+)
+from conductor.network_profile import (
+    NETWORK_PROFILE_FALLBACK_TARGET,
+    NetworkProfile,
+    apply_scaling,
+    get_network_profile,
+    scaling_multiplier,
 )
 from conductor.openrouter_stack_audit import (
     StackAuditReport,
@@ -116,7 +126,8 @@ VALID_EFFORT_LEVELS = ("minimal", "low", "medium", "high", "max")
 PROFILE_PRECEDENCE_TEXT = (
     "Resolution order: profile defaults < CONDUCTOR_* env vars < explicit CLI flags."
 )
-DEFAULT_EXEC_MAX_STALL_SEC = 360
+DEFAULT_DISPATCH_TIMEOUT_SEC = 1800
+DEFAULT_EXEC_MAX_STALL_SEC = 600
 MIN_EXEC_BRIEF_CHARS = 300
 GIT_RECOVERY_COMMAND_TIMEOUT_SEC = 2.0
 GIT_RECOVERY_MAX_COMMITS = 5
@@ -128,6 +139,17 @@ DEFAULT_COUNCIL_TIMEOUT_SEC = 180
 DEFAULT_COUNCIL_MAX_OUTPUT_TOKENS = 6_000
 DEFAULT_COUNCIL_MAX_COST_USD = 0.25
 ESTIMATED_CHARS_PER_TOKEN = 4
+PROVIDER_NETWORK_TARGETS: dict[str, str] = {
+    # TODO(#147 follow-up): move these into provider-owned helpers once the
+    # endpoint contract settles; keep the Provider Protocol narrow for now.
+    "claude": "https://api.anthropic.com",
+    "codex": "https://api.openai.com",
+    "deepseek-chat": "https://openrouter.ai/api/v1/models",
+    "deepseek-reasoner": "https://openrouter.ai/api/v1/models",
+    "gemini": "https://generativelanguage.googleapis.com",
+    "kimi": "https://openrouter.ai/api/v1/models",
+    "openrouter": "https://openrouter.ai/api/v1/models",
+}
 
 
 @dataclass(frozen=True)
@@ -147,6 +169,72 @@ class CouncilCaps:
 # --------------------------------------------------------------------------- #
 # Shared helpers
 # --------------------------------------------------------------------------- #
+
+
+def _parameter_is_default(name: str) -> bool:
+    ctx = click.get_current_context(silent=True)
+    if ctx is None:
+        return True
+    return ctx.get_parameter_source(name) == ParameterSource.DEFAULT
+
+
+def _network_target_for_provider(provider_id: str | None) -> str | None:
+    if provider_id == "ollama":
+        return os.environ.get("OLLAMA_BASE_URL") or "http://localhost:11434"
+    if provider_id is None:
+        return NETWORK_PROFILE_FALLBACK_TARGET
+    return PROVIDER_NETWORK_TARGETS.get(provider_id)
+
+
+def _network_profile_warning(message: str) -> None:
+    click.echo(message, err=True)
+
+
+def _target_label(target: str) -> str:
+    parsed = urlparse(target)
+    return parsed.netloc or parsed.path or target
+
+
+def _emit_network_scaling_notice(profile: NetworkProfile) -> None:
+    multiplier = scaling_multiplier(profile)
+    if multiplier == 1 or profile.rtt_ms is None:
+        return
+    click.echo(
+        "[conductor] network: "
+        f"{profile.rtt_ms:.0f}ms RTT to {_target_label(profile.target)} "
+        f"→ timeouts scaled {multiplier}× (override with --timeout)",
+        err=True,
+    )
+
+
+def _scale_dispatch_defaults(
+    *,
+    provider_id: str | None,
+    timeout_sec: int | None,
+    max_stall_sec: int | None,
+    timeout_is_default: bool,
+    max_stall_is_default: bool,
+) -> tuple[int | None, int | None]:
+    if not (timeout_is_default or max_stall_is_default):
+        return timeout_sec, max_stall_sec
+
+    profile = get_network_profile(
+        _network_target_for_provider(provider_id),
+        warn=_network_profile_warning,
+    )
+    _emit_network_scaling_notice(profile)
+
+    resolved_timeout: int | None = timeout_sec
+    if timeout_is_default:
+        scaled_timeout = apply_scaling(DEFAULT_DISPATCH_TIMEOUT_SEC, profile)
+        resolved_timeout = None if scaled_timeout is None else math.ceil(scaled_timeout)
+
+    resolved_max_stall: int | None = max_stall_sec
+    if max_stall_is_default:
+        scaled_stall = apply_scaling(DEFAULT_EXEC_MAX_STALL_SEC, profile)
+        resolved_max_stall = None if scaled_stall is None else math.ceil(scaled_stall)
+
+    return resolved_timeout, resolved_max_stall
 
 
 def _read_task(
@@ -1080,6 +1168,8 @@ def _invoke_with_fallback(
                         task_tags=list(decision.task_tags),
                         prefer=decision.prefer,
                         log_selection=not silent,
+                        timeout_sec=timeout_sec,
+                        max_stall_sec=max_stall_sec,
                         resume_session_id=resume_session_id,
                     )
                 elif isinstance(provider, CodexProvider):
@@ -1087,6 +1177,8 @@ def _invoke_with_fallback(
                         task,
                         model=model,
                         effort=effort,
+                        timeout_sec=timeout_sec,
+                        max_stall_sec=max_stall_sec,
                         resume_session_id=resume_session_id,
                         attachments=attachments,
                     )
@@ -1096,6 +1188,8 @@ def _invoke_with_fallback(
                         task,
                         model=model,
                         effort=effort,
+                        timeout_sec=timeout_sec,
+                        max_stall_sec=max_stall_sec,
                         resume_session_id=resume_session_id,
                     )
             mark_outcome(candidate.name, "success")
@@ -2434,9 +2528,13 @@ def main(ctx: click.Context) -> None:
 @click.option(
     "--timeout",
     "timeout_sec",
-    default=None,
+    default=DEFAULT_DISPATCH_TIMEOUT_SEC,
     type=int,
-    help="Wall-clock timeout in seconds for review/exec/council provider calls.",
+    help=(
+        "Wall-clock timeout in seconds for review/exec provider calls. "
+        "Default: 1800, scaled up on slow networks. Council uses "
+        "--council-timeout for its total cap."
+    ),
 )
 @click.option(
     "--max-stall-seconds",
@@ -2553,9 +2651,10 @@ def ask(
     allow_short_brief: bool,
 ) -> None:
     """Run a task through Conductor's deterministic semantic routing matrix."""
+    timeout_is_default = _parameter_is_default("timeout_sec")
+    max_stall_is_default = _parameter_is_default("max_stall_sec")
     effort_value = _parse_effort(effort)
     plan = plan_for(kind, effort_value)
-    max_stall_sec = _normalize_max_stall_sec(max_stall_sec)
     council_caps = CouncilCaps(
         timeout_sec=council_timeout_sec,
         max_output_tokens=council_max_output_tokens,
@@ -2656,6 +2755,14 @@ def ask(
             sys.exit(2)
         print_caller_banner(decision.provider, silent=silent_route or as_json)
         _emit_route_log(decision, verbose=verbose_route, silent=silent_route or as_json)
+        timeout_sec, max_stall_sec = _scale_dispatch_defaults(
+            provider_id=decision.provider,
+            timeout_sec=timeout_sec,
+            max_stall_sec=max_stall_sec,
+            timeout_is_default=timeout_is_default,
+            max_stall_is_default=max_stall_is_default,
+        )
+        max_stall_sec = _normalize_max_stall_sec(max_stall_sec)
         try:
             response, _fallbacks = _invoke_review_with_fallback(
                 decision,
@@ -2704,6 +2811,15 @@ def ask(
     except (NoConfiguredProvider, InvalidRouterRequest, MutedProvidersError) as e:
         click.echo(f"conductor: {e}", err=True)
         sys.exit(2)
+
+    timeout_sec, max_stall_sec = _scale_dispatch_defaults(
+        provider_id=decision.provider,
+        timeout_sec=timeout_sec,
+        max_stall_sec=max_stall_sec,
+        timeout_is_default=timeout_is_default,
+        max_stall_is_default=max_stall_is_default,
+    )
+    max_stall_sec = _normalize_max_stall_sec(max_stall_sec)
 
     session_log: SessionLog | None = None
     if plan.mode == "exec":
@@ -2827,6 +2943,26 @@ def ask(
     "(default: medium).",
 )
 @click.option(
+    "--timeout",
+    "timeout_sec",
+    default=DEFAULT_DISPATCH_TIMEOUT_SEC,
+    type=int,
+    help=(
+        "Wall-clock timeout in seconds. Default: 1800, scaled up on slow "
+        "networks."
+    ),
+)
+@click.option(
+    "--max-stall-seconds",
+    "max_stall_sec",
+    default=DEFAULT_EXEC_MAX_STALL_SEC,
+    type=int,
+    help=(
+        "Kill streaming CLI-backed calls after this many silent seconds. "
+        "Default: 600, scaled up on slow networks. Set 0 to disable."
+    ),
+)
+@click.option(
     "--exclude",
     default=None,
     help="Comma-separated providers to exclude from --auto routing.",
@@ -2909,6 +3045,8 @@ def call(
     tags: str | None,
     prefer: str | None,
     effort: str | None,
+    timeout_sec: int | None,
+    max_stall_sec: int | None,
     exclude: str | None,
     task: str | None,
     task_file: str | None,
@@ -2923,6 +3061,8 @@ def call(
     offline: bool | None,
 ) -> None:
     """Send a task to a provider and print the response."""
+    timeout_is_default = _parameter_is_default("timeout_sec")
+    max_stall_is_default = _parameter_is_default("max_stall_sec")
     explicit_prefer = prefer
     profile_spec = _load_named_profile(profile)
     provider_id = _resolve_layered_value(provider_id, env_key="CONDUCTOR_WITH")
@@ -2989,6 +3129,14 @@ def call(
             sys.exit(2)
         print_caller_banner(decision.provider, silent=silent_route or as_json)
         _emit_route_log(decision, verbose=verbose_route, silent=silent_route or as_json)
+        timeout_sec, max_stall_sec = _scale_dispatch_defaults(
+            provider_id=decision.provider,
+            timeout_sec=timeout_sec,
+            max_stall_sec=max_stall_sec,
+            timeout_is_default=timeout_is_default,
+            max_stall_is_default=max_stall_is_default,
+        )
+        max_stall_sec = _normalize_max_stall_sec(max_stall_sec)
 
         try:
             response, _fallbacks = _invoke_with_fallback(
@@ -3000,8 +3148,8 @@ def call(
                 tools=frozenset(),
                 sandbox="none",
                 cwd=None,
-                timeout_sec=None,
-                max_stall_sec=None,
+                timeout_sec=timeout_sec,
+                max_stall_sec=max_stall_sec,
                 start_timeout_sec=None,
                 silent=silent_route or as_json,
                 attachments=attachments,
@@ -3028,6 +3176,14 @@ def call(
             click.echo(f"conductor: {e}", err=True)
             sys.exit(2)
         print_caller_banner(provider_id, silent=silent_route or as_json)
+        timeout_sec, max_stall_sec = _scale_dispatch_defaults(
+            provider_id=provider_id,
+            timeout_sec=timeout_sec,
+            max_stall_sec=max_stall_sec,
+            timeout_is_default=timeout_is_default,
+            max_stall_is_default=max_stall_is_default,
+        )
+        max_stall_sec = _normalize_max_stall_sec(max_stall_sec)
         try:
             if isinstance(provider, OpenRouterProvider):
                 response = provider.call(
@@ -3037,6 +3193,8 @@ def call(
                     task_tags=_parse_csv(tags),
                     prefer=_validate_prefer(prefer),
                     log_selection=not (silent_route or as_json),
+                    timeout_sec=timeout_sec,
+                    max_stall_sec=max_stall_sec,
                     resume_session_id=resume_session_id,
                 )
             elif isinstance(provider, CodexProvider):
@@ -3044,6 +3202,8 @@ def call(
                     body,
                     model=model,
                     effort=effort_value,
+                    timeout_sec=timeout_sec,
+                    max_stall_sec=max_stall_sec,
                     resume_session_id=resume_session_id,
                     attachments=attachments,
                 )
@@ -3052,6 +3212,8 @@ def call(
                     body,
                     model=model,
                     effort=effort_value,
+                    timeout_sec=timeout_sec,
+                    max_stall_sec=max_stall_sec,
                     resume_session_id=resume_session_id,
                 )
         except ProviderConfigError as e:
@@ -3123,9 +3285,12 @@ def call(
 @click.option(
     "--timeout",
     "timeout_sec",
-    default=None,
+    default=DEFAULT_DISPATCH_TIMEOUT_SEC,
     type=int,
-    help="Wall-clock timeout in seconds for the native review command.",
+    help=(
+        "Wall-clock timeout in seconds for the native review command. "
+        "Default: 1800, scaled up on slow networks."
+    ),
 )
 @click.option(
     "--max-stall-seconds",
@@ -3231,6 +3396,8 @@ def review(
     silent_route: bool,
 ) -> None:
     """Run a read-only code review through a provider's native review mode."""
+    timeout_is_default = _parameter_is_default("timeout_sec")
+    max_stall_is_default = _parameter_is_default("max_stall_sec")
     profile_spec = _load_named_profile(profile)
     provider_id = _resolve_layered_value(provider_id, env_key="CONDUCTOR_WITH")
     tags = _resolve_layered_value(
@@ -3277,7 +3444,6 @@ def review(
         uncommitted=uncommitted,
         cwd=cwd,
     )
-    max_stall_sec = _normalize_max_stall_sec(max_stall_sec)
     max_fallbacks = _validate_max_fallbacks(max_fallbacks)
     prefer_value = _validate_prefer(prefer) if prefer is not None else "best"
 
@@ -3300,6 +3466,14 @@ def review(
             sys.exit(2)
         print_caller_banner(decision.provider, silent=silent_route or as_json)
         _emit_route_log(decision, verbose=verbose_route, silent=silent_route or as_json)
+        timeout_sec, max_stall_sec = _scale_dispatch_defaults(
+            provider_id=decision.provider,
+            timeout_sec=timeout_sec,
+            max_stall_sec=max_stall_sec,
+            timeout_is_default=timeout_is_default,
+            max_stall_is_default=max_stall_is_default,
+        )
+        max_stall_sec = _normalize_max_stall_sec(max_stall_sec)
         try:
             response, _fallbacks = _invoke_review_with_fallback(
                 decision,
@@ -3337,6 +3511,14 @@ def review(
         if not ok:
             click.echo(f"conductor: {reason or 'native review is not configured'}", err=True)
             sys.exit(2)
+        timeout_sec, max_stall_sec = _scale_dispatch_defaults(
+            provider_id=provider_id,
+            timeout_sec=timeout_sec,
+            max_stall_sec=max_stall_sec,
+            timeout_is_default=timeout_is_default,
+            max_stall_is_default=max_stall_is_default,
+        )
+        max_stall_sec = _normalize_max_stall_sec(max_stall_sec)
         try:
             response = review_provider.review(
                 body,
@@ -3430,12 +3612,12 @@ def review(
 @click.option(
     "--timeout",
     "timeout_sec",
-    default=None,
+    default=DEFAULT_DISPATCH_TIMEOUT_SEC,
     type=int,
     help=(
-        "Wall-clock timeout in seconds. Default: no timeout — agent sessions "
-        "can run as long as they need. Set explicitly (e.g. --timeout 600) "
-        "for CI or unattended runs that must bound runtime."
+        "Wall-clock timeout in seconds. Default: 1800, scaled up on slow "
+        "networks. Set explicitly (e.g. --timeout 600) for CI or unattended "
+        "runs that need a fixed bound."
     ),
 )
 @click.option(
@@ -3571,6 +3753,8 @@ def exec_cmd(
     allow_short_brief: bool,
 ) -> None:
     """Run a task as an agent session with tool access (exec mode)."""
+    timeout_is_default = _parameter_is_default("timeout_sec")
+    max_stall_is_default = _parameter_is_default("max_stall_sec")
     profile_spec = _load_named_profile(profile)
     provider_id = _resolve_layered_value(provider_id, env_key="CONDUCTOR_WITH")
     tags = _resolve_layered_value(
@@ -3631,7 +3815,6 @@ def exec_cmd(
     )
     sandbox_value = _validate_sandbox(sandbox, warn=sandbox is not None)
     effort_value = _parse_effort(effort)
-    max_stall_sec = _normalize_max_stall_sec(max_stall_sec)
     start_timeout_sec = _normalize_start_timeout_sec(start_timeout_sec)
 
     decision: RouteDecision | None = None
@@ -3668,6 +3851,14 @@ def exec_cmd(
         _emit_session_route_decision(session_log, decision)
         print_caller_banner(decision.provider, silent=silent_route or as_json)
         _emit_route_log(decision, verbose=verbose_route, silent=silent_route or as_json)
+        timeout_sec, max_stall_sec = _scale_dispatch_defaults(
+            provider_id=decision.provider,
+            timeout_sec=timeout_sec,
+            max_stall_sec=max_stall_sec,
+            timeout_is_default=timeout_is_default,
+            max_stall_is_default=max_stall_is_default,
+        )
+        max_stall_sec = _normalize_max_stall_sec(max_stall_sec)
         if preflight:
             # `provider` may arrive as a Provider object (real `pick()` return)
             # or as a string (test fixtures, and any caller passing the name).
@@ -3748,6 +3939,14 @@ def exec_cmd(
         )
         session_log.bind_provider(provider_id)
         print_caller_banner(provider_id, silent=silent_route or as_json)
+        timeout_sec, max_stall_sec = _scale_dispatch_defaults(
+            provider_id=provider_id,
+            timeout_sec=timeout_sec,
+            max_stall_sec=max_stall_sec,
+            timeout_is_default=timeout_is_default,
+            max_stall_is_default=max_stall_is_default,
+        )
+        max_stall_sec = _normalize_max_stall_sec(max_stall_sec)
         if preflight:
             ok, reason = _run_exec_preflight(provider)
             if not ok:

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -126,8 +126,7 @@ VALID_EFFORT_LEVELS = ("minimal", "low", "medium", "high", "max")
 PROFILE_PRECEDENCE_TEXT = (
     "Resolution order: profile defaults < CONDUCTOR_* env vars < explicit CLI flags."
 )
-DEFAULT_DISPATCH_TIMEOUT_SEC = 1800
-DEFAULT_EXEC_MAX_STALL_SEC = 600
+DEFAULT_EXEC_MAX_STALL_SEC = 360
 MIN_EXEC_BRIEF_CHARS = 300
 GIT_RECOVERY_COMMAND_TIMEOUT_SEC = 2.0
 GIT_RECOVERY_MAX_COMMITS = 5
@@ -226,12 +225,12 @@ def _scale_dispatch_defaults(
 
     resolved_timeout: int | None = timeout_sec
     if timeout_is_default:
-        scaled_timeout = apply_scaling(DEFAULT_DISPATCH_TIMEOUT_SEC, profile)
+        scaled_timeout = apply_scaling(timeout_sec, profile)
         resolved_timeout = None if scaled_timeout is None else math.ceil(scaled_timeout)
 
     resolved_max_stall: int | None = max_stall_sec
     if max_stall_is_default:
-        scaled_stall = apply_scaling(DEFAULT_EXEC_MAX_STALL_SEC, profile)
+        scaled_stall = apply_scaling(max_stall_sec, profile)
         resolved_max_stall = None if scaled_stall is None else math.ceil(scaled_stall)
 
     return resolved_timeout, resolved_max_stall
@@ -2528,12 +2527,11 @@ def main(ctx: click.Context) -> None:
 @click.option(
     "--timeout",
     "timeout_sec",
-    default=DEFAULT_DISPATCH_TIMEOUT_SEC,
+    default=None,
     type=int,
     help=(
         "Wall-clock timeout in seconds for review/exec provider calls. "
-        "Default: 1800, scaled up on slow networks. Council uses "
-        "--council-timeout for its total cap."
+        "Unbounded by default. Council uses --council-timeout for its total cap."
     ),
 )
 @click.option(
@@ -2945,12 +2943,9 @@ def ask(
 @click.option(
     "--timeout",
     "timeout_sec",
-    default=DEFAULT_DISPATCH_TIMEOUT_SEC,
+    default=None,
     type=int,
-    help=(
-        "Wall-clock timeout in seconds. Default: 1800, scaled up on slow "
-        "networks."
-    ),
+    help="Wall-clock timeout in seconds. Unbounded by default.",
 )
 @click.option(
     "--max-stall-seconds",
@@ -2959,7 +2954,7 @@ def ask(
     type=int,
     help=(
         "Kill streaming CLI-backed calls after this many silent seconds. "
-        "Default: 600, scaled up on slow networks. Set 0 to disable."
+        "Default: 360, scaled up on slow networks. Set 0 to disable."
     ),
 )
 @click.option(
@@ -3285,11 +3280,11 @@ def call(
 @click.option(
     "--timeout",
     "timeout_sec",
-    default=DEFAULT_DISPATCH_TIMEOUT_SEC,
+    default=None,
     type=int,
     help=(
         "Wall-clock timeout in seconds for the native review command. "
-        "Default: 1800, scaled up on slow networks."
+        "Unbounded by default."
     ),
 )
 @click.option(
@@ -3612,12 +3607,11 @@ def review(
 @click.option(
     "--timeout",
     "timeout_sec",
-    default=DEFAULT_DISPATCH_TIMEOUT_SEC,
+    default=None,
     type=int,
     help=(
-        "Wall-clock timeout in seconds. Default: 1800, scaled up on slow "
-        "networks. Set explicitly (e.g. --timeout 600) for CI or unattended "
-        "runs that need a fixed bound."
+        "Wall-clock timeout in seconds. Unbounded by default. Set explicitly "
+        "(e.g. --timeout 600) for CI or unattended runs that need a fixed bound."
     ),
 )
 @click.option(

--- a/src/conductor/network_profile.py
+++ b/src/conductor/network_profile.py
@@ -1,0 +1,216 @@
+"""Cheap network RTT profiling for CLI dispatch timeouts.
+
+The profile is derived state. It is cached briefly so a shell loop does not
+probe on every invocation, and corrupt cache content is deleted and rebuilt.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import httpx
+
+from conductor.offline_mode import _cache_dir
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+NETWORK_PROFILE_CACHE_NAME = "network_profile"
+NETWORK_PROFILE_TTL_SEC = 600
+NETWORK_PROFILE_MAX_WALL_SEC = 1.0
+NETWORK_PROFILE_SAMPLES = 3
+NETWORK_PROFILE_FALLBACK_TARGET = "https://1.1.1.1"
+NETWORK_PROFILE_SCALING_TABLE: tuple[tuple[float, int], ...] = (
+    (100.0, 1),
+    (250.0, 2),
+    (float("inf"), 3),
+)
+
+
+@dataclass(frozen=True)
+class NetworkProfile:
+    rtt_ms: float | None
+    target: str
+    timestamp: float
+
+
+def apply_scaling(timeout: float | None, profile: NetworkProfile) -> float | None:
+    """Scale a timeout-like value by the RTT tier.
+
+    ``None`` stays ``None`` so callers can preserve explicit "disabled"
+    semantics.
+    """
+    if timeout is None:
+        return None
+    return timeout * scaling_multiplier(profile)
+
+
+def scaling_multiplier(profile: NetworkProfile) -> int:
+    if profile.rtt_ms is None:
+        return 1
+    for upper_bound_ms, multiplier in NETWORK_PROFILE_SCALING_TABLE:
+        if profile.rtt_ms < upper_bound_ms:
+            return multiplier
+    return 1
+
+
+def get_network_profile(
+    target: str | None,
+    *,
+    now: float | None = None,
+    warn: Callable[[str], None] | None = None,
+) -> NetworkProfile:
+    """Return a cached or freshly probed RTT profile for ``target``.
+
+    Probe failures are surfaced through ``warn`` and return an unscaled profile
+    so dispatch can proceed with the normal defaults.
+    """
+    current_time = time.time() if now is None else now
+    normalized_target = _normalize_target(target)
+    cached = _read_cache(current_time, normalized_target, warn=warn)
+    if cached is not None:
+        return cached
+
+    try:
+        profile = _probe_profile(normalized_target, current_time)
+    except Exception as e:
+        _warn(warn, f"[conductor] network: probe failed for {normalized_target}: {e}")
+        return NetworkProfile(
+            rtt_ms=None,
+            target=normalized_target,
+            timestamp=current_time,
+        )
+
+    _write_cache(profile, warn=warn)
+    return profile
+
+
+def _normalize_target(target: str | None) -> str:
+    if target is None or not target.strip():
+        return NETWORK_PROFILE_FALLBACK_TARGET
+    return target.strip().rstrip("/")
+
+
+def _cache_path() -> Path:
+    return _cache_dir() / NETWORK_PROFILE_CACHE_NAME
+
+
+def _read_cache(
+    now: float,
+    target: str,
+    *,
+    warn: Callable[[str], None] | None,
+) -> NetworkProfile | None:
+    path = _cache_path()
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError as e:
+        _warn(warn, f"[conductor] network: could not read cache {path}: {e}")
+        return None
+
+    try:
+        data = json.loads(raw)
+        profile = NetworkProfile(
+            rtt_ms=float(data["rtt_ms"]),
+            target=str(data["target"]),
+            timestamp=float(data["timestamp"]),
+        )
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as e:
+        _delete_bad_cache(path, warn=warn, reason=e)
+        return None
+
+    if profile.target != target:
+        return None
+    if now - profile.timestamp > NETWORK_PROFILE_TTL_SEC:
+        return None
+    if profile.rtt_ms < 0:
+        _delete_bad_cache(path, warn=warn, reason=ValueError("negative rtt_ms"))
+        return None
+    return profile
+
+
+def _write_cache(profile: NetworkProfile, *, warn: Callable[[str], None] | None) -> None:
+    if profile.rtt_ms is None:
+        return
+    path = _cache_path()
+    payload = {
+        "rtt_ms": profile.rtt_ms,
+        "target": profile.target,
+        "timestamp": profile.timestamp,
+    }
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+    except OSError as e:
+        _warn(warn, f"[conductor] network: could not write cache {path}: {e}")
+
+
+def _delete_bad_cache(
+    path: Path,
+    *,
+    warn: Callable[[str], None] | None,
+    reason: Exception,
+) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+    except OSError as e:
+        _warn(
+            warn,
+            f"[conductor] network: corrupt cache {path} could not be deleted: {e}",
+        )
+        return
+    _warn(warn, f"[conductor] network: deleted corrupt cache {path}: {reason}")
+
+
+def _probe_profile(target: str, timestamp: float) -> NetworkProfile:
+    deadline = time.monotonic() + NETWORK_PROFILE_MAX_WALL_SEC
+    primary_rtts = _sample_rtts(target, deadline)
+    if primary_rtts:
+        return NetworkProfile(
+            rtt_ms=round(statistics.median(primary_rtts), 3),
+            target=target,
+            timestamp=timestamp,
+        )
+
+    fallback_rtts = _sample_rtts(NETWORK_PROFILE_FALLBACK_TARGET, deadline)
+    if fallback_rtts:
+        return NetworkProfile(
+            rtt_ms=round(statistics.median(fallback_rtts), 3),
+            target=NETWORK_PROFILE_FALLBACK_TARGET,
+            timestamp=timestamp,
+        )
+
+    raise RuntimeError(
+        f"no successful RTT samples for {target} or {NETWORK_PROFILE_FALLBACK_TARGET}"
+    )
+
+
+def _sample_rtts(target: str, deadline: float) -> list[float]:
+    samples: list[float] = []
+    with httpx.Client(follow_redirects=True) as client:
+        for _ in range(NETWORK_PROFILE_SAMPLES):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            timeout = min(remaining, NETWORK_PROFILE_MAX_WALL_SEC)
+            started = time.perf_counter()
+            try:
+                client.head(target, timeout=timeout)
+            except httpx.HTTPError:
+                continue
+            samples.append((time.perf_counter() - started) * 1000)
+    return samples
+
+
+def _warn(warn: Callable[[str], None] | None, message: str) -> None:
+    if warn is not None:
+        warn(message)

--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -399,6 +399,8 @@ class ClaudeProvider:
         model: str | None = None,
         *,
         effort: str | int = "medium",
+        timeout_sec: int | None = None,
+        max_stall_sec: int | None = None,
         resume_session_id: str | None = None,
     ) -> CallResponse:
         return self._run(
@@ -407,6 +409,10 @@ class ClaudeProvider:
             effort=effort,
             allowed_tools=None,
             permission_mode=None,
+            timeout_sec_override=(
+                timeout_sec if timeout_sec is not None else _USE_DEFAULT
+            ),
+            max_stall_sec=max_stall_sec,
             resume_session_id=resume_session_id,
         )
 

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -685,6 +685,8 @@ class CodexProvider:
         model: str | None = None,
         *,
         effort: str | int = "medium",
+        timeout_sec: int | None = None,
+        max_stall_sec: int | None = None,
         resume_session_id: str | None = None,
         attachments: tuple[Path, ...] = (),
     ) -> CallResponse:
@@ -693,6 +695,10 @@ class CodexProvider:
             model=model,
             effort=effort,
             sandbox="danger-full-access",
+            timeout_sec_override=(
+                timeout_sec if timeout_sec is not None else _USE_DEFAULT
+            ),
+            max_stall_sec=max_stall_sec,
             resume_session_id=resume_session_id,
             attachments=attachments,
         )

--- a/src/conductor/providers/gemini.py
+++ b/src/conductor/providers/gemini.py
@@ -453,6 +453,8 @@ class GeminiProvider:
         model: str | None = None,
         *,
         effort: str | int = "medium",
+        timeout_sec: int | None = None,
+        max_stall_sec: int | None = None,
         resume_session_id: str | None = None,
     ) -> CallResponse:
         return self._run(
@@ -460,6 +462,10 @@ class GeminiProvider:
             model=model,
             effort=effort,
             approval_mode="plan",
+            timeout_sec_override=(
+                timeout_sec if timeout_sec is not None else _USE_DEFAULT
+            ),
+            max_stall_sec=max_stall_sec,
             resume_session_id=resume_session_id,
             require_inline_response=True,
         )

--- a/src/conductor/providers/interface.py
+++ b/src/conductor/providers/interface.py
@@ -220,6 +220,8 @@ class Provider(Protocol):
         model: str | None = None,
         *,
         effort: str | int = "medium",
+        timeout_sec: int | None = None,
+        max_stall_sec: int | None = None,
         resume_session_id: str | None = None,
     ) -> CallResponse:
         """Single-turn call. `effort` is a symbolic dial (see EFFORT_LEVELS)

--- a/src/conductor/providers/ollama.py
+++ b/src/conductor/providers/ollama.py
@@ -413,8 +413,11 @@ class OllamaProvider:
         model: str | None = None,
         *,
         effort: str | int = "medium",
+        timeout_sec: int | None = None,
+        max_stall_sec: int | None = None,
         resume_session_id: str | None = None,
     ) -> CallResponse:
+        _ = max_stall_sec
         if resume_session_id:
             raise UnsupportedCapability(
                 "ollama has no session model — each /api/chat call is stateless. "
@@ -433,7 +436,8 @@ class OllamaProvider:
 
         start = time.monotonic()
         try:
-            with httpx.Client(timeout=self._timeout_sec) as client:
+            timeout = self._timeout_sec if timeout_sec is None else timeout_sec
+            with httpx.Client(timeout=timeout) as client:
                 resp = self._post_chat_with_model_fallback(
                     client,
                     url,

--- a/src/conductor/providers/openrouter.py
+++ b/src/conductor/providers/openrouter.py
@@ -171,9 +171,10 @@ class OpenRouterProvider:
             return False, f"OpenRouter returned HTTP {resp.status_code}: {resp.text[:200]}"
         return True, None
 
-    def _post_chat(self, payload: dict) -> dict:
+    def _post_chat(self, payload: dict, *, timeout_sec: int | None = None) -> dict:
         try:
-            with httpx.Client(timeout=self._timeout_sec) as client:
+            timeout = self._timeout_sec if timeout_sec is None else timeout_sec
+            with httpx.Client(timeout=timeout) as client:
                 resp = client.post(
                     f"{self._base_url}/chat/completions",
                     headers=self._headers(),
@@ -268,8 +269,11 @@ class OpenRouterProvider:
         exclude: set[str] | frozenset[str] | None = None,
         log_selection: bool = True,
         max_tokens: int | None = None,
+        timeout_sec: int | None = None,
+        max_stall_sec: int | None = None,
         resume_session_id: str | None = None,
     ) -> CallResponse:
+        _ = max_stall_sec
         if resume_session_id:
             raise UnsupportedCapability(
                 "openrouter has no session model — each OpenRouter API call is "
@@ -298,7 +302,7 @@ class OpenRouterProvider:
             payload["max_tokens"] = max(1, max_tokens)
 
         start = time.monotonic()
-        body = self._post_chat(payload)
+        body = self._post_chat(payload, timeout_sec=timeout_sec)
         duration_ms = int((time.monotonic() - start) * 1000)
 
         try:

--- a/src/conductor/providers/shell.py
+++ b/src/conductor/providers/shell.py
@@ -177,8 +177,11 @@ class ShellProvider:
         model: str | None = None,
         *,
         effort: str | int = "medium",
+        timeout_sec: int | None = None,
+        max_stall_sec: int | None = None,
         resume_session_id: str | None = None,
     ) -> CallResponse:
+        _ = max_stall_sec
         if resume_session_id:
             raise UnsupportedCapability(
                 f"custom provider `{self._spec.name}` is stateless — no session "
@@ -188,7 +191,11 @@ class ShellProvider:
         if not ok:
             raise ProviderConfigError(reason or f"{self._spec.name} not configured")
 
-        return self._invoke(task, effort=effort)
+        return self._invoke(
+            task,
+            effort=effort,
+            timeout_override=timeout_sec if timeout_sec is not None else _USE_DEFAULT,
+        )
 
     def exec(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,9 @@ git-environment``).
 from __future__ import annotations
 
 import os
+import time
+
+import pytest
 
 for _var in (
     "GIT_DIR",
@@ -26,3 +29,19 @@ for _var in (
     "GIT_NAMESPACE",
 ):
     os.environ.pop(_var, None)
+
+
+@pytest.fixture(autouse=True)
+def _fast_cli_network_profile(monkeypatch):
+    """Keep CLI tests off the real network unless they patch this explicitly."""
+    from conductor import cli
+    from conductor.network_profile import NETWORK_PROFILE_FALLBACK_TARGET, NetworkProfile
+
+    def _profile(target: str | None, *, warn=None):
+        return NetworkProfile(
+            rtt_ms=50,
+            target=target or NETWORK_PROFILE_FALLBACK_TARGET,
+            timestamp=time.time(),
+        )
+
+    monkeypatch.setattr(cli, "get_network_profile", _profile)

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -30,6 +30,8 @@ DOCUMENTED_STABLE_FLAGS: frozenset[str] = frozenset(
         "--tags",
         "--prefer",
         "--effort",
+        "--timeout",
+        "--max-stall-seconds",
         "--exclude",
         "--brief",
         "--brief-file",

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -1512,16 +1512,18 @@ def test_exec_missing_task_file_errors(mocker, tmp_path):
     assert str(missing) in result.output
 
 
-def test_exec_cli_default_passes_network_scaled_timeout_to_provider(mocker):
-    """`conductor exec --with codex --task ...` applies the dispatch default.
-
-    Slow-network scaling may raise the default, but it must happen before the
-    provider starts so timeout/stall behavior is visible in one place.
+def test_exec_cli_default_passes_no_timeout_to_provider(mocker):
+    """`conductor exec --with codex --task ...` (no --timeout) must hand
+    the provider `timeout_sec=None` so subprocess.run runs unbounded.
+    Regression for the 22-minute lost-work bug where the CLI silently
+    capped exec at 300s and the partial session_id was never recoverable.
+    Network scaling must NOT materialize a timeout where there wasn't one
+    — apply_scaling(None, profile) returns None.
     """
     _stub_all_configured(mocker, {"codex"})
     mocker.patch(
         "conductor.cli.get_network_profile",
-        return_value=NetworkProfile(50, "https://api.openai.com", 1_000),
+        return_value=NetworkProfile(310, "https://api.openai.com", 1_000),
     )
     exec_mock = mocker.patch.object(
         CodexProvider, "exec", return_value=_fake_response("codex")
@@ -1534,7 +1536,10 @@ def test_exec_cli_default_passes_network_scaled_timeout_to_provider(mocker):
 
     assert result.exit_code == 0, result.output
     assert exec_mock.called
-    assert exec_mock.call_args.kwargs["timeout_sec"] == 1800
+    assert exec_mock.call_args.kwargs["timeout_sec"] is None, (
+        "exec without --timeout must pass None (unbounded). "
+        f"Got timeout_sec={exec_mock.call_args.kwargs['timeout_sec']!r}"
+    )
 
 
 def test_exec_cli_explicit_timeout_passes_through(mocker):
@@ -1573,7 +1578,7 @@ def test_exec_cli_max_stall_seconds_flag_propagates(mocker):
     assert exec_mock.call_args.kwargs["max_stall_sec"] == 60
 
 
-def test_exec_cli_no_max_stall_seconds_defaults_to_600(mocker):
+def test_exec_cli_no_max_stall_seconds_defaults_to_360(mocker):
     _stub_all_configured(mocker, {"codex"})
     exec_mock = mocker.patch.object(
         CodexProvider, "exec", return_value=_fake_response("codex")
@@ -1585,7 +1590,7 @@ def test_exec_cli_no_max_stall_seconds_defaults_to_600(mocker):
     )
 
     assert result.exit_code == 0, result.output
-    assert exec_mock.call_args.kwargs["max_stall_sec"] == 600
+    assert exec_mock.call_args.kwargs["max_stall_sec"] == 360
 
 
 def test_exec_cli_max_stall_seconds_zero_disables_watchdog(mocker):

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -24,6 +24,7 @@ import respx
 from click.testing import CliRunner
 
 from conductor.cli import SANDBOX_DEPRECATION_WARNING, main
+from conductor.network_profile import NetworkProfile
 from conductor.openrouter_model_stacks import OPENROUTER_CODING_HIGH
 from conductor.providers import (
     CallResponse,
@@ -1511,12 +1512,17 @@ def test_exec_missing_task_file_errors(mocker, tmp_path):
     assert str(missing) in result.output
 
 
-def test_exec_cli_default_passes_no_timeout_to_provider(mocker):
-    """`conductor exec --with codex --task ...` (no --timeout) must hand
-    the provider `timeout_sec=None` so subprocess.run runs unbounded.
-    Regression for the 22-minute lost-work bug where the CLI silently
-    capped exec at 300s and the partial session_id was never recoverable."""
+def test_exec_cli_default_passes_network_scaled_timeout_to_provider(mocker):
+    """`conductor exec --with codex --task ...` applies the dispatch default.
+
+    Slow-network scaling may raise the default, but it must happen before the
+    provider starts so timeout/stall behavior is visible in one place.
+    """
     _stub_all_configured(mocker, {"codex"})
+    mocker.patch(
+        "conductor.cli.get_network_profile",
+        return_value=NetworkProfile(50, "https://api.openai.com", 1_000),
+    )
     exec_mock = mocker.patch.object(
         CodexProvider, "exec", return_value=_fake_response("codex")
     )
@@ -1528,10 +1534,7 @@ def test_exec_cli_default_passes_no_timeout_to_provider(mocker):
 
     assert result.exit_code == 0, result.output
     assert exec_mock.called
-    assert exec_mock.call_args.kwargs["timeout_sec"] is None, (
-        "exec without --timeout must pass None (unbounded). "
-        f"Got timeout_sec={exec_mock.call_args.kwargs['timeout_sec']!r}"
-    )
+    assert exec_mock.call_args.kwargs["timeout_sec"] == 1800
 
 
 def test_exec_cli_explicit_timeout_passes_through(mocker):
@@ -1570,7 +1573,7 @@ def test_exec_cli_max_stall_seconds_flag_propagates(mocker):
     assert exec_mock.call_args.kwargs["max_stall_sec"] == 60
 
 
-def test_exec_cli_no_max_stall_seconds_defaults_to_360(mocker):
+def test_exec_cli_no_max_stall_seconds_defaults_to_600(mocker):
     _stub_all_configured(mocker, {"codex"})
     exec_mock = mocker.patch.object(
         CodexProvider, "exec", return_value=_fake_response("codex")
@@ -1582,7 +1585,7 @@ def test_exec_cli_no_max_stall_seconds_defaults_to_360(mocker):
     )
 
     assert result.exit_code == 0, result.output
-    assert exec_mock.call_args.kwargs["max_stall_sec"] == 360
+    assert exec_mock.call_args.kwargs["max_stall_sec"] == 600
 
 
 def test_exec_cli_max_stall_seconds_zero_disables_watchdog(mocker):

--- a/tests/test_network_profile.py
+++ b/tests/test_network_profile.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import httpx
+from click.testing import CliRunner
+
+from conductor.cli import main
+from conductor.network_profile import (
+    NETWORK_PROFILE_FALLBACK_TARGET,
+    NETWORK_PROFILE_TTL_SEC,
+    NetworkProfile,
+    apply_scaling,
+    get_network_profile,
+    scaling_multiplier,
+)
+from conductor.providers import CallResponse, CodexProvider
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _cache_file(tmp_path: Path) -> Path:
+    return tmp_path / "conductor" / "network_profile"
+
+
+class _FakeClient:
+    calls: list[str] = []
+    failures: dict[str, int] = {}
+
+    def __init__(self, *, follow_redirects: bool) -> None:
+        self.follow_redirects = follow_redirects
+
+    def __enter__(self) -> _FakeClient:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def head(self, target: str, *, timeout: float) -> httpx.Response:
+        self.calls.append(target)
+        remaining_failures = self.failures.get(target, 0)
+        if remaining_failures:
+            self.failures[target] = remaining_failures - 1
+            raise httpx.ConnectError("connect failed")
+        return httpx.Response(204)
+
+
+def _install_fake_probe(monkeypatch, perf_values: list[float]) -> None:
+    monkeypatch.setattr("conductor.network_profile.httpx.Client", _FakeClient)
+    monkeypatch.setattr(
+        "conductor.network_profile.time.perf_counter",
+        lambda: perf_values.pop(0),
+    )
+    monkeypatch.setattr("conductor.network_profile.time.monotonic", lambda: 10.0)
+
+
+def test_cache_hit_reuses_fresh_profile(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    path = _cache_file(tmp_path)
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "rtt_ms": 123,
+                "target": "https://api.example.test",
+                "timestamp": 1_000,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "conductor.network_profile.httpx.Client",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("probe should not run")),
+    )
+
+    profile = get_network_profile("https://api.example.test", now=1_100)
+
+    assert profile == NetworkProfile(
+        rtt_ms=123,
+        target="https://api.example.test",
+        timestamp=1_000,
+    )
+
+
+def test_cache_miss_probes_and_writes_profile(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    _FakeClient.calls = []
+    _FakeClient.failures = {}
+    _install_fake_probe(monkeypatch, [0.0, 0.050, 1.0, 1.120, 2.0, 2.250])
+
+    profile = get_network_profile("https://api.example.test", now=2_000)
+
+    assert profile.rtt_ms == 120
+    assert profile.target == "https://api.example.test"
+    cached = json.loads(_cache_file(tmp_path).read_text(encoding="utf-8"))
+    assert cached["rtt_ms"] == 120
+    assert cached["target"] == "https://api.example.test"
+
+
+def test_ttl_expiry_reprobes(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    path = _cache_file(tmp_path)
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "rtt_ms": 90,
+                "target": "https://api.example.test",
+                "timestamp": 1_000,
+            }
+        ),
+        encoding="utf-8",
+    )
+    _FakeClient.calls = []
+    _FakeClient.failures = {}
+    _install_fake_probe(monkeypatch, [0.0, 0.300, 1.0, 1.330, 2.0, 2.360])
+
+    profile = get_network_profile(
+        "https://api.example.test",
+        now=1_000 + NETWORK_PROFILE_TTL_SEC + 1,
+    )
+
+    assert profile.rtt_ms == 330
+    assert _FakeClient.calls == ["https://api.example.test"] * 3
+
+
+def test_scaling_tiers():
+    assert scaling_multiplier(NetworkProfile(99, "target", 0)) == 1
+    assert scaling_multiplier(NetworkProfile(100, "target", 0)) == 2
+    assert scaling_multiplier(NetworkProfile(250, "target", 0)) == 3
+    assert apply_scaling(600, NetworkProfile(310, "target", 0)) == 1800
+
+
+def test_fallback_target_when_provider_unreachable(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    _FakeClient.calls = []
+    _FakeClient.failures = {"https://api.example.test": 3}
+    _install_fake_probe(
+        monkeypatch,
+        [0.0, 1.0, 2.0, 3.0, 3.040, 4.0, 4.070, 5.0, 5.100],
+    )
+
+    profile = get_network_profile("https://api.example.test", now=3_000)
+
+    assert profile.target == NETWORK_PROFILE_FALLBACK_TARGET
+    assert profile.rtt_ms == 70
+    assert _FakeClient.calls == [
+        "https://api.example.test",
+        "https://api.example.test",
+        "https://api.example.test",
+        NETWORK_PROFILE_FALLBACK_TARGET,
+        NETWORK_PROFILE_FALLBACK_TARGET,
+        NETWORK_PROFILE_FALLBACK_TARGET,
+    ]
+
+
+def test_corrupt_cache_is_deleted_and_rebuilt(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    path = _cache_file(tmp_path)
+    path.parent.mkdir(parents=True)
+    path.write_text("{not json", encoding="utf-8")
+    warnings: list[str] = []
+    _FakeClient.calls = []
+    _FakeClient.failures = {}
+    _install_fake_probe(monkeypatch, [0.0, 0.080, 1.0, 1.090, 2.0, 2.100])
+
+    profile = get_network_profile(
+        "https://api.example.test",
+        now=4_000,
+        warn=warnings.append,
+    )
+
+    assert profile.rtt_ms == 90
+    assert "deleted corrupt cache" in warnings[0]
+    assert json.loads(path.read_text(encoding="utf-8"))["rtt_ms"] == 90
+
+
+def test_exec_default_scaling_line_and_values(monkeypatch, mocker, tmp_path):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    mocker.patch.object(CodexProvider, "configured", return_value=(True, None))
+    mocker.patch.object(CodexProvider, "health_probe", return_value=(True, None))
+    exec_mock = mocker.patch.object(
+        CodexProvider,
+        "exec",
+        return_value=CallResponse(
+            text="ok",
+            provider="codex",
+            model="gpt",
+            duration_ms=1,
+            usage={},
+            raw={},
+        ),
+    )
+    mocker.patch(
+        "conductor.cli.get_network_profile",
+        return_value=NetworkProfile(310, "https://api.openai.com", 1_000),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["exec", "--with", "codex", "--task", "Reply OK."],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "310ms RTT to api.openai.com" in result.stderr
+    assert "timeouts scaled 3×" in result.stderr
+    assert exec_mock.call_args.kwargs["timeout_sec"] == 5400
+    assert exec_mock.call_args.kwargs["max_stall_sec"] == 1800
+
+
+def test_call_default_scaling_line_and_values(monkeypatch, mocker, tmp_path):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    mocker.patch.object(CodexProvider, "configured", return_value=(True, None))
+    call_mock = mocker.patch.object(
+        CodexProvider,
+        "call",
+        return_value=CallResponse(
+            text="ok",
+            provider="codex",
+            model="gpt",
+            duration_ms=1,
+            usage={},
+            raw={},
+        ),
+    )
+    mocker.patch(
+        "conductor.cli.get_network_profile",
+        return_value=NetworkProfile(180, "https://api.openai.com", 1_000),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["call", "--with", "codex", "--task", "Reply OK."],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "180ms RTT to api.openai.com" in result.stderr
+    assert "timeouts scaled 2×" in result.stderr
+    assert call_mock.call_args.kwargs["timeout_sec"] == 3600
+    assert call_mock.call_args.kwargs["max_stall_sec"] == 1200
+
+
+def test_user_timeout_and_stall_overrides_win(monkeypatch, mocker, tmp_path):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    mocker.patch.object(CodexProvider, "configured", return_value=(True, None))
+    mocker.patch.object(CodexProvider, "health_probe", return_value=(True, None))
+    profile_mock = mocker.patch("conductor.cli.get_network_profile")
+    exec_mock = mocker.patch.object(
+        CodexProvider,
+        "exec",
+        return_value=CallResponse(
+            text="ok",
+            provider="codex",
+            model="gpt",
+            duration_ms=1,
+            usage={},
+            raw={},
+        ),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--with",
+            "codex",
+            "--timeout",
+            "600",
+            "--max-stall-seconds",
+            "5",
+            "--task",
+            "Reply OK.",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    profile_mock.assert_not_called()
+    assert exec_mock.call_args.kwargs["timeout_sec"] == 600
+    assert exec_mock.call_args.kwargs["max_stall_sec"] == 5

--- a/tests/test_network_profile.py
+++ b/tests/test_network_profile.py
@@ -206,8 +206,10 @@ def test_exec_default_scaling_line_and_values(monkeypatch, mocker, tmp_path):
     assert result.exit_code == 0, result.output
     assert "310ms RTT to api.openai.com" in result.stderr
     assert "timeouts scaled 3×" in result.stderr
-    assert exec_mock.call_args.kwargs["timeout_sec"] == 5400
-    assert exec_mock.call_args.kwargs["max_stall_sec"] == 1800
+    # exec --timeout default is None (unbounded); scaling None stays None.
+    assert exec_mock.call_args.kwargs["timeout_sec"] is None
+    # max_stall_sec default 360 → 3× = 1080.
+    assert exec_mock.call_args.kwargs["max_stall_sec"] == 1080
 
 
 def test_call_default_scaling_line_and_values(monkeypatch, mocker, tmp_path):
@@ -238,8 +240,10 @@ def test_call_default_scaling_line_and_values(monkeypatch, mocker, tmp_path):
     assert result.exit_code == 0, result.output
     assert "180ms RTT to api.openai.com" in result.stderr
     assert "timeouts scaled 2×" in result.stderr
-    assert call_mock.call_args.kwargs["timeout_sec"] == 3600
-    assert call_mock.call_args.kwargs["max_stall_sec"] == 1200
+    # call --timeout default is None (unbounded); scaling None stays None.
+    assert call_mock.call_args.kwargs["timeout_sec"] is None
+    # max_stall_sec default 360 → 2× = 720.
+    assert call_mock.call_args.kwargs["max_stall_sec"] == 720
 
 
 def test_user_timeout_and_stall_overrides_win(monkeypatch, mocker, tmp_path):


### PR DESCRIPTION
## Summary

Adds a cheap RTT probe + cache + scaling table so `conductor exec` / `call` / `review` defaults adapt to slow networks instead of failing mid-dispatch.

- New module `src/conductor/network_profile.py`:
  - Up to 3 `httpx.HEAD` samples to the active provider's endpoint, capped at 1s wall-clock.
  - Median RTT cached at `~/.cache/conductor/network_profile` with 10-min TTL; corrupt cache is deleted and re-probed.
  - Scaling table: <100ms → 1×, 100–250ms → 2×, >250ms → 3×.
  - Falls back to `https://1.1.1.1` if the provider endpoint is unreachable.
  - Probe failure surfaces as a single stderr warning; dispatch continues with unscaled defaults.
- CLI integration via `_scale_dispatch_defaults` for `call` / `exec` / `review` / `council` defaults. User-supplied `--timeout` / `--max-stall-seconds` always win.
- One-line stderr notice only when scaling is non-1×: `[conductor] network: 310ms RTT to api.openai.com → timeouts scaled 3× (override with --timeout)`.

## Important: preserves unbounded-by-default for `--timeout`

The original implementation changed click `default=None` for `--timeout` to `default=DEFAULT_DISPATCH_TIMEOUT_SEC=1800` so the scaling helper had a constant to scale from. That regressed two intentional behaviors (#144 bullet 4 explicitly relied on `timeout_sec=None` for unbounded exec; `DEFAULT_EXEC_MAX_STALL_SEC` was 360, not 600). Fixed in a follow-up commit on this branch — the scaling helper now scales the *resolved input value*, so `None` stays `None` and unbounded exec remains unbounded on slow networks; max-stall default stays 360 and scales as expected.

Closes #147.

## Test plan

- [x] \`tests/test_network_profile.py\` — 281 lines covering cache hit/miss, TTL expiry, corrupt-cache rebuild, fallback target, all scaling tiers, CLI scaling emission, user-override behavior, and that unbounded \`timeout_sec=None\` stays unbounded.
- [x] Restored regression tests for #144 bullet 4: \`test_exec_cli_default_passes_no_timeout_to_provider\` and \`test_exec_cli_no_max_stall_seconds_defaults_to_360\`.
- [x] \`uv run pytest tests/\` — 854 passed, 15 skipped.
- [x] \`uv run ruff check src/ tests/\` — clean.
- [x] Manual: \`conductor exec --with codex --tools Read --brief 'Reply OK.'\` returns OK; no scaling line appears on a fast/fresh network.