### PR TITLE
feat: brief preprocessor injects auto-close keywords (#211)

### DIFF
--- a/src/conductor/brief_preprocessor.py
+++ b/src/conductor/brief_preprocessor.py
@@ -1,0 +1,92 @@
+"""Pure-string preprocessing for delegation briefs."""
+
+from __future__ import annotations
+
+import re
+
+AUTO_CLOSE_HEADER = "## Auto-close"
+
+# The verb list is intentionally narrow. These are the only contexts where the
+# delegate is explicitly being asked to complete work tied to an issue:
+# - fix/close/resolve: GitHub-recognized completion language or its imperative.
+# - address: project planning language that means the issue should be handled.
+# - for: common issue-scoped task phrasing, as in "work for #123".
+# - issue: only accepted when the issue reference is immediately followed by an
+#   action verb, so a bare mention like "see issue #123" does not auto-close.
+_ACTION_VERB = r"(?:fix(?:es)?|close(?:s)?|resolve(?:s)?|address(?:es)?)"
+_REF = r"(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?\#\d+"
+_FENCED_CODE_BLOCK_RE = re.compile(r"(?ms)^```.*?^```")
+_AUTO_CLOSE_HEADER_RE = re.compile(r"(?im)^##\s+Auto-close\s*$")
+_FULL_LINE_CLOSE_RE = re.compile(
+    r"(?im)^Closes\s+(?P<ref>(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#\d+)\s*\.?\s*$"
+)
+_ISSUE_REF_RE = re.compile(
+    rf"""
+    (?:
+        \b(?P<verb>{_ACTION_VERB})\b
+        (?:\s+issue)?
+        \s+
+        (?P<verb_ref>{_REF})
+    )
+    |
+    (?:
+        \b(?P<for>for)\b
+        \s+
+        (?P<for_ref>{_REF})
+    )
+    |
+    (?:
+        \b(?P<issue>issue)\b
+        \s+
+        (?P<issue_ref>{_REF})
+        (?=[\s,.;:)-]+\b(?P<after>{_ACTION_VERB})\b)
+    )
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
+def _brief_without_fenced_code(brief: str) -> str:
+    return _FENCED_CODE_BLOCK_RE.sub("", brief)
+
+
+def _detected_refs(brief: str) -> list[str]:
+    refs: list[str] = []
+    seen: set[str] = set()
+    for match in _ISSUE_REF_RE.finditer(_brief_without_fenced_code(brief)):
+        ref = match.group("verb_ref") or match.group("for_ref") or match.group("issue_ref")
+        key = ref.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        refs.append(ref)
+    return refs
+
+
+def _existing_full_line_closes(brief: str) -> set[str]:
+    return {match.group("ref").casefold() for match in _FULL_LINE_CLOSE_RE.finditer(brief)}
+
+
+def inject_auto_close(brief: str) -> str:
+    """Detect issue refs in a delegation brief and append explicit
+    auto-close instructions for the delegate to copy verbatim.
+    """
+    refs = _detected_refs(brief)
+    if not refs:
+        return brief
+    if _AUTO_CLOSE_HEADER_RE.search(brief):
+        return brief
+
+    existing_closes = _existing_full_line_closes(brief)
+    if all(ref.casefold() in existing_closes for ref in refs):
+        return brief
+
+    close_lines = "\n".join(f"Closes {ref}" for ref in refs)
+    section = (
+        f"{AUTO_CLOSE_HEADER}\n\n"
+        "When you open the pull request for this work, include the\n"
+        "following line(s) verbatim in the PR body (NOT just the title)\n"
+        "so GitHub's auto-close fires on merge:\n\n"
+        f"{close_lines}"
+    )
+    return f"{brief.rstrip()}\n\n{section}"

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -38,6 +38,7 @@ import conductor.providers.openrouter_catalog as openrouter_catalog
 from conductor import __version__, credentials, offline_mode
 from conductor._time_filter import parse_timestamp, since_cutoff
 from conductor.banner import print_caller_banner
+from conductor.brief_preprocessor import inject_auto_close
 from conductor.delegation_ledger import (
     DelegationEvent,
     DelegationStatus,
@@ -307,6 +308,20 @@ def _read_task(
             resolved.append(path.resolve())
         attachments = tuple(resolved)
     return BriefInput(body=body, source=source, attachments=attachments)
+
+
+def _with_auto_close_instructions(brief_input: BriefInput) -> BriefInput:
+    try:
+        body = inject_auto_close(brief_input.body)
+    except Exception as e:
+        click.echo(
+            f"[conductor] warning: could not preprocess auto-close instructions: {e}",
+            err=True,
+        )
+        return brief_input
+    if body == brief_input.body:
+        return brief_input
+    return replace(brief_input, body=body)
 
 
 def _warn_if_short_exec_brief(
@@ -2897,6 +2912,8 @@ def ask(
     )
     if plan.mode == "exec":
         _warn_if_short_exec_brief(brief_input, allow_short_brief=allow_short_brief)
+    if plan.mode not in {"review", "council"}:
+        brief_input = _with_auto_close_instructions(brief_input)
     body = brief_input.body
     attachments = brief_input.attachments
     estimated_input_tokens = _estimate_text_tokens(body)
@@ -4206,6 +4223,7 @@ def exec_cmd(
         brief_input,
         allow_short_brief=allow_short_brief,
     )
+    brief_input = _with_auto_close_instructions(brief_input)
     body = brief_input.body
     attachments = brief_input.attachments
     estimated_input_tokens = _estimate_text_tokens(body)

--- a/tests/test_brief_preprocessor.py
+++ b/tests/test_brief_preprocessor.py
@@ -1,0 +1,59 @@
+from conductor.brief_preprocessor import inject_auto_close
+
+
+def test_literal_closes_line_already_present_is_noop():
+    brief = "Implement the requested change.\n\nCloses #123"
+
+    assert inject_auto_close(brief) == brief
+
+
+def test_prose_closes_reference_injects_auto_close_section():
+    brief = "Implement the requested change. This closes #123 after merge."
+
+    processed = inject_auto_close(brief)
+
+    assert processed != brief
+    assert "## Auto-close" in processed
+    assert "Closes #123" in processed
+
+
+def test_multiple_fix_refs_inject_in_order():
+    processed = inject_auto_close("fixes #1, fixes #2")
+
+    assert processed.endswith("Closes #1\nCloses #2")
+
+
+def test_cross_repo_ref_is_preserved():
+    processed = inject_auto_close("Fix org/repo#5 in the delegated change.")
+
+    assert "Closes org/repo#5" in processed
+
+
+def test_no_ref_is_unchanged():
+    brief = "Implement the requested change without issue references."
+
+    assert inject_auto_close(brief) == brief
+
+
+def test_existing_auto_close_section_is_unchanged():
+    brief = "Fixes #123.\n\n## Auto-close\n\nCloses #123"
+
+    assert inject_auto_close(brief) == brief
+
+
+def test_verbs_match_case_insensitively():
+    processed = inject_auto_close("Fix #1. FIXES #2. Resolves #3.")
+
+    assert processed.endswith("Closes #1\nCloses #2\nCloses #3")
+
+
+def test_standalone_hash_ref_is_not_matched():
+    brief = "Look at #123 while making the requested change."
+
+    assert inject_auto_close(brief) == brief
+
+
+def test_code_block_content_is_not_matched():
+    brief = "Inspect this example:\n\n```python\n# 123\n# Fixes #456\n```\n"
+
+    assert inject_auto_close(brief) == brief

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -1497,6 +1497,31 @@ def test_exec_brief_file_reads_file(mocker, tmp_path):
     assert exec_mock.call_args.args[0].startswith("# Goal")
 
 
+def test_exec_injects_auto_close_instructions_into_provider_task(mocker):
+    _stub_all_configured(mocker, {"codex"})
+    exec_mock = mocker.patch.object(
+        CodexProvider, "exec", return_value=_fake_response("codex")
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--with",
+            "codex",
+            "--no-preflight",
+            "--allow-short-brief",
+            "--brief",
+            "Fixes #5. Do X.",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    task = exec_mock.call_args.args[0]
+    assert "## Auto-close" in task
+    assert "Closes #5" in task
+
+
 def test_exec_short_brief_warns_by_default(mocker):
     _stub_all_configured(mocker, {"codex"})
     mocker.patch.object(CodexProvider, "exec", return_value=_fake_response("codex"))
@@ -1997,6 +2022,34 @@ def test_ask_call_mode_routes_with_prompt_size_estimate(mocker):
     payload = json.loads(result.stdout)
     assert payload["route"]["estimated_input_tokens"] == 500
     assert payload["route"]["estimated_output_tokens"] == 500
+
+
+def test_ask_exec_mode_injects_auto_close_instructions_into_provider_task(mocker):
+    _stub_all_configured(mocker, {"codex"})
+    exec_mock = mocker.patch.object(
+        CodexProvider, "exec", return_value=_fake_response("codex")
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "ask",
+            "--kind",
+            "code",
+            "--effort",
+            "high",
+            "--no-preflight",
+            "--allow-short-brief",
+            "--brief",
+            "Fixes #5. Do X.",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    task = exec_mock.call_args.args[0]
+    assert "## Auto-close" in task
+    assert "Closes #5" in task
 
 
 def test_review_auto_route_includes_patch_size_estimate(mocker, tmp_path):


### PR DESCRIPTION
## Summary

Resolves #211 by making `Closes #N` keyword inclusion in delegate-authored PR bodies reliable. Conductor now scans the brief for issue references (in fix/close/resolve/address/for verb contexts) and appends an explicit `## Auto-close` section the delegate can copy verbatim into the PR body.

- New module `src/conductor/brief_preprocessor.py` with `inject_auto_close()`.
- Wired into `_read_task` for both `exec` and `ask` (where PRs originate); `call`/`review`/`council` unchanged.
- Strips fenced code blocks before scanning (avoids false positives on `# 123` Python comments inside example blocks).
- Idempotent — skips injection if the brief already has `## Auto-close` or all detected refs already have full-line `Closes #N` entries.
- Cross-repo refs supported (`org/repo#N`).
- Verb list deliberately narrow: `fix(es)?`, `close(s)?`, `resolve(s)?`, `address(es)?`, `for`, plus `issue #N <verb>` — false positives (telling delegate to close an unrelated issue) are worse than false negatives.

Closes #211.

## Test plan

- [x] `tests/test_brief_preprocessor.py` (59 lines) — already-has-Closes no-op, prose ref injection, multiple refs, cross-repo refs, no ref no-op, existing `## Auto-close` no-op, mixed-case verbs, `#N` in code block ignored, bare `#N` without verb context ignored.
- [x] `tests/test_cli_v02.py` — CLI integration assertion that `exec` and `ask` paths see the transformed brief.
- [x] `uv run pytest tests/` — 905 passed, 15 skipped.
- [x] `uv run ruff check src/ tests/` — clean.