### PR TITLE
chore: verify caller-detection env footprints (#202)

### DIFF
--- a/src/conductor/banner.py
+++ b/src/conductor/banner.py
@@ -135,10 +135,10 @@ _CALLER_REGISTRY: tuple[tuple[str, str], ...] = (
     ("CLAUDECODE", "Claude Code"),     # verified
     ("SENTINEL", "Sentinel"),          # convention (autumn-garage peer)
     ("TOUCHSTONE", "Touchstone"),      # convention (autumn-garage peer)
-    # ("CURSOR_AGENT", "Cursor"),      # TODO: verify env footprint
-    # ("AIDER_AGENT", "Aider"),        # TODO: verify env footprint
-    # ("CODEX_CLI", "Codex CLI"),      # TODO: verify env footprint
-    # ("GEMINI_CLI", "Gemini CLI"),    # TODO: verify env footprint
+    ("CURSOR_AGENT", "Cursor"),        # verified — Cursor docs: Agent shell marker
+    ("CODEX_THREAD_ID", "Codex CLI"),  # verified — openai/codex injects it into shell tool env
+    ("GEMINI_CLI", "Gemini CLI"),      # verified — gemini-cli sets GEMINI_CLI=1 for shell
+    # ("AIDER_AGENT", "Aider"),        # not verified — shell commands inherit env only
 )
 
 

--- a/tests/test_banner.py
+++ b/tests/test_banner.py
@@ -119,6 +119,17 @@ def test_detect_caller_returns_claude_code_when_claudecode_set(monkeypatch):
     assert detect_caller() == "Claude Code"
 
 
+def test_detect_caller_returns_verified_external_callers(monkeypatch):
+    for env_var, caller_name in (
+        ("CURSOR_AGENT", "Cursor"),
+        ("CODEX_THREAD_ID", "Codex CLI"),
+        ("GEMINI_CLI", "Gemini CLI"),
+    ):
+        _strip_caller_env(monkeypatch)
+        monkeypatch.setenv(env_var, "1")
+        assert detect_caller() == caller_name
+
+
 def test_detect_caller_first_match_wins(monkeypatch):
     """When multiple markers are set, the registry's order decides."""
     _strip_caller_env(monkeypatch)
@@ -126,6 +137,14 @@ def test_detect_caller_first_match_wins(monkeypatch):
     monkeypatch.setenv("SENTINEL", "1")
     # Registry orders Claude Code before Sentinel; verify that holds.
     assert detect_caller() == "Claude Code"
+
+
+def test_detect_caller_first_match_wins_for_external_callers(monkeypatch):
+    _strip_caller_env(monkeypatch)
+    monkeypatch.setenv("GEMINI_CLI", "1")
+    monkeypatch.setenv("CODEX_THREAD_ID", "thread-id")
+    monkeypatch.setenv("CURSOR_AGENT", "1")
+    assert detect_caller() == "Cursor"
 
 
 def test_print_caller_banner_named_caller_is_attributed(monkeypatch):


### PR DESCRIPTION
## Summary

Resolves the four `# TODO: verify env footprint` comments in `banner.py` by checking each tool's actual source/docs:

- **Cursor** → enabled. `CURSOR_AGENT` (from public Cursor docs: Agent terminal marker).
- **Codex CLI** → enabled. `CODEX_THREAD_ID` (from openai/codex source — injects this into shell-tool env). **Note: differs from the speculative `CODEX_CLI` that was commented out.**
- **Gemini CLI** → enabled. `GEMINI_CLI=1` (from gemini-cli source).
- **Aider** → stays commented. Aider spawns subprocesses with inherited env only; no stable Aider-specific marker found in public source.

Each enabled entry has an inline `# verified — <evidence>` comment. The not-verified Aider entry has a `# not verified — <reason>` comment documenting the decline.

Closes #202.

## Test plan

- [x] `tests/test_banner.py` — 2 new tests: each verified env var resolves to the right caller; order-precedence among external callers.
- [x] `uv run pytest tests/` — 890 passed, 15 skipped.
- [x] `uv run ruff check src/ tests/` — clean.