### PR TITLE
fix: declare packaging as runtime dependency (v0.9.2 broken on fresh install)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ keywords = ["ai", "llm", "router", "cli", "moonshot", "kimi", "claude", "codex",
 dependencies = [
     "click>=8.1.0",
     "httpx>=0.28.0",
+    "packaging>=24.0",
     "rich>=13.9.0",
     "tomli>=2.0.0; python_version<'3.11'",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -54,6 +54,7 @@ source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "httpx" },
+    { name = "packaging" },
     { name = "rich" },
 ]
 
@@ -69,6 +70,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.1.0" },
     { name = "httpx", specifier = ">=0.28.0" },
+    { name = "packaging", specifier = ">=24.0" },
     { name = "rich", specifier = ">=13.9.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
 ]


### PR DESCRIPTION
## Symptom

\`\`\`
$ brew upgrade autumngarage/conductor/conductor    # 0.9.0 -> 0.9.2
$ conductor --version
Traceback (most recent call last):
  File \"/opt/homebrew/bin/conductor\", line 4, in <module>
    from conductor.cli import main
  File \"/opt/homebrew/Cellar/conductor/0.9.2/libexec/venv/lib/python3.12/site-packages/conductor/cli.py\", line 34, in <module>
    from packaging.version import InvalidVersion
ModuleNotFoundError: No module named 'packaging'
\`\`\`

## Root cause

v0.9.1 (PR #205, closing #204 — doctor version-skew warning) added \`from packaging.version import parse, InvalidVersion\`. CI/dev tests passed because \`packaging\` was transitively installed. But it wasn't declared as a runtime dependency in \`pyproject.toml\`, so the brew-bundled venv ships without it, breaking every fresh install of v0.9.1 and v0.9.2.

## Fix

Add \`packaging>=24.0\` to \`[project].dependencies\` and refresh \`uv.lock\`. \`packaging\` is a PyPA standard library, MIT-licensed, near-universal; the bound is just to pin a sane floor.

## Verification needed post-merge

After this lands and v0.9.3 is cut, run on a clean machine:

\`\`\`
brew upgrade autumngarage/conductor/conductor
conductor --version    # should print \"conductor, version 0.9.3\"
\`\`\`

## How this slipped past

- Test runs use the project venv (where \`packaging\` is transitively pulled by other deps and explicitly available in dev groups).
- The brew formula bundles only the declared \`[project].dependencies\` into its libexec venv.
- We don't have a "fresh-install smoke test" in the release workflow that would have caught this. Worth filing as a follow-up.