### PR TITLE
fix: claude exec startup-stall diagnostic + opt-in retry (#210)

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -1028,6 +1028,7 @@ def _invoke_with_fallback(
     max_stall_sec: int | None,
     start_timeout_sec: float | None,
     silent: bool,
+    retry_on_stall: int = 0,
     resume_session_id: str | None = None,
     session_log: SessionLog | None = None,
     models_by_provider: dict[str, tuple[str, ...]] | None = None,
@@ -1156,6 +1157,7 @@ def _invoke_with_fallback(
                         start_timeout_sec=start_timeout_sec,
                         resume_session_id=resume_session_id,
                         session_log=session_log,
+                        retry_on_stall=retry_on_stall,
                     )
                 elif isinstance(provider, CodexProvider):
                     response = provider.exec(
@@ -3120,13 +3122,14 @@ def ask(
             tools=tools_set,
             sandbox=sandbox_value,
             cwd=cwd,
-                timeout_sec=timeout_sec,
-                max_stall_sec=max_stall_sec,
-                start_timeout_sec=None,
-                silent=silent_route or as_json,
-                session_log=session_log,
-                models_by_provider=models_by_provider,
-                attachments=attachments,
+            timeout_sec=timeout_sec,
+            max_stall_sec=max_stall_sec,
+            start_timeout_sec=None,
+            retry_on_stall=0,
+            silent=silent_route or as_json,
+            session_log=session_log,
+            models_by_provider=models_by_provider,
+            attachments=attachments,
         )
     except UnsupportedCapability as e:
         if session_log is not None:
@@ -3464,6 +3467,7 @@ def call(
                 timeout_sec=timeout_sec,
                 max_stall_sec=max_stall_sec,
                 start_timeout_sec=None,
+                retry_on_stall=0,
                 silent=silent_route or as_json,
                 attachments=attachments,
             )
@@ -4045,6 +4049,16 @@ def review(
     ),
 )
 @click.option(
+    "--retry-on-stall",
+    default=0,
+    type=click.IntRange(min=0),
+    help=(
+        "Claude exec only: retry this many times if the provider stalls before "
+        "its first output byte. Never retries after first output, to avoid "
+        "duplicating side effects."
+    ),
+)
+@click.option(
     "--task",
     default=None,
     help="The task / prompt. Reads stdin if omitted.\n"
@@ -4138,6 +4152,7 @@ def exec_cmd(
     timeout_sec: int | None,
     max_stall_sec: int | None,
     start_timeout_sec: float | None,
+    retry_on_stall: int,
     task: str | None,
     task_file: str | None,
     brief: str | None,
@@ -4301,6 +4316,7 @@ def exec_cmd(
                 timeout_sec=timeout_sec,
                 max_stall_sec=max_stall_sec,
                 start_timeout_sec=start_timeout_sec,
+                retry_on_stall=retry_on_stall,
                 silent=silent_route or as_json,
                 resume_session_id=resume_session_id,
                 session_log=session_log,
@@ -4450,6 +4466,7 @@ def exec_cmd(
                     start_timeout_sec=start_timeout_sec,
                     resume_session_id=resume_session_id,
                     session_log=session_log,
+                    retry_on_stall=retry_on_stall,
                 )
             elif isinstance(provider, CodexProvider):
                 response = provider.exec(

--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -16,6 +16,7 @@ import os
 import shutil
 import subprocess
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -29,6 +30,7 @@ from conductor.providers.interface import (
     ProviderConfigError,
     ProviderError,
     ProviderHTTPError,
+    ProviderStartupStalledError,
     resolve_effort_tokens,
 )
 from conductor.providers.review_contract import ensure_requested_review_sentinel
@@ -43,6 +45,7 @@ CLAUDE_REQUEST_TIMEOUT_SEC = 180.0
 CLAUDE_AUTH_PROBE_TIMEOUT_SEC = 15.0
 CLAUDE_CALL_FIRST_OUTPUT_TIMEOUT_SEC = 60.0
 CLAUDE_EXEC_FIRST_OUTPUT_TIMEOUT_SEC = 300.0
+CLAUDE_RETRY_ON_STALL_DELAY_SEC = 7.0
 CLAUDE_SETTING_SOURCES = "user,project,local"
 CLAUDE_CLI_ENV = "CONDUCTOR_CLAUDE_CLI"
 CLAUDE_LINKED_WORKTREE_ERROR = (
@@ -53,6 +56,112 @@ CLAUDE_LINKED_WORKTREE_ERROR = (
 # Sentinel: "caller didn't specify a timeout" vs "caller explicitly passed
 # None". The constructor default applies only in the first case.
 _USE_DEFAULT: object = object()
+
+
+@dataclass(frozen=True)
+class ClaudeProcessInfo:
+    pid: int
+    ppid: int | None
+    command: str
+
+
+@dataclass(frozen=True)
+class ClaudeStateProbe:
+    live_processes: tuple[ClaudeProcessInfo, ...]
+    lock_files: tuple[Path, ...]
+    probe_errors: tuple[str, ...] = ()
+
+    def as_dict(self) -> dict:
+        return {
+            "live_process_count": len(self.live_processes),
+            "live_processes": [
+                {"pid": proc.pid, "ppid": proc.ppid, "command": proc.command}
+                for proc in self.live_processes
+            ],
+            "lock_files": [str(path) for path in self.lock_files],
+            "probe_errors": list(self.probe_errors),
+        }
+
+
+def probe_claude_state() -> ClaudeStateProbe:
+    """Inspect shallow Claude CLI state used to diagnose startup stalls."""
+    errors: list[str] = []
+    processes = _probe_live_claude_processes(errors)
+    lock_files = _probe_claude_lock_files(errors)
+    return ClaudeStateProbe(
+        live_processes=tuple(processes),
+        lock_files=tuple(lock_files),
+        probe_errors=tuple(errors),
+    )
+
+
+def _probe_live_claude_processes(errors: list[str]) -> list[ClaudeProcessInfo]:
+    user = os.environ.get("USER")
+    if not user:
+        errors.append("USER is not set; skipped claude process probe")
+        return []
+    try:
+        returncode, stdout, stderr = _run_ps_for_claude_probe(user)
+    except (OSError, subprocess.TimeoutExpired) as e:
+        errors.append(f"claude process probe failed: {e}")
+        return []
+    if returncode != 0:
+        detail = (stderr or stdout).strip()
+        errors.append(f"claude process probe exited {returncode}: {detail[:200]}")
+        return []
+
+    current_pid = os.getpid()
+    processes: list[ClaudeProcessInfo] = []
+    for line in stdout.splitlines():
+        parsed = _parse_ps_line(line)
+        if parsed is None:
+            continue
+        pid, ppid, command = parsed
+        if pid == current_pid or not _is_claude_command(command):
+            continue
+        processes.append(ClaudeProcessInfo(pid=pid, ppid=ppid, command=command))
+    return processes
+
+
+def _run_ps_for_claude_probe(user: str) -> tuple[int, str, str]:
+    process = _ORIGINAL_POPEN(
+        ["ps", "-u", user, "-o", "pid=,ppid=,command="],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    stdout, stderr = process.communicate(timeout=2)
+    return process.returncode or 0, stdout, stderr
+
+
+def _parse_ps_line(line: str) -> tuple[int, int | None, str] | None:
+    parts = line.strip().split(maxsplit=2)
+    if len(parts) < 3:
+        return None
+    try:
+        pid = int(parts[0])
+    except ValueError:
+        return None
+    try:
+        ppid = int(parts[1])
+    except ValueError:
+        ppid = None
+    return pid, ppid, parts[2]
+
+
+def _is_claude_command(command: str) -> bool:
+    executable = command.split(maxsplit=1)[0]
+    return Path(executable).name == "claude"
+
+
+def _probe_claude_lock_files(errors: list[str]) -> list[Path]:
+    claude_dir = Path.home() / ".claude"
+    try:
+        candidates = [*claude_dir.glob("*.lock"), *claude_dir.glob("*.tmp")]
+    except OSError as e:
+        errors.append(f"claude lock-file probe failed: {e}")
+        return []
+    return sorted(path for path in candidates if path.is_file())
 
 
 class ClaudeProvider:
@@ -433,6 +542,7 @@ class ClaudeProvider:
         start_timeout_sec: float | None = None,
         resume_session_id: str | None = None,
         session_log: SessionLog | None = None,
+        retry_on_stall: int = 0,
     ) -> CallResponse:
         # Claude's `--allowedTools` is fine-grained; passing an empty set
         # is effectively "no tools permitted" (single-turn).
@@ -450,6 +560,7 @@ class ClaudeProvider:
             resume_session_id=resume_session_id,
             live_auth_capture=True,
             session_log=session_log,
+            retry_on_stall=retry_on_stall,
         )
 
     def _run(
@@ -467,6 +578,7 @@ class ClaudeProvider:
         resume_session_id: str | None = None,
         live_auth_capture: bool = False,
         session_log: SessionLog | None = None,
+        retry_on_stall: int = 0,
     ) -> CallResponse:
         # Cheap PATH check only on the hot path — auth state surfaces as a
         # CLI exit failure below if the user installed but didn't log in.
@@ -514,59 +626,19 @@ class ClaudeProvider:
         start = time.monotonic()
         tracker = AuthPromptTracker(self.name, session_log=session_log)
         try:
-            effective_cwd = self._effective_cwd(cwd)
-            proc_env = self._build_proc_env(env_overrides, effective_cwd=effective_cwd)
-            first_output_timeout_sec = self._effective_first_output_timeout(
-                start_timeout_sec
-            )
-            if session_log is not None:
-                session_log.emit(
-                    "provider_diagnostic",
-                    {
-                        "provider": self.name,
-                        "check": "claude_exec_watchdogs",
-                        "first_output_timeout_sec": first_output_timeout_sec,
-                        "max_stall_sec": max_stall_sec,
-                    },
-                )
-            self._emit_project_settings_diagnostic(
-                effective_cwd=effective_cwd,
-                sandbox_permission_mode=permission_mode,
-                session_log=session_log,
-            )
-            self._reject_mutating_linked_worktree(
-                effective_cwd=effective_cwd,
+            result = self._run_with_optional_startup_retry(
+                args=args,
+                cwd=cwd,
+                env_overrides=env_overrides,
                 permission_mode=permission_mode,
+                timeout=timeout,
+                max_stall_sec=max_stall_sec,
+                start_timeout_sec=start_timeout_sec,
+                live_auth_capture=live_auth_capture,
                 session_log=session_log,
+                tracker=tracker,
+                retry_on_stall=retry_on_stall,
             )
-            if live_auth_capture:
-                result = run_subprocess_with_live_stderr(
-                    args=args,
-                    cwd=str(effective_cwd) if effective_cwd is not None else None,
-                    env=proc_env,
-                    timeout=timeout,
-                    max_stall_sec=max_stall_sec,
-                    first_output_timeout_sec=first_output_timeout_sec,
-                    provider_name=self.name,
-                    session_log=session_log,
-                    tracker=tracker,
-                    popen_factory=subprocess.Popen,
-                )
-            else:
-                completed = subprocess.run(
-                    args,
-                    capture_output=True,
-                    text=True,
-                    timeout=timeout,
-                    cwd=str(effective_cwd) if effective_cwd is not None else None,
-                    env=proc_env,
-                )
-                result = CapturedProcessResult(
-                    returncode=completed.returncode,
-                    stdout=completed.stdout,
-                    stderr=completed.stderr,
-                    duration_ms=int((time.monotonic() - start) * 1000),
-                )
         except subprocess.TimeoutExpired as e:
             elapsed = time.monotonic() - start
             raise ProviderError(
@@ -610,6 +682,182 @@ class ClaudeProvider:
             session_id=data.get("session_id"),
             raw=data,
             auth_prompts=tracker.prompts or None,
+        )
+
+    def _run_with_optional_startup_retry(
+        self,
+        *,
+        args: list[str],
+        cwd: str | None,
+        env_overrides: dict[str, str],
+        permission_mode: str | None,
+        timeout: float | None,
+        max_stall_sec: int | None,
+        start_timeout_sec: float | None,
+        live_auth_capture: bool,
+        session_log: SessionLog | None,
+        tracker: AuthPromptTracker,
+        retry_on_stall: int,
+    ) -> CapturedProcessResult:
+        effective_cwd = self._effective_cwd(cwd)
+        proc_env = self._build_proc_env(env_overrides, effective_cwd=effective_cwd)
+        first_output_timeout_sec = self._effective_first_output_timeout(
+            start_timeout_sec
+        )
+        if session_log is not None:
+            session_log.emit(
+                "provider_diagnostic",
+                {
+                    "provider": self.name,
+                    "check": "claude_exec_watchdogs",
+                    "first_output_timeout_sec": first_output_timeout_sec,
+                    "max_stall_sec": max_stall_sec,
+                    "retry_on_stall": retry_on_stall,
+                },
+            )
+        self._emit_project_settings_diagnostic(
+            effective_cwd=effective_cwd,
+            sandbox_permission_mode=permission_mode,
+            session_log=session_log,
+        )
+        self._reject_mutating_linked_worktree(
+            effective_cwd=effective_cwd,
+            permission_mode=permission_mode,
+            session_log=session_log,
+        )
+        if not live_auth_capture:
+            start = time.monotonic()
+            completed = subprocess.run(
+                args,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                cwd=str(effective_cwd) if effective_cwd is not None else None,
+                env=proc_env,
+            )
+            return CapturedProcessResult(
+                returncode=completed.returncode,
+                stdout=completed.stdout,
+                stderr=completed.stderr,
+                duration_ms=int((time.monotonic() - start) * 1000),
+            )
+
+        max_attempts = 1 + max(0, retry_on_stall)
+        attempt = 1
+        overall_start = time.monotonic()
+        while True:
+            attempt_timeout = self._remaining_timeout(
+                timeout,
+                start=overall_start,
+                args=args,
+            )
+            try:
+                return run_subprocess_with_live_stderr(
+                    args=args,
+                    cwd=str(effective_cwd) if effective_cwd is not None else None,
+                    env=proc_env,
+                    timeout=attempt_timeout,
+                    max_stall_sec=max_stall_sec,
+                    first_output_timeout_sec=first_output_timeout_sec,
+                    provider_name=self.name,
+                    session_log=session_log,
+                    tracker=tracker,
+                    popen_factory=subprocess.Popen,
+                )
+            except ProviderStartupStalledError as e:
+                probe = probe_claude_state()
+                if attempt >= max_attempts:
+                    raise self._startup_stall_with_diagnostic(
+                        e,
+                        probe=probe,
+                        attempts=attempt,
+                        retry_on_stall=retry_on_stall,
+                    ) from e
+                if session_log is not None:
+                    session_log.emit(
+                        "provider_diagnostic",
+                        {
+                            "provider": self.name,
+                            "check": "claude_startup_stall_retry",
+                            "attempt": attempt,
+                            "max_attempts": max_attempts,
+                            "delay_sec": CLAUDE_RETRY_ON_STALL_DELAY_SEC,
+                            "probe": probe.as_dict(),
+                        },
+                    )
+                self._sleep_before_startup_retry(
+                    timeout,
+                    start=overall_start,
+                    args=args,
+                )
+                attempt += 1
+
+    def _remaining_timeout(
+        self,
+        timeout: float | None,
+        *,
+        start: float,
+        args: list[str],
+    ) -> float | None:
+        if timeout is None:
+            return None
+        remaining = timeout - (time.monotonic() - start)
+        if remaining <= 0:
+            raise subprocess.TimeoutExpired(cmd=args, timeout=timeout)
+        return remaining
+
+    def _sleep_before_startup_retry(
+        self,
+        timeout: float | None,
+        *,
+        start: float,
+        args: list[str],
+    ) -> None:
+        if timeout is None:
+            time.sleep(CLAUDE_RETRY_ON_STALL_DELAY_SEC)
+            return
+        remaining = timeout - (time.monotonic() - start)
+        if remaining <= 0:
+            raise subprocess.TimeoutExpired(cmd=args, timeout=timeout)
+        time.sleep(min(CLAUDE_RETRY_ON_STALL_DELAY_SEC, remaining))
+
+    def _startup_stall_with_diagnostic(
+        self,
+        error: ProviderStartupStalledError,
+        *,
+        probe: ClaudeStateProbe,
+        attempts: int,
+        retry_on_stall: int,
+    ) -> ProviderStartupStalledError:
+        diagnostic = probe.as_dict()
+        diagnostic["attempts"] = attempts
+        diagnostic["retry_on_stall"] = retry_on_stall
+        process_count = len(probe.live_processes)
+        pids = [str(proc.pid) for proc in probe.live_processes[:8]]
+        pid_text = f" (PIDs: {', '.join(pids)})" if pids else ""
+        lock_text = (
+            f" Lock/tmp files in ~/.claude: {', '.join(diagnostic['lock_files'])}."
+            if diagnostic["lock_files"]
+            else " No *.lock or *.tmp files found directly under ~/.claude."
+        )
+        recovery_text = (
+            " Retry attempts were exhausted."
+            if retry_on_stall
+            else " Or add `--retry-on-stall 1` to allow conductor to re-spawn."
+        )
+        message = (
+            f"conductor: claude exec stalled at first_output "
+            f"({error.timeout_sec:g}s). Detected {process_count} other live "
+            f"`claude` processes{pid_text}. Likely cause: claude CLI auth-lock "
+            "or session-state contention during startup."
+            f"{lock_text} Reduce parallel claude exec sessions to <= 2."
+            f"{recovery_text}"
+        )
+        return ProviderStartupStalledError(
+            provider=error.provider,
+            timeout_sec=error.timeout_sec,
+            message=message,
+            diagnostic=diagnostic,
         )
 
     def _effective_cwd(self, cwd: str | None) -> Path | None:

--- a/src/conductor/providers/interface.py
+++ b/src/conductor/providers/interface.py
@@ -106,7 +106,14 @@ class ProviderStalledError(ProviderError):
 class ProviderStartupStalledError(ProviderStalledError):
     """Raised when a CLI provider produces no initial output after launch."""
 
-    def __init__(self, *, provider: str, timeout_sec: float) -> None:
+    def __init__(
+        self,
+        *,
+        provider: str,
+        timeout_sec: float,
+        message: str | None = None,
+        diagnostic: dict | None = None,
+    ) -> None:
         self.provider = provider
         self.timeout_sec = timeout_sec
         self.phase = "startup"
@@ -115,12 +122,14 @@ class ProviderStartupStalledError(ProviderStalledError):
             if float(timeout_sec).is_integer()
             else f"{timeout_sec:g}"
         )
+        self.diagnostic = diagnostic
         self.error_response = {
             "error": "provider_startup_stalled",
             "provider": provider,
             "timeout_sec": timeout_sec,
             "phase": self.phase,
-            "message": (
+            "message": message
+            or (
                 f"{provider} CLI startup stalled: produced no output within "
                 f"{formatted_timeout}s after start"
             ),

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -561,7 +561,7 @@ def test_claude_exec_first_output_watchdog_is_separate_from_mid_task_stall(
         )
 
     assert fake.terminated is True
-    assert "produced no output within 0.05s after start" in str(exc.value)
+    assert "claude exec stalled at first_output" in str(exc.value)
     events = [
         json.loads(line)
         for line in session_log.log_path.read_text(encoding="utf-8").splitlines()
@@ -578,6 +578,184 @@ def test_claude_exec_first_output_watchdog_is_separate_from_mid_task_stall(
     assert error_event["data"]["reason"] == "no_initial_provider_output_within_0.05s"
     assert error_event["data"]["phase"] == "first_output"
     assert error_event["data"]["last_event"] == "provider_started"
+
+
+def test_claude_exec_startup_stall_diagnostic_includes_processes_and_locks(
+    mocker,
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+    (claude_dir / "auth.lock").write_text("", encoding="utf-8")
+    (claude_dir / "session.tmp").write_text("", encoding="utf-8")
+    mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
+    mocker.patch(
+        "conductor.providers.claude._run_ps_for_claude_probe",
+        return_value=(
+            0,
+            (
+                "123 1 claude -p hi\n"
+                "456 1 /usr/local/bin/claude --model sonnet\n"
+                "789 1 conductor exec --with claude\n"
+            ),
+            "",
+        ),
+    )
+    fake = _FakePopen(stdout_schedule=[], hang_after_stdout=True)
+    mocker.patch(
+        "conductor.providers.claude.subprocess.Popen",
+        side_effect=lambda args, **kwargs: fake,
+    )
+
+    with pytest.raises(ProviderStartupStalledError) as exc:
+        ClaudeProvider(exec_first_output_timeout_sec=0.01).exec(
+            "hi",
+            timeout_sec=1,
+            max_stall_sec=30,
+        )
+
+    assert fake.terminated is True
+    message = str(exc.value)
+    assert "claude exec stalled at first_output" in message
+    assert "Detected 2 other live `claude` processes" in message
+    assert "PIDs: 123, 456" in message
+    assert "auth.lock" in message
+    assert "session.tmp" in message
+    assert "--retry-on-stall 1" in message
+
+
+def test_claude_exec_retry_on_stall_respawns_once_then_reports_diagnostic(
+    mocker,
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".claude").mkdir()
+    mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
+    mocker.patch(
+        "conductor.providers.claude._run_ps_for_claude_probe",
+        return_value=(0, "123 1 claude -p hi\n", ""),
+    )
+    mocker.patch("conductor.providers.claude.time.sleep")
+    fakes = [
+        _FakePopen(stdout_schedule=[], hang_after_stdout=True),
+        _FakePopen(stdout_schedule=[], hang_after_stdout=True),
+    ]
+    popen = mocker.patch(
+        "conductor.providers.claude.subprocess.Popen",
+        side_effect=lambda args, **kwargs: fakes.pop(0),
+    )
+
+    with pytest.raises(ProviderStartupStalledError) as exc:
+        ClaudeProvider(exec_first_output_timeout_sec=0.01).exec(
+            "hi",
+            timeout_sec=1,
+            max_stall_sec=30,
+            retry_on_stall=1,
+        )
+
+    assert popen.call_count == 2
+    assert "Retry attempts were exhausted" in str(exc.value)
+
+
+def test_claude_exec_retry_on_stall_can_succeed_after_respawn(
+    mocker,
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".claude").mkdir()
+    mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
+    mocker.patch(
+        "conductor.providers.claude._run_ps_for_claude_probe",
+        return_value=(0, "123 1 claude -p hi\n", ""),
+    )
+    mocker.patch("conductor.providers.claude.time.sleep")
+    fakes = [
+        _FakePopen(stdout_schedule=[], hang_after_stdout=True),
+        _FakePopen(stdout_schedule=[(0, CLAUDE_JSON)]),
+    ]
+    popen = mocker.patch(
+        "conductor.providers.claude.subprocess.Popen",
+        side_effect=lambda args, **kwargs: fakes.pop(0),
+    )
+
+    response = ClaudeProvider(exec_first_output_timeout_sec=0.01).exec(
+        "hi",
+        timeout_sec=1,
+        max_stall_sec=30,
+        retry_on_stall=1,
+    )
+
+    assert popen.call_count == 2
+    assert response.text == "hello from claude"
+
+
+def test_cli_exec_retry_on_stall_wires_to_claude_provider(
+    mocker,
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".claude").mkdir()
+    mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
+    mocker.patch(
+        "conductor.providers.claude._run_ps_for_claude_probe",
+        return_value=(0, "123 1 claude -p hi\n", ""),
+    )
+    mocker.patch("conductor.providers.claude.time.sleep")
+    fakes = [
+        _FakePopen(stdout_schedule=[], hang_after_stdout=True),
+        _FakePopen(stdout_schedule=[(0, CLAUDE_JSON)]),
+    ]
+    popen = mocker.patch(
+        "conductor.providers.claude.subprocess.Popen",
+        side_effect=lambda args, **kwargs: fakes.pop(0),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--with",
+            "claude",
+            "--no-preflight",
+            "--start-timeout",
+            "0.01",
+            "--retry-on-stall",
+            "1",
+            "--task",
+            "hi",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert popen.call_count == 2
+    assert "hello from claude" in result.output
+
+
+def test_claude_exec_retry_on_stall_never_retries_mid_task_stall(
+    mocker,
+):
+    mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
+    fake = _FakePopen(stdout_schedule=[(0, "{")], hang_after_stdout=True)
+    popen = mocker.patch(
+        "conductor.providers.claude.subprocess.Popen",
+        side_effect=lambda args, **kwargs: fake,
+    )
+
+    with pytest.raises(ProviderStalledError):
+        ClaudeProvider(exec_first_output_timeout_sec=1).exec(
+            "hi",
+            timeout_sec=1,
+            max_stall_sec=0.01,
+            retry_on_stall=1,
+        )
+
+    assert popen.call_count == 1
+    assert fake.terminated is True
 
 
 def test_claude_startup_timeout_defaults_split_call_and_exec():
@@ -614,7 +792,7 @@ def test_claude_legacy_first_output_timeout_does_not_override_exec_default(
         )
 
     assert exc.value.error_response["timeout_sec"] == 300.0
-    assert "within 300s after start" in exc.value.error_response["message"]
+    assert "claude exec stalled at first_output (300s)" in exc.value.error_response["message"]
 
 
 def test_claude_exec_start_timeout_allows_slow_first_byte(
@@ -680,16 +858,11 @@ def test_claude_exec_start_timeout_fails_nonzero_with_error_shape(
     assert result.exit_code == 1
     assert fake.terminated is True
     payload = json.loads(result.stdout)
-    assert payload == {
-        "error": "provider_startup_stalled",
-        "provider": "claude",
-        "timeout_sec": 0.03,
-        "phase": "startup",
-        "message": (
-            "claude CLI startup stalled: produced no output within "
-            "0.03s after start"
-        ),
-    }
+    assert payload["error"] == "provider_startup_stalled"
+    assert payload["provider"] == "claude"
+    assert payload["timeout_sec"] == 0.03
+    assert payload["phase"] == "startup"
+    assert "claude exec stalled at first_output (0.03s)" in payload["message"]
 
 
 def test_claude_exec_zero_bytes_ever_fails_as_startup_stall(mocker):


### PR DESCRIPTION
## Summary

Resolves #210 — the recurring `no_initial_provider_output_within_900s` first-output stalls on parallel `conductor exec --with claude` sessions.

### Investigation findings

(Full investigation summary in commit body.)

- Confirmed the failure pattern in today's session NDJSON: claude reaches `provider_started` then never emits any output. Last events are `provider_started` + `claude_exec_watchdogs`.
- Ruled out 429/rate-limit (those have output and `provider_failed` details; this is zero-byte).
- Inspected `~/.claude/`: no root `*.lock` / `*.tmp` files at probe time, but `~/.claude/sessions/*.json` and global state files were being actively updated, with multiple same-user `claude` processes alive.
- Conclusion: claude CLI auth/session-state startup contention outside conductor's pipe reader. Conductor isn't the root cause but is the visible surface.

### Conductor-side fix (the fundamental fix at this layer)

**A) Stall diagnostic.** When `first_output` stall fires, conductor probes:
- Live same-user `claude` processes (PID, PPID, command).
- Shallow `~/.claude/*.lock` / `*.tmp` inventory.

The wedge error message is enriched with this snapshot. Operators get a real picture of contention instead of "stalled after 900s, no output."

**B) Opt-in `--retry-on-stall N`** flag (exec only). When set, on a first-output stall, conductor kills the stalled subprocess, waits a short delay, re-spawns, and tries again up to N times.

**Critical invariant**: retry is restricted to `first_output` stalls only. **Mid-task stalls are never retried** — the flag's `--help` text documents this, and a regression test asserts it. This protects against duplicating side effects (committed files, opened PRs).

`call`, `review`, and `council` do NOT get this flag; they hardcode `retry_on_stall=0`.

`ProviderStartupStalledError` extended additively with optional `message` and `diagnostic` kwargs; existing error shape preserved.

Closes #210.

## Test plan

- [x] `tests/test_adapters_subprocess.py` (~197 lines new) — 4 cases:
  - Diagnostic includes process count + lock file inventory
  - `--retry-on-stall 1` triggers retry; on second stall, exits with the diagnostic
  - `--retry-on-stall 1` can succeed after respawn
  - Mid-task stall NEVER retried
  - CLI flag wires correctly to ClaudeProvider
- [x] `uv run pytest tests/` — 899 passed, 15 skipped
- [x] `uv run ruff check src/ tests/` clean