### PR TITLE
refactor: move provider endpoint URLs into adapters (#201)

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -151,17 +151,6 @@ DEFAULT_COUNCIL_TIMEOUT_SEC = 180
 DEFAULT_COUNCIL_MAX_OUTPUT_TOKENS = 6_000
 DEFAULT_COUNCIL_MAX_COST_USD = 0.25
 ESTIMATED_CHARS_PER_TOKEN = 4
-PROVIDER_NETWORK_TARGETS: dict[str, str] = {
-    # TODO(#147 follow-up): move these into provider-owned helpers once the
-    # endpoint contract settles; keep the Provider Protocol narrow for now.
-    "claude": "https://api.anthropic.com",
-    "codex": "https://api.openai.com",
-    "deepseek-chat": "https://openrouter.ai/api/v1/models",
-    "deepseek-reasoner": "https://openrouter.ai/api/v1/models",
-    "gemini": "https://generativelanguage.googleapis.com",
-    "kimi": "https://openrouter.ai/api/v1/models",
-    "openrouter": "https://openrouter.ai/api/v1/models",
-}
 
 
 @dataclass(frozen=True)
@@ -195,7 +184,7 @@ def _network_target_for_provider(provider_id: str | None) -> str | None:
         return os.environ.get("OLLAMA_BASE_URL") or "http://localhost:11434"
     if provider_id is None:
         return NETWORK_PROFILE_FALLBACK_TARGET
-    return PROVIDER_NETWORK_TARGETS.get(provider_id)
+    return get_provider(provider_id).endpoint_url()
 
 
 def _network_profile_warning(message: str) -> None:

--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -115,6 +115,9 @@ class ClaudeProvider:
         )
         self._exec_first_output_timeout_sec = exec_first_output_timeout_sec
 
+    def endpoint_url(self) -> str | None:
+        return "https://api.anthropic.com"
+
     def _check_cli_path(self) -> tuple[bool, str | None]:
         """Cheap PATH-only check (no subprocess). Used by call()/exec()
         for the defensive guard so the hot path doesn't take an auth-probe

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -203,6 +203,9 @@ class CodexProvider:
         self._timeout_sec = timeout_sec
         self._startup_probe_timeout_sec = startup_probe_timeout_sec
 
+    def endpoint_url(self) -> str | None:
+        return "https://api.openai.com"
+
     def _check_cli_path(self) -> tuple[bool, str | None]:
         """Cheap PATH-only check (no subprocess) for the call/exec hot path."""
         if not shutil.which(self._cli):

--- a/src/conductor/providers/gemini.py
+++ b/src/conductor/providers/gemini.py
@@ -148,6 +148,9 @@ class GeminiProvider:
             else GEMINI_DEFAULT_OAUTH_CREDS_PATH
         )
 
+    def endpoint_url(self) -> str | None:
+        return "https://generativelanguage.googleapis.com"
+
     def _check_cli_path(self) -> tuple[bool, str | None]:
         """Cheap PATH-only check (no subprocess) for the call/exec hot path."""
         if not shutil.which(self._cli):

--- a/src/conductor/providers/interface.py
+++ b/src/conductor/providers/interface.py
@@ -20,6 +20,7 @@ Capability declarations (v0.2):
   - supports_effort         — whether the provider has a thinking/reasoning dial
   - supports_image_attachments — whether the provider can accept image file attachments
                                  alongside the brief (today: codex only)
+  - endpoint_url           — HTTPS URL whose RTT represents provider network path
   - effort_to_thinking      — mapping from symbolic effort level to expected thinking tokens
   - cost_per_1k_in/out/thinking — for prefer=cheapest scoring
   - typical_p50_ms          — for prefer=fastest scoring
@@ -213,6 +214,15 @@ class Provider(Protocol):
         their transport.
         """
         raise NotImplementedError
+
+    def endpoint_url(self) -> str | None:
+        """Return the HTTPS URL whose RTT represents this provider's
+        network path.
+
+        Used by the slow-network scaler. Return None if the provider has no
+        single canonical network endpoint, such as local-only providers.
+        """
+        return None
 
     def call(
         self,

--- a/src/conductor/providers/ollama.py
+++ b/src/conductor/providers/ollama.py
@@ -239,6 +239,9 @@ class OllamaProvider:
             or OLLAMA_DEFAULT_BASE_URL
         ).rstrip("/")
 
+    def endpoint_url(self) -> str | None:
+        return None
+
     def resolved_default_model(self) -> str:
         """Return the host-local default model Conductor will send to Ollama."""
         return _clean_model_name(os.environ.get(OLLAMA_MODEL_ENV)) or self.default_model

--- a/src/conductor/providers/openrouter.py
+++ b/src/conductor/providers/openrouter.py
@@ -98,6 +98,9 @@ class OpenRouterProvider:
         self._base_url = base_url.rstrip("/")
         self._timeout_sec = timeout_sec
 
+    def endpoint_url(self) -> str | None:
+        return f"{self._base_url}/models"
+
     def _resolve_key(self) -> str:
         key = self._api_key or credentials.get(OPENROUTER_API_KEY_ENV)
         if not key:

--- a/src/conductor/providers/shell.py
+++ b/src/conductor/providers/shell.py
@@ -139,6 +139,9 @@ class ShellProvider:
     def typical_p50_ms(self) -> int:
         return self._spec.typical_p50_ms
 
+    def endpoint_url(self) -> str | None:
+        return None
+
     # --- liveness checks --------------------------------------------------- #
 
     def configured(self) -> tuple[bool, str | None]:

--- a/tests/test_cli_delegation_ledger.py
+++ b/tests/test_cli_delegation_ledger.py
@@ -41,6 +41,9 @@ class FakeProvider:
     def health_probe(self, timeout_sec: float = 30.0):
         return True, None
 
+    def endpoint_url(self):
+        return None
+
 
 class FakeCouncilProvider:
     def __init__(self):

--- a/tests/test_network_profile.py
+++ b/tests/test_network_profile.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import httpx
 from click.testing import CliRunner
 
-from conductor.cli import main
+from conductor.cli import _network_target_for_provider, main
 from conductor.network_profile import (
     NETWORK_PROFILE_FALLBACK_TARGET,
     NETWORK_PROFILE_TTL_SEC,
@@ -15,7 +15,13 @@ from conductor.network_profile import (
     get_network_profile,
     scaling_multiplier,
 )
-from conductor.providers import CallResponse, CodexProvider
+from conductor.providers import (
+    CallResponse,
+    CodexProvider,
+    ShellProvider,
+    ShellProviderSpec,
+    get_provider,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -47,6 +53,17 @@ class _FakeClient:
         return httpx.Response(204)
 
 
+EXPECTED_ENDPOINT_URLS = {
+    "claude": "https://api.anthropic.com",
+    "codex": "https://api.openai.com",
+    "deepseek-chat": "https://openrouter.ai/api/v1/models",
+    "deepseek-reasoner": "https://openrouter.ai/api/v1/models",
+    "gemini": "https://generativelanguage.googleapis.com",
+    "kimi": "https://openrouter.ai/api/v1/models",
+    "openrouter": "https://openrouter.ai/api/v1/models",
+}
+
+
 def _install_fake_probe(monkeypatch, perf_values: list[float]) -> None:
     monkeypatch.setattr("conductor.network_profile.httpx.Client", _FakeClient)
     monkeypatch.setattr(
@@ -54,6 +71,34 @@ def _install_fake_probe(monkeypatch, perf_values: list[float]) -> None:
         lambda: perf_values.pop(0),
     )
     monkeypatch.setattr("conductor.network_profile.time.monotonic", lambda: 10.0)
+
+
+def test_provider_endpoint_urls_are_adapter_owned() -> None:
+    for provider_id, expected in EXPECTED_ENDPOINT_URLS.items():
+        assert get_provider(provider_id).endpoint_url() == expected
+
+    assert get_provider("ollama").endpoint_url() is None
+    assert (
+        ShellProvider(ShellProviderSpec(name="local-shell", shell="printf ok"))
+        .endpoint_url()
+        is None
+    )
+
+
+def test_network_target_for_provider_delegates_to_provider_endpoint() -> None:
+    for provider_id in EXPECTED_ENDPOINT_URLS:
+        provider = get_provider(provider_id)
+        assert _network_target_for_provider(provider_id) == provider.endpoint_url()
+
+    assert _network_target_for_provider(None) == NETWORK_PROFILE_FALLBACK_TARGET
+
+
+def test_network_target_for_ollama_keeps_local_base_url(monkeypatch) -> None:
+    monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+    assert _network_target_for_provider("ollama") == "http://localhost:11434"
+
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://ollama.internal:11434")
+    assert _network_target_for_provider("ollama") == "http://ollama.internal:11434"
 
 
 def test_cache_hit_reuses_fresh_profile(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Folds the CLI-side `PROVIDER_NETWORK_TARGETS` dict (added as a v1 shortcut in #147) into provider-owned helpers. Each adapter now declares its own network endpoint URL, eliminating the duplicate source of truth that future provider authors would inevitably forget to update.

- Adds `Provider.endpoint_url() -> str | None` to the Provider Protocol.
- Each adapter implements it: claude, codex, gemini → their respective HTTPS APIs; openrouter, kimi, deepseek* → openrouter.ai endpoint (shared via the OpenRouter transport); ollama → None (local-only, no useful network probe target).
- `_network_target_for_provider` in cli.py becomes a thin wrapper around `provider.endpoint_url()`.
- `PROVIDER_NETWORK_TARGETS` and the `# TODO(#147 follow-up)` comment deleted.

Closes #201.

## Test plan

- [x] New tests: each adapter's `endpoint_url()` returns the expected URL (or None for ollama).
- [x] Test fakes (delegation_ledger, etc.) updated to satisfy the new Protocol method.
- [x] `uv run pytest tests/` — 891 passed, 15 skipped.
- [x] `uv run ruff check src/ tests/` — clean.
- [x] `uv run mypy src/conductor/cli.py` — clean.
- [x] `grep -RnE "PROVIDER_NETWORK_TARGETS" src/ tests/` — zero matches.