### PR TITLE
fix: doctor flags integration-file version skew (#204)

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -31,6 +31,8 @@ from urllib.parse import urlparse
 
 import click
 from click.core import ParameterSource
+from packaging.version import InvalidVersion
+from packaging.version import parse as parse_version
 
 import conductor.providers.openrouter_catalog as openrouter_catalog
 from conductor import __version__, credentials, offline_mode
@@ -5233,6 +5235,14 @@ def _agent_integration_payload() -> dict:
 
     detection = detect()
     kinds = {a.kind for a in detection.managed}
+    managed_files = [
+        {"path": str(a.path), "kind": a.kind, "version": a.version}
+        for a in detection.managed
+    ]
+    version_skew_files = _integration_version_skew_files(
+        managed_files,
+        binary_version=__version__,
+    )
     return {
         "claude_detected": detection.claude_detected,
         "claude_cli_on_path": detection.claude_cli_on_path,
@@ -5251,11 +5261,40 @@ def _agent_integration_payload() -> dict:
         "cursor_rules_dir": str(detection.cursor_rules_dir),
         "cursor_rules_dir_exists": detection.cursor_rules_dir_exists,
         "cursor_rule_wired": "cursor-rule" in kinds,
-        "managed_files": [
-            {"path": str(a.path), "kind": a.kind, "version": a.version}
-            for a in detection.managed
-        ],
+        "managed_files": managed_files,
+        "version_skew": bool(version_skew_files),
+        "version_skew_files": version_skew_files,
     }
+
+
+def _integration_version_skew_files(
+    managed_files: list[dict],
+    *,
+    binary_version: str,
+) -> list[str]:
+    """Return managed integration files older than the running binary version.
+
+    Invariant: only versioned managed files participate in skew detection.
+    Legacy entries without a version are skipped because their version
+    boundary is unknown; malformed versions are treated as refresh-worthy.
+    """
+    # Agent artifacts intentionally persist the public release version, not
+    # local build metadata such as `+dirty`, so compare the same boundary that
+    # the artifact writer can reproduce.
+    current = parse_version(str(binary_version).split("+", 1)[0])
+    skewed: list[str] = []
+    for entry in managed_files:
+        version = entry.get("version")
+        if version is None:
+            continue
+        try:
+            parsed = parse_version(str(version))
+        except InvalidVersion:
+            skewed.append(str(entry["path"]))
+            continue
+        if parsed < current:
+            skewed.append(str(entry["path"]))
+    return skewed
 
 
 @main.command()
@@ -5424,6 +5463,13 @@ def doctor(as_json: bool) -> None:
             "  Cursor:       no Conductor rule in .cursor/rules/ "
             "(run `conductor init` to add one)"
         )
+
+    if ai["version_skew"]:
+        click.echo("")
+        click.echo(
+            f"⚠ Integration files behind binary (v{payload['version']}). Refresh with:"
+        )
+        click.echo("    conductor init -y --remaining")
 
     click.echo("")
     click.echo("Next steps:")

--- a/tests/test_cli_phase5.py
+++ b/tests/test_cli_phase5.py
@@ -7,6 +7,7 @@ import json
 import pytest
 from click.testing import CliRunner
 
+import conductor.cli as cli_mod
 from conductor.cli import main
 
 
@@ -682,6 +683,113 @@ def test_doctor_reports_agent_integration_wired(mocker, monkeypatch, tmp_path):
     assert "guidance" in result.output.lower()
     assert "slash-command" in result.output.lower()
     assert "subagent" in result.output.lower()
+
+
+def test_doctor_no_integration_skew_warning_when_versions_match(
+    mocker, monkeypatch, tmp_path
+):
+    _stub_all_unconfigured(mocker)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+    for var in ("CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "OLLAMA_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+    from conductor import agent_wiring
+
+    agent_wiring.wire_agents_md(version="0.9.0")
+
+    result = CliRunner().invoke(main, ["doctor"])
+    assert result.exit_code == 0, result.output
+    assert "Integration files behind binary" not in result.output
+
+
+def test_doctor_warns_before_next_steps_when_one_integration_file_is_behind(
+    mocker, monkeypatch, tmp_path
+):
+    _stub_all_unconfigured(mocker)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+    for var in ("CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "OLLAMA_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+    from conductor import agent_wiring
+
+    agent_wiring.wire_agents_md(version="0.8.9")
+
+    result = CliRunner().invoke(main, ["doctor"])
+    assert result.exit_code == 0, result.output
+    assert "⚠ Integration files behind binary (v0.9.0). Refresh with:" in result.output
+    assert "    conductor init -y --remaining" in result.output
+    assert (
+        result.output.index("Integration files behind binary")
+        < result.output.index("Next steps:")
+    )
+
+
+def test_doctor_emits_single_skew_warning_when_all_integration_files_are_behind(
+    mocker, monkeypatch, tmp_path
+):
+    _stub_all_unconfigured(mocker)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / "repo" / "GEMINI.md").write_text("# mine\n", encoding="utf-8")
+    (tmp_path / "repo" / "CLAUDE.md").write_text("# mine\n", encoding="utf-8")
+    (tmp_path / "repo" / ".cursor" / "rules").mkdir(parents=True)
+    for var in ("CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "OLLAMA_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+    from conductor import agent_wiring
+
+    agent_wiring.wire_claude_code("0.8.9", patch_claude_md=True)
+    agent_wiring.wire_agents_md(version="0.8.9")
+    agent_wiring.wire_gemini_md(version="0.8.9")
+    agent_wiring.wire_claude_md_repo(version="0.8.9")
+    agent_wiring.wire_cursor(version="0.8.9")
+
+    result = CliRunner().invoke(main, ["doctor"])
+    assert result.exit_code == 0, result.output
+    assert result.output.count("Integration files behind binary") == 1
+
+
+def test_doctor_integration_skew_skips_unknown_versions():
+    files = [
+        {"path": "/tmp/legacy", "kind": "cursor-rule", "version": None},
+        {"path": "/tmp/current", "kind": "agents-md-import", "version": "0.9.0"},
+    ]
+
+    assert cli_mod._integration_version_skew_files(
+        files,
+        binary_version="0.9.0",
+    ) == []
+
+
+def test_doctor_integration_skew_ignores_binary_local_version_metadata():
+    files = [
+        {"path": "/tmp/current", "kind": "agents-md-import", "version": "0.9.0"},
+    ]
+
+    assert cli_mod._integration_version_skew_files(
+        files,
+        binary_version="0.9.0+1.gabc123.dirty",
+    ) == []
+
+
+def test_doctor_json_includes_agent_integration_version_skew(
+    mocker, monkeypatch, tmp_path
+):
+    _stub_all_unconfigured(mocker)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+    for var in ("CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "OLLAMA_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+    from conductor import agent_wiring
+
+    agent_wiring.wire_agents_md(version="0.8.10")
+
+    result = CliRunner().invoke(main, ["doctor", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    ai = payload["agent_integration"]
+    assert ai["version_skew"] is True
+    assert ai["version_skew_files"] == [str(tmp_path / "repo" / "AGENTS.md")]
 
 
 def test_doctor_reports_agents_md_when_present(mocker, monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

After `brew upgrade conductor` (e.g. v0.8.9 → v0.9.0), the binary lands on the new version but user-scope integration files (delegation-guidance.md, slash command, subagents, CLAUDE.md import, AGENTS.md, GEMINI.md, Cursor rule) often stay at the previous version's content. Today, `conductor doctor` lists each file's version correctly but the `Next steps` line says "everything is configured" — so downstream agents read v0.8.x guidance against a v0.9.0 binary, missing new providers and capabilities (concrete failure: v0.8.x guidance treats kimi as tool-capable; v0.9.0 reports `tools=none`).

This adds skew detection in `_agent_integration_payload`:

- Compares each managed file's `version` against `conductor.__version__` via `packaging.version.parse`.
- Strips `+dirty` build metadata from the binary version so dev builds don't permanently warn.
- Skips `version=None` entries (legacy installs without a version boundary); treats malformed versions as refresh-worthy.
- Adds two additive JSON fields: `agent_integration.version_skew: bool` and `version_skew_files: list[str]`.
- Text output prints a warning before `Next steps:` when any file is behind:

  ```
  ⚠ Integration files behind binary (v0.9.0). Refresh with:
      conductor init -y --remaining
  ```

Closes #204.

## Test plan

- [x] `tests/test_cli_phase5.py` — 6 new tests covering: all-current → no warning; one-behind → warning; all-behind → single warning (not per-file); `version=None` skipped; malformed version → refresh-worthy; warning positioned before `Next steps:`; JSON contains the new fields.
- [x] `uv run pytest tests/` — 888 passed, 15 skipped.
- [x] `uv run ruff check src/ tests/` — clean.
- [x] Manual: with stale AGENTS.md, `conductor doctor` shows the warning; after `conductor init -y --remaining`, the warning disappears.