### PR TITLE
feat: ollama is offline-only in auto-router fallback chain (#216)

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -857,15 +857,73 @@ def _requires_strong_code_provider(plan: SemanticPlan) -> bool:
     return plan.kind == "code" and plan.effort_bucket in {"high", "max"}
 
 
-def _exclude_ollama_from_strong_code_plan(plan: SemanticPlan) -> tuple[SemanticPlan, bool]:
-    if not _requires_strong_code_provider(plan):
-        return plan, False
+OLLAMA_ONLINE_EXCLUSION_MESSAGE = (
+    "[conductor] excluding ollama from fallback chain "
+    "(online; ollama is offline-only — pass --offline to override)"
+)
+OLLAMA_PROBE_OFFLINE_INCLUSION_MESSAGE = (
+    "[conductor] including ollama as local fallback "
+    "(network probe found no reachable target; assuming offline)"
+)
+
+
+def _with_user_semantic_tags(
+    plan: SemanticPlan,
+    user_tags: tuple[str, ...],
+) -> SemanticPlan:
+    if not user_tags:
+        return plan
+    tags = list(plan.tags)
+    for tag in user_tags:
+        if tag not in tags:
+            tags.append(tag)
+    return replace(plan, tags=tuple(tags))
+
+
+def _semantic_plan_contains_ollama(plan: SemanticPlan) -> bool:
+    return any(candidate.provider == "ollama" for candidate in plan.candidates)
+
+
+def _first_online_candidate_provider(plan: SemanticPlan) -> str | None:
+    for candidate in plan.candidates:
+        if candidate.provider != "ollama":
+            return candidate.provider
+    return None
+
+
+def _apply_ollama_offline_only_policy(
+    plan: SemanticPlan,
+    *,
+    user_tags: tuple[str, ...],
+    offline_requested: bool,
+) -> tuple[SemanticPlan, str | None]:
+    """Keep ollama in semantic fallback chains only for explicit offline intent.
+
+    Invariant: an online semantic plan must not retain ollama as an implicit
+    fallback. Local routing remains available through --offline, sticky offline
+    mode, explicit ollama tags, and when the network probe cannot reach any
+    target.
+    """
+    if not _semantic_plan_contains_ollama(plan):
+        return plan, None
+    if offline_requested or offline_mode.is_active():
+        return plan, None
+    if "ollama" in user_tags:
+        return plan, None
+
+    profile = get_network_profile(
+        _network_target_for_provider(_first_online_candidate_provider(plan)),
+        warn=None,
+    )
+    if profile.rtt_ms is None:
+        return plan, OLLAMA_PROBE_OFFLINE_INCLUSION_MESSAGE
+
     candidates = tuple(
         candidate for candidate in plan.candidates if candidate.provider != "ollama"
     )
     if len(candidates) == len(plan.candidates):
-        return plan, False
-    return replace(plan, candidates=candidates), True
+        return plan, None
+    return replace(plan, candidates=candidates), OLLAMA_ONLINE_EXCLUSION_MESSAGE
 
 
 def _format_strong_code_no_fallback_error(
@@ -2750,6 +2808,11 @@ def main(ctx: click.Context) -> None:
     default=None,
     help=f"Thinking depth: {' | '.join(VALID_EFFORT_LEVELS)} or integer budget.",
 )
+@click.option(
+    "--tags",
+    default=None,
+    help="Comma-separated task tags to add to the semantic route.",
+)
 @click.option("--cwd", default=None, help="Repository working directory for code/review.")
 @click.option(
     "--timeout",
@@ -2852,6 +2915,7 @@ def main(ctx: click.Context) -> None:
 def ask(
     kind: str,
     effort: str | None,
+    tags: str | None,
     cwd: str | None,
     timeout_sec: int | None,
     max_stall_sec: int | None,
@@ -2880,6 +2944,8 @@ def ask(
     max_stall_is_default = _parameter_is_default("max_stall_sec")
     effort_value = _parse_effort(effort)
     plan = plan_for(kind, effort_value)
+    user_tags = tuple(_parse_csv(tags))
+    plan = _with_user_semantic_tags(plan, user_tags)
     council_caps = CouncilCaps(
         timeout_sec=council_timeout_sec,
         max_output_tokens=council_max_output_tokens,
@@ -2898,9 +2964,11 @@ def ask(
         offline_mode.set_active()
         plan = with_candidate_override(plan, provider="ollama")
 
-    excluded_ollama = False
-    if offline is not True:
-        plan, excluded_ollama = _exclude_ollama_from_strong_code_plan(plan)
+    plan, ollama_policy_message = _apply_ollama_offline_only_policy(
+        plan,
+        user_tags=user_tags,
+        offline_requested=offline is True,
+    )
 
     if kind == "council" and plan.candidates[0].provider != "openrouter":
         raise click.UsageError("council always routes through OpenRouter.")
@@ -2930,12 +2998,8 @@ def ask(
             "use `conductor exec --with codex --attach ...` instead."
         )
 
-    if excluded_ollama and not silent_route:
-        click.echo(
-            "[conductor] excluding ollama from fallback chain "
-            f"(--kind code --effort {plan.effort_bucket} requires strong reasoning)",
-            err=True,
-        )
+    if ollama_policy_message and not silent_route:
+        click.echo(ollama_policy_message, err=True)
     if not (silent_route or as_json):
         click.echo(_format_semantic_plan_line(plan), err=True)
 

--- a/src/conductor/network_profile.py
+++ b/src/conductor/network_profile.py
@@ -80,11 +80,13 @@ def get_network_profile(
         profile = _probe_profile(normalized_target, current_time)
     except Exception as e:
         _warn(warn, f"[conductor] network: probe failed for {normalized_target}: {e}")
-        return NetworkProfile(
+        profile = NetworkProfile(
             rtt_ms=None,
             target=normalized_target,
             timestamp=current_time,
         )
+        _write_cache(profile, warn=warn)
+        return profile
 
     _write_cache(profile, warn=warn)
     return profile
@@ -117,8 +119,9 @@ def _read_cache(
 
     try:
         data = json.loads(raw)
+        raw_rtt_ms = data["rtt_ms"]
         profile = NetworkProfile(
-            rtt_ms=float(data["rtt_ms"]),
+            rtt_ms=None if raw_rtt_ms is None else float(raw_rtt_ms),
             target=str(data["target"]),
             timestamp=float(data["timestamp"]),
         )
@@ -130,15 +133,13 @@ def _read_cache(
         return None
     if now - profile.timestamp > NETWORK_PROFILE_TTL_SEC:
         return None
-    if profile.rtt_ms is None or profile.rtt_ms < 0:
+    if profile.rtt_ms is not None and profile.rtt_ms < 0:
         _delete_bad_cache(path, warn=warn, reason=ValueError("invalid rtt_ms"))
         return None
     return profile
 
 
 def _write_cache(profile: NetworkProfile, *, warn: Callable[[str], None] | None) -> None:
-    if profile.rtt_ms is None:
-        return
     path = _cache_path()
     payload = {
         "rtt_ms": profile.rtt_ms,

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -23,6 +23,7 @@ import pytest
 import respx
 from click.testing import CliRunner
 
+from conductor import offline_mode
 from conductor.cli import SANDBOX_DEPRECATION_WARNING, main
 from conductor.network_profile import NetworkProfile
 from conductor.openrouter_model_stacks import OPENROUTER_CODING_HIGH
@@ -615,17 +616,12 @@ def test_ask_code_high_without_frontier_fallback_refuses_ollama(mocker):
     assert "falling through to ollama" not in result.stderr
 
 
-def test_ask_code_medium_falls_through_from_openrouter_404_to_ollama(mocker):
-    from conductor.providers.interface import ProviderHTTPError
-
+def test_ask_code_medium_online_excludes_ollama_from_fallback(mocker):
     _stub_all_configured(mocker, {"openrouter", "ollama"})
-    mocker.patch.object(
+    openrouter_call = mocker.patch.object(
         OpenRouterProvider,
         "call",
-        side_effect=ProviderHTTPError(
-            "OpenRouter provider failed locally after upstream HTTP 404. "
-            "request restrictions/models tried: ['openrouter/auto', 'qwen/qwen3.6-flash']"
-        ),
+        return_value=_fake_response("openrouter", "openrouter/auto"),
     )
     ollama_call = mocker.patch.object(
         OllamaProvider,
@@ -644,21 +640,96 @@ def test_ask_code_medium_falls_through_from_openrouter_404_to_ollama(mocker):
             "--allow-short-brief",
             "--brief",
             "Explain the small code change.",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert openrouter_call.called
+    assert not ollama_call.called
+    assert "excluding ollama from fallback chain" in result.stderr
+    assert "online; ollama is offline-only" in result.stderr
+    assert "falling through to ollama" not in result.stderr
+    payload = json.loads(result.stdout)
+    assert [candidate["provider"] for candidate in payload["semantic"]["candidates"]] == [
+        "openrouter",
+    ]
+
+
+def test_ask_offline_keeps_ollama_in_semantic_candidates(mocker):
+    _stub_all_configured(mocker, {"openrouter", "ollama"})
+    ollama_call = mocker.patch.object(
+        OllamaProvider,
+        "call",
+        return_value=_fake_response("ollama", "llama3.2"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "ask",
+            "--kind",
+            "research",
+            "--effort",
+            "low",
+            "--offline",
+            "--brief",
+            "Use local model.",
+            "--json",
         ],
     )
 
     assert result.exit_code == 0, result.output
     assert ollama_call.called
-    assert "openrouter failed (provider-error)" in result.stderr
-    assert "falling through to ollama" in result.stderr
-    assert "falling back" in result.stderr
-    assert "→ ollama" in result.stderr
+    assert "excluding ollama from fallback chain" not in result.stderr
+    payload = json.loads(result.stdout)
+    assert [candidate["provider"] for candidate in payload["semantic"]["candidates"]] == [
+        "ollama",
+    ]
 
 
-def test_ask_research_high_keeps_ollama_fallback(mocker):
+def test_ask_sticky_offline_keeps_ollama_without_policy_message(mocker):
+    _stub_all_configured(mocker, {"openrouter", "ollama"})
+    offline_mode.set_active(ttl_sec=600)
+    ollama_call = mocker.patch.object(
+        OllamaProvider,
+        "call",
+        return_value=_fake_response("ollama", "llama3.2"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "ask",
+            "--kind",
+            "research",
+            "--effort",
+            "low",
+            "--brief",
+            "Use sticky local model.",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert ollama_call.called
+    assert "excluding ollama from fallback chain" not in result.stderr
+    assert "including ollama as local fallback" not in result.stderr
+    payload = json.loads(result.stdout)
+    assert [candidate["provider"] for candidate in payload["semantic"]["candidates"]] == [
+        "openrouter",
+        "ollama",
+    ]
+
+
+def test_ask_network_probe_offline_keeps_ollama_fallback(mocker):
     from conductor.providers.interface import ProviderHTTPError
 
     _stub_all_configured(mocker, {"openrouter", "ollama"})
+    mocker.patch(
+        "conductor.cli.get_network_profile",
+        return_value=NetworkProfile(None, "https://1.1.1.1", 1_000),
+    )
     mocker.patch.object(
         OpenRouterProvider,
         "call",
@@ -685,10 +756,76 @@ def test_ask_research_high_keeps_ollama_fallback(mocker):
 
     assert result.exit_code == 0, result.output
     assert ollama_call.called
+    assert "including ollama as local fallback" in result.stderr
+    assert "network probe found no reachable target" in result.stderr
     assert "excluding ollama from fallback chain" not in result.stderr
     assert "openrouter failed (5xx)" in result.stderr
     assert "falling through to ollama" in result.stderr
     assert "→ ollama" in result.stderr
+
+
+def test_ask_explicit_ollama_tag_keeps_ollama_fallback(mocker):
+    _stub_all_configured(mocker, {"openrouter", "ollama"})
+    openrouter_call = mocker.patch.object(
+        OpenRouterProvider,
+        "call",
+        return_value=_fake_response("openrouter", "openrouter/auto"),
+    )
+    ollama_call = mocker.patch.object(
+        OllamaProvider,
+        "call",
+        return_value=_fake_response("ollama", "llama3.2"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "ask",
+            "--kind",
+            "research",
+            "--effort",
+            "low",
+            "--tags",
+            "ollama,cheap",
+            "--brief",
+            "Keep local fallback available.",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert openrouter_call.called
+    assert not ollama_call.called
+    assert "excluding ollama from fallback chain" not in result.stderr
+    payload = json.loads(result.stdout)
+    assert [candidate["provider"] for candidate in payload["semantic"]["candidates"]] == [
+        "openrouter",
+        "ollama",
+    ]
+    assert "ollama" in payload["semantic"]["tags"]
+
+
+def test_call_with_ollama_bypasses_semantic_ollama_policy(mocker):
+    _stub_all_configured(mocker, {"ollama"})
+    profile_mock = mocker.patch(
+        "conductor.cli.get_network_profile",
+        return_value=NetworkProfile(50, "http://localhost:11434", 1_000),
+    )
+    ollama_call = mocker.patch.object(
+        OllamaProvider,
+        "call",
+        return_value=_fake_response("ollama", "llama3.2"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["call", "--with", "ollama", "--brief", "Use the local provider."],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert ollama_call.called
+    assert profile_mock.called
+    assert "excluding ollama from fallback chain" not in result.stderr
 
 
 def test_ask_review_uses_native_review_route(mocker):
@@ -2009,8 +2146,12 @@ def test_route_json_accepts_explicit_size_estimate(mocker):
 
 
 def test_ask_call_mode_routes_with_prompt_size_estimate(mocker):
-    _stub_all_configured(mocker, {"ollama"})
-    mocker.patch.object(OllamaProvider, "call", return_value=_fake_response("ollama"))
+    _stub_all_configured(mocker, {"openrouter"})
+    mocker.patch.object(
+        OpenRouterProvider,
+        "call",
+        return_value=_fake_response("openrouter", "openrouter/auto"),
+    )
     prompt = "x" * 2000
 
     result = CliRunner().invoke(

--- a/tests/test_network_profile.py
+++ b/tests/test_network_profile.py
@@ -201,6 +201,34 @@ def test_fallback_target_when_provider_unreachable(monkeypatch, tmp_path):
     ]
 
 
+def test_no_rtt_profile_is_cached(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    _FakeClient.calls = []
+    _FakeClient.failures = {
+        "https://api.example.test": 3,
+        NETWORK_PROFILE_FALLBACK_TARGET: 3,
+    }
+    _install_fake_probe(monkeypatch, [0.0, 1.0, 2.0, 3.0, 4.0, 5.0])
+
+    profile = get_network_profile("https://api.example.test", now=3_000)
+
+    assert profile == NetworkProfile(
+        rtt_ms=None,
+        target="https://api.example.test",
+        timestamp=3_000,
+    )
+    cached = json.loads(_cache_file(tmp_path).read_text(encoding="utf-8"))
+    assert cached["rtt_ms"] is None
+
+    monkeypatch.setattr(
+        "conductor.network_profile.httpx.Client",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("probe should not run")),
+    )
+    cached_profile = get_network_profile("https://api.example.test", now=3_100)
+
+    assert cached_profile == profile
+
+
 def test_corrupt_cache_is_deleted_and_rebuilt(monkeypatch, tmp_path):
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
     path = _cache_file(tmp_path)


### PR DESCRIPTION
## Summary

Treat ollama as the **offline-only** fallback. When online, the auto-router excludes ollama from the candidate chain; OpenRouter (with cheap-tier model selection) covers the cost-tier fallback slot ollama was nominally filling.

This generalizes #143 b4 (skip-on-context-overflow) and #191 b2 (refuse-for-code/high) into a single coherent policy.

### When ollama stays in the chain

1. `--offline` flag set (operator's explicit "use local").
2. `offline_mode.is_active()` is true (sticky offline-until cache).
3. Network probe returns no RTT samples (provider endpoint AND fallback target both unreachable).
4. Operator explicitly listed `ollama` in `--tags`.

Carve-outs (1) and (2) emit no extra stderr line — they're explicit operator state already announced elsewhere. (3) emits `[conductor] including ollama as local fallback (network probe found no reachable target; assuming offline)`. The new `--tags` flag on `ask` makes (4) reachable.

### When ollama is excluded (the new default for online operators)

```
[conductor] excluding ollama from fallback chain (online; ollama is offline-only — pass --offline to override)
```

### One code path

`_exclude_ollama_from_strong_code_plan` (from #191 b2) is replaced by the new general `_apply_ollama_offline_only_policy`. The strong-code-no-fallback error message shape is preserved at its existing call site.

### Adjacent fix in network_profile

`get_network_profile` now caches probe failures (rtt_ms=None) too. Without this, the new policy would re-probe on every offline invocation. TTL is the existing 10-min — same as for successful probes.

Closes #216.

## Test plan

- [x] `tests/test_cli_v02.py` (extensive): online → ollama excluded; `--offline` → present; `offline_mode.is_active()` → present; probe-no-samples → present with the inclusion line; `--with ollama` direct → unaffected; `--tags ollama` → present; code/high → still excluded via the general path.
- [x] `tests/test_network_profile.py` (28 new lines): None-rtt caching, TTL behavior.
- [x] `uv run pytest tests/` — 915 passed, 15 skipped.
- [x] `uv run ruff check src/ tests/` — clean.
- [x] `uv run mypy src/conductor/cli.py` — clean.