### PR TITLE
fix: cap OpenRouter models array at 3 (#206)

### DIFF
--- a/src/conductor/providers/openrouter.py
+++ b/src/conductor/providers/openrouter.py
@@ -41,6 +41,9 @@ OPENROUTER_DEFAULT_MODEL = "openrouter/auto"
 OPENROUTER_REQUEST_TIMEOUT_SEC = 120.0
 OPENROUTER_HEALTH_PROBE_TIMEOUT_SEC = 10.0
 OPENROUTER_MAX_TOOL_ITERATIONS = 10
+# OpenRouter's chat completions API accepts at most three entries in the
+# request-level `models` array.
+OPENROUTER_MODELS_ARRAY_MAX = 3
 OPENROUTER_HTTP_REFERER = "https://github.com/autumngarage/conductor"
 OPENROUTER_X_TITLE = "conductor"
 
@@ -221,7 +224,7 @@ class OpenRouterProvider:
         )
         payload: dict = {}
         if ordered_models:
-            payload["models"] = list(ordered_models)
+            payload["models"] = _openrouter_models_wire_list(ordered_models)
             selected_model = ordered_models[0]
             reasoning = self._reasoning_payload(effort)
             if reasoning is not None:
@@ -241,6 +244,7 @@ class OpenRouterProvider:
             )
             payload.update(selector_payload)
             if "models" in payload:
+                payload["models"] = _openrouter_models_wire_list(payload["models"])
                 selected_model = str(payload["models"][0])
             else:
                 selected_model = str(payload["model"])
@@ -250,7 +254,7 @@ class OpenRouterProvider:
                 _log_selector_choice(
                     task_tags=task_tags,
                     prefer=prefer,
-                    payload=selector_payload,
+                    payload=payload,
                 )
         else:
             payload["model"] = selected_model
@@ -926,6 +930,10 @@ def _reasoning_payload(effort: str | int) -> dict[str, str] | None:
     if mapped is None:
         return None
     return {"effort": mapped}
+
+
+def _openrouter_models_wire_list(models: tuple[str, ...] | list[str]) -> list[str]:
+    return list(models[:OPENROUTER_MODELS_ARRAY_MAX])
 
 
 def _log_selector_choice(

--- a/tests/test_openrouter.py
+++ b/tests/test_openrouter.py
@@ -17,6 +17,7 @@ from conductor.providers.interface import (
     ProviderConfigError,
     ProviderError,
     ProviderExecutionError,
+    ProviderHTTPError,
     UnsupportedCapability,
 )
 from conductor.providers.kimi import KimiProvider
@@ -24,6 +25,7 @@ from conductor.providers.openrouter import (
     OPENROUTER_API_KEY_ENV,
     OPENROUTER_DEFAULT_MODEL,
     OPENROUTER_MAX_TOOL_ITERATIONS,
+    OPENROUTER_MODELS_ARRAY_MAX,
     OpenRouterProvider,
 )
 
@@ -263,15 +265,25 @@ def test_call_sends_ordered_models_stack(configured):
         router.post("/chat/completions").mock(side_effect=_record)
         OpenRouterProvider().call(
             "hi",
-            models=("google/gemini-flash-latest", "moonshotai/kimi-k2.6"),
+            models=(
+                "google/gemini-flash-latest",
+                "moonshotai/kimi-k2.6",
+                "openai/gpt-5.5",
+                "anthropic/claude-sonnet-4.6",
+            ),
             effort="low",
         )
 
     assert captured["payload"] == {
-        "models": ["google/gemini-flash-latest", "moonshotai/kimi-k2.6"],
+        "models": [
+            "google/gemini-flash-latest",
+            "moonshotai/kimi-k2.6",
+            "openai/gpt-5.5",
+        ],
         "messages": [{"role": "user", "content": "hi"}],
         "reasoning": {"effort": "low"},
     }
+    assert len(captured["payload"]["models"]) <= OPENROUTER_MODELS_ARRAY_MAX
 
 
 def test_call_rejects_model_and_models_together(configured):
@@ -508,7 +520,10 @@ def test_exec_with_tools_uses_curated_coding_stack_by_default(configured, tmp_pa
         )
 
     assert response.model == OPENROUTER_CODING_HIGH[0]
-    assert captured["payload"]["models"] == list(OPENROUTER_CODING_HIGH)
+    assert captured["payload"]["models"] == list(
+        OPENROUTER_CODING_HIGH[:OPENROUTER_MODELS_ARRAY_MAX]
+    )
+    assert len(captured["payload"]["models"]) <= OPENROUTER_MODELS_ARRAY_MAX
     assert "model" not in captured["payload"]
     assert "openrouter/auto" not in captured["payload"]["models"]
     assert "google/gemini-2.5-flash-lite" not in captured["payload"]["models"]
@@ -550,8 +565,41 @@ def test_exec_with_tools_and_balanced_prefer_uses_curated_coding_stack(
         )
 
     assert response.model == OPENROUTER_CODING_HIGH[0]
-    assert captured["payload"]["models"] == list(OPENROUTER_CODING_HIGH)
+    assert captured["payload"]["models"] == list(
+        OPENROUTER_CODING_HIGH[:OPENROUTER_MODELS_ARRAY_MAX]
+    )
     assert "model" not in captured["payload"]
+
+
+def test_openrouter_models_array_cap_error_is_clear(configured):
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.post("/chat/completions").mock(
+            return_value=httpx.Response(
+                400,
+                json={
+                    "error": {
+                        "message": "'models' array must have 3 items or fewer.",
+                        "code": 400,
+                    }
+                },
+            )
+        )
+        with pytest.raises(ProviderHTTPError) as excinfo:
+            OpenRouterProvider().call(
+                "hi",
+                models=(
+                    "openai/gpt-5.3-codex",
+                    "openai/gpt-5.5",
+                    "anthropic/claude-sonnet-4.6",
+                    "google/gemini-3.1-pro-preview",
+                ),
+            )
+
+    message = str(excinfo.value)
+    assert "OpenRouter provider failed locally after upstream HTTP 400" in message
+    assert "'models' array must have 3 items or fewer" in message
+    assert "request restrictions/models tried" in message
+    assert "openai/gpt-5.3-codex" in message
 
 
 def test_exec_code_task_no_tool_calls_raises_noop_status(configured, tmp_path):

--- a/tests/test_openrouter_selector.py
+++ b/tests/test_openrouter_selector.py
@@ -10,7 +10,11 @@ from conductor.openrouter_model_stacks import (
     OPENROUTER_CODING_MAX,
 )
 from conductor.providers.interface import ProviderError
-from conductor.providers.openrouter import OPENROUTER_DEFAULT_MODEL, select_model_for_task
+from conductor.providers.openrouter import (
+    OPENROUTER_DEFAULT_MODEL,
+    OPENROUTER_MODELS_ARRAY_MAX,
+    select_model_for_task,
+)
 
 
 @pytest.fixture
@@ -151,6 +155,9 @@ def test_tool_use_best_and_balanced_use_curated_coding_stack_without_catalog(
     payload = select_model_for_task(["tool-use", "strong-reasoning"], prefer, effort)
 
     assert payload["models"] == list(expected_stack)
+    assert payload["models"][:OPENROUTER_MODELS_ARRAY_MAX] == list(
+        expected_stack[:OPENROUTER_MODELS_ARRAY_MAX]
+    )
     assert payload["models"][0] == "openai/gpt-5.3-codex"
     assert any(model.startswith("openai/") for model in payload["models"])
     assert any(model.startswith("anthropic/") for model in payload["models"])


### PR DESCRIPTION
## Summary

OpenRouter's chat-completions API caps the request-level `models` array at 3 items. Conductor was sending up to 6 (the curated coding stack). The result for any operator on `--kind code --effort high` whose codex provider was busy / in cooldown:

\`\`\`
upstream response: {\"error\":{\"message\":\"'models' array must have 3 items or fewer.\",\"code\":400}}
\`\`\`

…and after #191 b2 there's no ollama fallback, so the operator was stuck.

- Named constant `OPENROUTER_MODELS_ARRAY_MAX = 3` (with a comment citing the API contract).
- Small `_openrouter_models_wire_list` helper truncates the wire-format array.
- Applied at BOTH payload-build sites: explicit `models=` and selector-produced curated stacks.
- Internal candidate-list ordering preserved — caps the wire boundary, not the planning layer.

Closes #206.

## Test plan

- [x] New tests assert: `len(payload[\"models\"]) <= 3`; first-three ordering preserved; internal stack ordering retained for non-wire consumers; mocked OR HTTP 400 surfaces clearly.
- [x] `uv run pytest tests/` — 894 passed, 15 skipped.
- [x] `uv run ruff check src/ tests/` — clean.
- [x] Manual: live OpenRouter route returns OK without HTTP 400.