### PR TITLE
fix: refuse ollama fallback for --kind code --effort high (#191)

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -36,6 +36,7 @@ from conductor import __version__, credentials, offline_mode
 from conductor.banner import print_caller_banner
 from conductor.delegation_ledger import (
     DelegationEvent,
+    DelegationStatus,
     read_delegations,
     record_delegation,
 )
@@ -839,6 +840,33 @@ def _semantic_candidate_exclude_set(
 
 def _semantic_priority(plan: SemanticPlan) -> tuple[str, ...]:
     return tuple(candidate.provider for candidate in plan.candidates)
+
+
+def _requires_strong_code_provider(plan: SemanticPlan) -> bool:
+    return plan.kind == "code" and plan.effort_bucket in {"high", "max"}
+
+
+def _exclude_ollama_from_strong_code_plan(plan: SemanticPlan) -> tuple[SemanticPlan, bool]:
+    if not _requires_strong_code_provider(plan):
+        return plan, False
+    candidates = tuple(
+        candidate for candidate in plan.candidates if candidate.provider != "ollama"
+    )
+    if len(candidates) == len(plan.candidates):
+        return plan, False
+    return replace(plan, candidates=candidates), True
+
+
+def _format_strong_code_no_fallback_error(
+    plan: SemanticPlan,
+    provider: str,
+    err: Exception,
+) -> str:
+    return (
+        f"conductor: no usable fallback for --kind code --effort {plan.effort_bucket} "
+        f"after primary {provider} failed ({err}).\n"
+        "           Configure another frontier provider, or relax --effort to medium."
+    )
 
 
 def _format_semantic_plan_line(plan: SemanticPlan) -> str:
@@ -2219,7 +2247,7 @@ def _delegation_tags(
     return []
 
 
-def _delegation_status_from_error(error: Exception | str) -> str:
+def _delegation_status_from_error(error: Exception | str) -> DelegationStatus:
     if isinstance(error, ProviderStalledError):
         text = str(error).lower()
         if "timed out" in text or "timeout" in text:
@@ -2857,6 +2885,10 @@ def ask(
         offline_mode.set_active()
         plan = with_candidate_override(plan, provider="ollama")
 
+    excluded_ollama = False
+    if offline is not True:
+        plan, excluded_ollama = _exclude_ollama_from_strong_code_plan(plan)
+
     if kind == "council" and plan.candidates[0].provider != "openrouter":
         raise click.UsageError("council always routes through OpenRouter.")
 
@@ -2883,6 +2915,12 @@ def ask(
             "use `conductor exec --with codex --attach ...` instead."
         )
 
+    if excluded_ollama and not silent_route:
+        click.echo(
+            "[conductor] excluding ollama from fallback chain "
+            f"(--kind code --effort {plan.effort_bucket} requires strong reasoning)",
+            err=True,
+        )
     if not (silent_route or as_json):
         click.echo(_format_semantic_plan_line(plan), err=True)
 
@@ -3142,7 +3180,17 @@ def ask(
             semantic_plan=plan,
             session_log=session_log,
         )
-        click.echo(f"conductor: {e}", err=True)
+        if (
+            _requires_strong_code_provider(plan)
+            and len(decision.ranked) == 1
+            and decision.provider == decision.ranked[0].name
+        ):
+            click.echo(
+                _format_strong_code_no_fallback_error(plan, decision.provider, e),
+                err=True,
+            )
+        else:
+            click.echo(f"conductor: {e}", err=True)
         _maybe_echo_stall_recovery_hint(e, cwd=cwd)
         sys.exit(1)
 

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -520,13 +520,22 @@ def test_ask_code_high_falls_back_immediately_to_openrouter_on_quota(mocker):
 
 
 def test_ask_code_high_falls_back_to_openrouter_exec_before_ollama(mocker):
-    _stub_all_configured(mocker, {"openrouter", "ollama"})
+    from conductor.providers.interface import ProviderHTTPError
+
+    _stub_all_configured(mocker, {"codex", "openrouter", "ollama"})
+    codex_exec = mocker.patch.object(
+        CodexProvider,
+        "exec",
+        side_effect=ProviderHTTPError("codex reported rate limit: out of tokens"),
+    )
     exec_mock = mocker.patch.object(
         OpenRouterProvider,
         "exec",
         return_value=_fake_response("openrouter", "openrouter/auto"),
     )
-    mocker.patch.object(OllamaProvider, "exec", return_value=_fake_response("ollama"))
+    ollama_exec = mocker.patch.object(
+        OllamaProvider, "exec", return_value=_fake_response("ollama")
+    )
 
     result = CliRunner().invoke(
         main,
@@ -544,30 +553,33 @@ def test_ask_code_high_falls_back_to_openrouter_exec_before_ollama(mocker):
     )
 
     assert result.exit_code == 0, result.output
+    assert codex_exec.called
     assert exec_mock.called
+    assert not ollama_exec.called
     assert exec_mock.call_args.kwargs["tools"] == frozenset(
         {"Read", "Grep", "Glob", "Edit", "Write", "Bash"}
     )
     assert exec_mock.call_args.kwargs["models"] == OPENROUTER_CODING_HIGH
+    assert "excluding ollama from fallback chain" in result.stderr
+    assert "falling through to ollama" not in result.stderr
     payload = json.loads(result.stdout)
     assert [candidate["provider"] for candidate in payload["semantic"]["candidates"]] == [
         "codex",
         "openrouter",
-        "ollama",
     ]
     assert payload["semantic"]["candidates"][1]["models"] == list(
         OPENROUTER_CODING_HIGH
     )
 
 
-def test_ask_code_high_falls_back_after_openrouter_execution_failure(mocker):
-    _stub_all_configured(mocker, {"openrouter", "ollama"})
-    openrouter_exec = mocker.patch.object(
-        OpenRouterProvider,
+def test_ask_code_high_without_frontier_fallback_refuses_ollama(mocker):
+    _stub_all_configured(mocker, {"codex", "ollama"})
+    codex_exec = mocker.patch.object(
+        CodexProvider,
         "exec",
         side_effect=ProviderExecutionError(
-            "OpenRouter code execution failed: no-op",
-            provider="openrouter",
+            "codex execution failed: no-op",
+            provider="codex",
             status={"state": "no-op", "repo_changing": True},
         ),
     )
@@ -591,12 +603,16 @@ def test_ask_code_high_falls_back_after_openrouter_execution_failure(mocker):
         ],
     )
 
-    assert result.exit_code == 0, result.output
-    assert openrouter_exec.called
-    assert ollama_exec.called
-    assert "openrouter failed (provider-error)" in result.stderr
-    assert "falling back" in result.stderr
-    assert "→ ollama" in result.stderr
+    assert result.exit_code == 1, result.output
+    assert codex_exec.called
+    assert not ollama_exec.called
+    assert "excluding ollama from fallback chain" in result.stderr
+    assert (
+        "conductor: no usable fallback for --kind code --effort high "
+        "after primary codex failed (codex execution failed: no-op)."
+    ) in result.stderr
+    assert "Configure another frontier provider, or relax --effort to medium." in result.stderr
+    assert "falling through to ollama" not in result.stderr
 
 
 def test_ask_code_medium_falls_through_from_openrouter_404_to_ollama(mocker):
@@ -636,6 +652,42 @@ def test_ask_code_medium_falls_through_from_openrouter_404_to_ollama(mocker):
     assert "openrouter failed (provider-error)" in result.stderr
     assert "falling through to ollama" in result.stderr
     assert "falling back" in result.stderr
+    assert "→ ollama" in result.stderr
+
+
+def test_ask_research_high_keeps_ollama_fallback(mocker):
+    from conductor.providers.interface import ProviderHTTPError
+
+    _stub_all_configured(mocker, {"openrouter", "ollama"})
+    mocker.patch.object(
+        OpenRouterProvider,
+        "call",
+        side_effect=ProviderHTTPError("OpenRouter provider failed with HTTP 503"),
+    )
+    ollama_call = mocker.patch.object(
+        OllamaProvider,
+        "call",
+        return_value=_fake_response("ollama", "llama3.2"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "ask",
+            "--kind",
+            "research",
+            "--effort",
+            "high",
+            "--brief",
+            "Find the relevant background and summarize it.",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert ollama_call.called
+    assert "excluding ollama from fallback chain" not in result.stderr
+    assert "openrouter failed (5xx)" in result.stderr
+    assert "falling through to ollama" in result.stderr
     assert "→ ollama" in result.stderr
 
 


### PR DESCRIPTION
## Summary

When `conductor ask --kind code --effort high` falls through from a frontier provider failure to ollama, ollama can't realistically complete the task and burns 45s + 77k input tokens before silently failing on the tool-use iteration cap. Operator gets nothing.

This implements Option B from #191: at planning time, exclude ollama from the candidate chain when the request is `--kind code --effort high|max`. If only the primary remains and it fails, exit 1 with a clear no-fallback message.

- `_requires_strong_code_provider(plan)` and `_exclude_ollama_from_strong_code_plan(plan)` at the planning layer (BEFORE dispatch).
- Stderr: `[conductor] excluding ollama from fallback chain (--kind code --effort high requires strong reasoning)`.
- On `ProviderError` from a strong-code request with only one candidate, emits: `conductor: no usable fallback for --kind code --effort high after primary <provider> failed (...). Configure another frontier provider, or relax --effort to medium.` Exit 1.
- `--offline` keeps ollama (operator's explicit override).
- Other kinds (`research`, `review`, `council`) and lower efforts (`minimal`, `low`, `medium`) keep ollama as a fallback — they're tractable.

Bundles a small typing fix that surfaced from the touchstone-validate pre-push hook against current main: `_delegation_status_from_error` returns the proper `DelegationStatus` Literal, not bare `str`.

Closes #191 sub-issue 2 (ollama-as-bad-fallback). Sub-issue 1 (opaque OR errors) and sub-issue 3 (codex probe) are separate; #191 b3 is already fixed by today's #184/#187.

## Test plan

- [x] `tests/test_cli_v02.py` — 88 passed (covers: code/high with codex+OR fails clearly; code/high with another frontier provider falls correctly; research/high keeps ollama; code/medium keeps ollama)
- [x] `uv run pytest tests/` — 864 passed, 15 skipped
- [x] `uv run ruff check src/ tests/` — clean
- [x] `mypy src/conductor/cli.py` — clean