### PR TITLE
feat: add filters to conductor sessions list (#197)

### DIFF
--- a/src/conductor/_time_filter.py
+++ b/src/conductor/_time_filter.py
@@ -1,0 +1,38 @@
+"""Shared relative-time parsing for CLI filters."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+
+def since_cutoff(since: str | timedelta | None) -> datetime | None:
+    if since is None:
+        return None
+    if isinstance(since, timedelta):
+        return datetime.now(UTC) - since
+    unit = since[-1:]
+    try:
+        amount = int(since[:-1])
+    except ValueError as e:
+        raise ValueError("since must be like 1h, 24h, or 7d") from e
+    if unit == "h":
+        delta = timedelta(hours=amount)
+    elif unit == "d":
+        delta = timedelta(days=amount)
+    elif unit == "m":
+        delta = timedelta(minutes=amount)
+    else:
+        raise ValueError("since must use m, h, or d")
+    return datetime.now(UTC) - delta
+
+
+def parse_timestamp(value: object) -> datetime:
+    if not isinstance(value, str):
+        return datetime.min.replace(tzinfo=UTC)
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return datetime.min.replace(tzinfo=UTC)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -26,6 +26,7 @@ import sys
 import time
 from dataclasses import asdict, dataclass, replace
 from pathlib import Path
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import click
@@ -33,6 +34,7 @@ from click.core import ParameterSource
 
 import conductor.providers.openrouter_catalog as openrouter_catalog
 from conductor import __version__, credentials, offline_mode
+from conductor._time_filter import parse_timestamp, since_cutoff
 from conductor.banner import print_caller_banner
 from conductor.delegation_ledger import (
     DelegationEvent,
@@ -138,6 +140,9 @@ GIT_RECOVERY_COMMAND_TIMEOUT_SEC = 2.0
 GIT_RECOVERY_MAX_COMMITS = 5
 GIT_RECOVERY_MAX_STATUS_PATHS = 8
 NATIVE_REVIEW_TAG = "code-review"
+
+if TYPE_CHECKING:
+    from datetime import datetime
 DEFAULT_REVIEW_MAX_FALLBACKS = 3
 DEFAULT_COUNCIL_ROUNDS = 1
 DEFAULT_COUNCIL_TIMEOUT_SEC = 180
@@ -5723,9 +5728,74 @@ def sessions() -> None:
 
 
 @sessions.command("list")
-def sessions_list() -> None:
+@click.option(
+    "--last",
+    "last_n",
+    default=20,
+    type=click.IntRange(min=0),
+    show_default=True,
+    help="Show the N most recently updated sessions; 0 disables the cap.",
+)
+@click.option(
+    "--since",
+    default=None,
+    help="Only show sessions updated since 1h, 24h, 7d, etc.",
+)
+@click.option(
+    "--status",
+    "status_filter",
+    default=None,
+    help="Only show sessions with this status.",
+)
+@click.option(
+    "--provider",
+    "provider_filter",
+    default=None,
+    help="Only show sessions for this provider.",
+)
+@click.option("--all", "show_all", is_flag=True, default=False, help="Show all matching sessions.")
+@click.option("--json", "as_json", is_flag=True, default=False)
+@click.pass_context
+def sessions_list(
+    ctx: click.Context,
+    last_n: int,
+    since: str | None,
+    status_filter: str | None,
+    provider_filter: str | None,
+    show_all: bool,
+    as_json: bool,
+) -> None:
     """List known session logs with their latest status."""
     records = list_session_records()
+    if records:
+        _validate_session_filter("status", status_filter, {record.status for record in records})
+        _validate_session_filter(
+            "provider",
+            provider_filter,
+            {record.provider for record in records if record.provider is not None},
+        )
+
+    try:
+        cutoff = since_cutoff(since)
+    except ValueError as e:
+        raise click.UsageError(str(e)) from e
+
+    records = _filter_session_records(
+        records,
+        cutoff=cutoff,
+        status_filter=status_filter,
+        provider_filter=provider_filter,
+    )
+    if show_all:
+        if ctx.get_parameter_source("last_n") == ParameterSource.COMMANDLINE:
+            click.echo("[conductor] --all ignores --last", err=True)
+    elif last_n:
+        records = records[-last_n:]
+
+    if as_json:
+        click.echo(json.dumps([asdict(record) for record in records], default=str, indent=2))
+        return
+
     if not records:
         click.echo("(no session logs)")
         return
@@ -5742,6 +5812,36 @@ def sessions_list() -> None:
             f"{record.updated_at:<27}  "
             f"{provider}"
         )
+
+
+def _validate_session_filter(
+    name: str,
+    value: str | None,
+    known_values: set[str],
+) -> None:
+    if value is None or value in known_values:
+        return
+    choices = ", ".join(sorted(known_values)) or "none"
+    raise click.UsageError(f"unknown session {name} {value!r}; known values: {choices}")
+
+
+def _filter_session_records(
+    records: list[SessionRecord],
+    *,
+    cutoff: datetime | None,
+    status_filter: str | None,
+    provider_filter: str | None,
+) -> list[SessionRecord]:
+    filtered: list[SessionRecord] = []
+    for record in records:
+        if status_filter is not None and record.status != status_filter:
+            continue
+        if provider_filter is not None and record.provider != provider_filter:
+            continue
+        if cutoff is not None and parse_timestamp(record.updated_at) < cutoff:
+            continue
+        filtered.append(record)
+    return filtered
 
 
 @sessions.command("tail")

--- a/src/conductor/delegation_ledger.py
+++ b/src/conductor/delegation_ledger.py
@@ -19,6 +19,7 @@ from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Literal
 
+from conductor._time_filter import parse_timestamp, since_cutoff
 from conductor.offline_mode import _cache_dir
 
 if TYPE_CHECKING:
@@ -94,7 +95,7 @@ def read_delegations(
     path: Path | None = None,
 ) -> Iterable[dict]:
     events = list(_iter_events(path or ledger_path()))
-    cutoff = _since_cutoff(since)
+    cutoff = since_cutoff(since)
     filtered = []
     for event in events:
         if not include_members and event.get("parent_delegation_id"):
@@ -105,7 +106,7 @@ def read_delegations(
             continue
         if provider is not None and event.get("provider") != provider:
             continue
-        if cutoff is not None and _parse_timestamp(event.get("timestamp")) < cutoff:
+        if cutoff is not None and parse_timestamp(event.get("timestamp")) < cutoff:
             continue
         filtered.append(event)
     if last is not None:
@@ -144,39 +145,6 @@ def _iter_events(path: Path) -> Iterable[dict]:
             continue
         if isinstance(payload, dict):
             yield payload
-
-
-def _since_cutoff(since: str | timedelta | None) -> datetime | None:
-    if since is None:
-        return None
-    if isinstance(since, timedelta):
-        return datetime.now(UTC) - since
-    unit = since[-1:]
-    try:
-        amount = int(since[:-1])
-    except ValueError as e:
-        raise ValueError("since must be like 1h, 24h, or 7d") from e
-    if unit == "h":
-        delta = timedelta(hours=amount)
-    elif unit == "d":
-        delta = timedelta(days=amount)
-    elif unit == "m":
-        delta = timedelta(minutes=amount)
-    else:
-        raise ValueError("since must use m, h, or d")
-    return datetime.now(UTC) - delta
-
-
-def _parse_timestamp(value: object) -> datetime:
-    if not isinstance(value, str):
-        return datetime.min.replace(tzinfo=UTC)
-    try:
-        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError:
-        return datetime.min.replace(tzinfo=UTC)
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=UTC)
-    return parsed.astimezone(UTC)
 
 
 def _matches_delegation_id(event: dict, delegation_id: str) -> bool:

--- a/tests/test_cli_log_file.py
+++ b/tests/test_cli_log_file.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 from click.testing import CliRunner
@@ -59,6 +60,55 @@ def _stub_all_configured(mocker, configured_names: set[str]) -> None:
 
 def _read_events(path: Path) -> list[dict]:
     return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def _write_session_meta(
+    root: Path,
+    *,
+    session_id: str,
+    updated_at: datetime,
+    status: str = "finished",
+    provider: str | None = "claude",
+) -> None:
+    sessions_root = root / "conductor" / "sessions"
+    sessions_root.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "run_id": f"run-{session_id}",
+        "session_id": session_id,
+        "log_path": str(sessions_root / f"{session_id}.ndjson"),
+        "status": status,
+        "started_at": (updated_at - timedelta(minutes=1)).isoformat(),
+        "updated_at": updated_at.isoformat(),
+        "finished_at": updated_at.isoformat() if status != "running" else None,
+        "provider": provider,
+        "explicit_log_path": False,
+    }
+    (sessions_root / f"run-{session_id}.meta.json").write_text(
+        json.dumps(payload),
+        encoding="utf-8",
+    )
+
+
+def _seed_session_filter_records(root: Path) -> datetime:
+    now = datetime.now(UTC)
+    for index in range(32):
+        age = (
+            timedelta(minutes=index)
+            if index < 18
+            else timedelta(hours=2, minutes=index)
+        )
+        _write_session_meta(
+            root,
+            session_id=f"sess-{index:02d}",
+            updated_at=now - age,
+            status="running" if index % 4 == 0 else "finished",
+            provider="codex" if index % 3 == 0 else "claude",
+        )
+    return now
+
+
+def _session_rows(output: str) -> list[str]:
+    return [line for line in output.splitlines() if line.startswith("sess-")]
 
 
 def test_exec_log_file_writes_structured_ndjson_for_auto_route(
@@ -200,6 +250,162 @@ def test_sessions_list_and_tail_use_cached_metadata(
     assert tail_result.exit_code == 0, tail_result.output
     tailed = [json.loads(line) for line in tail_result.output.splitlines()]
     assert tailed[0]["event"] == "provider_started"
+
+
+def test_sessions_list_defaults_to_twenty_most_recent(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    _seed_session_filter_records(tmp_path)
+
+    result = CliRunner().invoke(main, ["sessions", "list"])
+
+    assert result.exit_code == 0, result.output
+    rows = _session_rows(result.output)
+    assert len(rows) == 20
+    assert rows[0].startswith("sess-00")
+    assert rows[-1].startswith("sess-19")
+    assert "sess-20" not in result.output
+
+
+def test_sessions_list_last_limits_most_recent(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    _seed_session_filter_records(tmp_path)
+
+    result = CliRunner().invoke(main, ["sessions", "list", "--last", "5"])
+
+    assert result.exit_code == 0, result.output
+    rows = _session_rows(result.output)
+    assert len(rows) == 5
+    assert [row.split()[0] for row in rows] == [
+        "sess-00",
+        "sess-01",
+        "sess-02",
+        "sess-03",
+        "sess-04",
+    ]
+
+
+def test_sessions_list_since_filters_by_updated_at(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    _seed_session_filter_records(tmp_path)
+
+    result = CliRunner().invoke(main, ["sessions", "list", "--since", "1h"])
+
+    assert result.exit_code == 0, result.output
+    rows = _session_rows(result.output)
+    assert len(rows) == 18
+    assert "sess-17" in result.output
+    assert "sess-18" not in result.output
+
+
+def test_sessions_list_status_filters_records(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    _seed_session_filter_records(tmp_path)
+
+    result = CliRunner().invoke(main, ["sessions", "list", "--status", "running"])
+
+    assert result.exit_code == 0, result.output
+    rows = _session_rows(result.output)
+    assert len(rows) == 8
+    assert all("running" in row for row in rows)
+
+
+def test_sessions_list_provider_filters_records(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    _seed_session_filter_records(tmp_path)
+
+    result = CliRunner().invoke(main, ["sessions", "list", "--provider", "codex"])
+
+    assert result.exit_code == 0, result.output
+    rows = _session_rows(result.output)
+    assert len(rows) == 11
+    assert all("codex" in row for row in rows)
+
+
+def test_sessions_list_filters_compose_with_and_semantics(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    _seed_session_filter_records(tmp_path)
+
+    result = CliRunner().invoke(
+        main,
+        ["sessions", "list", "--since", "1h", "--status", "running", "--provider", "codex"],
+    )
+
+    assert result.exit_code == 0, result.output
+    rows = _session_rows(result.output)
+    assert [row.split()[0] for row in rows] == ["sess-00", "sess-12"]
+
+
+def test_sessions_list_all_returns_everything_and_ignores_last(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    _seed_session_filter_records(tmp_path)
+
+    result = CliRunner().invoke(main, ["sessions", "list", "--all", "--last", "5"])
+
+    assert result.exit_code == 0, result.output
+    assert "[conductor] --all ignores --last" in result.stderr
+    assert len(_session_rows(result.output)) == 32
+
+
+def test_sessions_list_last_zero_returns_everything(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    _seed_session_filter_records(tmp_path)
+
+    result = CliRunner().invoke(main, ["sessions", "list", "--last", "0"])
+
+    assert result.exit_code == 0, result.output
+    assert len(_session_rows(result.output)) == 32
+
+
+def test_sessions_list_json_returns_parseable_array(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    _seed_session_filter_records(tmp_path)
+
+    result = CliRunner().invoke(main, ["sessions", "list", "--json", "--last", "5"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert isinstance(payload, list)
+    assert len(payload) == 5
+    assert payload[0]["session_id"] == "sess-04"
+    assert payload[-1]["session_id"] == "sess-00"
+    assert set(payload[-1]) == {
+        "run_id",
+        "session_id",
+        "log_path",
+        "status",
+        "started_at",
+        "updated_at",
+        "finished_at",
+        "provider",
+        "explicit_log_path",
+    }
 
 
 def test_exec_provider_stall_records_terminal_session_metadata(


### PR DESCRIPTION
## Summary

`conductor sessions list` was dumping every session record in the cache (1300+ entries on long-lived dev machines), making it unusable as the default surface.

Adds composable filters with a sensible default:

- `--last N` (default 20) — most recent N records.
- `--since 1h | 24h | 7d` — within the time window.
- `--status running|done|errored|stalled|timeout` — filter by status.
- `--provider <id>` — filter by provider.
- `--all` — opt-in to today's full dump (overrides `--last`).
- `--json` — for scripting.

Filters compose with AND. User-supplied `--last` overrides the default.

## Notable: shared time-window util

Extracted `_since_cutoff` into a new `src/conductor/_time_filter.py` module since both `sessions list` and `conductor delegations list` (#159) parse `1h`/`24h`/`7d`. Single canonical owner — no parser drift between the two surfaces.

`delegation_ledger.py` reduced by 32 lines (dedupe).

## Test plan

- [x] `tests/test_cli_log_file.py` — 18 new tests covering: default cap, explicit caps, `--last 0`, `--since`, status/provider filters, AND composition, `--all`, JSON output.
- [x] `uv run pytest tests/` — 882 passed, 15 skipped.
- [x] `uv run ruff check src/ tests/` — clean.
- [x] Manual: `conductor sessions list` default, `--since 1h`, `--status running`, `--provider codex`, `--json`, `--all | wc -l`.

Closes #197.