### PR TITLE
docs: correct timeout defaults table; fix latent mypy on network_profile

### DIFF
--- a/docs/consumers.md
+++ b/docs/consumers.md
@@ -118,8 +118,8 @@ The canonical reference is `conductor call --help`. The contract-level commitmen
 | `--tags <csv>` | string | stable | For `--auto` routing |
 | `--prefer <mode>` | string | stable | One of: best, cheapest, fastest, balanced. Default: balanced |
 | `--effort <level>` | string \| int | stable | One of: minimal, low, medium, high, max. Or integer token budget. Default: medium |
-| `--timeout <sec>` | int | stable | Wall-clock timeout. Default: 1800, scaled up on slow networks unless explicitly set |
-| `--max-stall-seconds <sec>` | int | stable | Streaming CLI stall watchdog. Default: 600, scaled up on slow networks unless explicitly set. `0` disables |
+| `--timeout <sec>` | int | stable | Wall-clock timeout. Unbounded by default. When set explicitly, value is honored as-is (no scaling) |
+| `--max-stall-seconds <sec>` | int | stable | Streaming CLI stall watchdog. Default: 360, scaled up on slow networks unless explicitly set. `0` disables |
 | `--exclude <csv>` | string | stable | Providers to skip in `--auto` |
 | `--brief <text>` | string | stable | Inline delegation brief / prompt |
 | `--brief-file <path>` | string | stable | File path, `-` for stdin |

--- a/src/conductor/network_profile.py
+++ b/src/conductor/network_profile.py
@@ -130,8 +130,8 @@ def _read_cache(
         return None
     if now - profile.timestamp > NETWORK_PROFILE_TTL_SEC:
         return None
-    if profile.rtt_ms < 0:
-        _delete_bad_cache(path, warn=warn, reason=ValueError("negative rtt_ms"))
+    if profile.rtt_ms is None or profile.rtt_ms < 0:
+        _delete_bad_cache(path, warn=warn, reason=ValueError("invalid rtt_ms"))
         return None
     return profile
 


### PR DESCRIPTION
Two small follow-ups to #147 (PR #196): correct docs/consumers.md timeout defaults to match the unbounded-by-default behavior we preserved, and fix a latent mypy error in network_profile._read_cache (rtt_ms None case).