### PR TITLE
feat: filesystem-flock startup serialization for CLI providers (#222)

### DIFF
--- a/src/conductor/providers/_startup_lock.py
+++ b/src/conductor/providers/_startup_lock.py
@@ -1,0 +1,309 @@
+"""Per-provider filesystem locks for CLI startup contention windows."""
+
+from __future__ import annotations
+
+import contextlib
+import errno
+import os
+import subprocess
+import sys
+import time
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import IO, TYPE_CHECKING, Any
+
+if os.name == "posix":
+    import fcntl
+else:  # pragma: no cover - exercised only on non-POSIX platforms.
+    fcntl = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:
+    from conductor.session_log import SessionLog
+
+StartupProcessSnapshot = tuple[int, str]
+SnapshotProvider = Callable[[], StartupProcessSnapshot]
+
+STARTUP_LOCK_TIMEOUT_SEC = 30.0
+
+
+@dataclass
+class StartupLockHandle:
+    provider: str
+    path: Path | None
+    acquired: bool
+    waited_sec: float
+    _fh: IO[Any] | None = None
+    _session_log: SessionLog | None = None
+    _released: bool = False
+
+    def release(self) -> None:
+        if self._released:
+            return
+        self._released = True
+        if not self.acquired or self._fh is None or fcntl is None:
+            return
+        try:
+            fcntl.flock(self._fh.fileno(), fcntl.LOCK_UN)
+        except OSError as exc:
+            sys.stderr.write(
+                f"[conductor] {self.provider} startup lock release failed: {exc}\n"
+            )
+            sys.stderr.flush()
+            if self._session_log is not None:
+                self._session_log.emit(
+                    "provider_startup_lock",
+                    {
+                        "provider": self.provider,
+                        "action": "release_failed",
+                        "path": str(self.path),
+                        "error": str(exc),
+                    },
+                )
+            return
+        if self._session_log is not None:
+            self._session_log.emit(
+                "provider_startup_lock",
+                {
+                    "provider": self.provider,
+                    "action": "released",
+                    "path": str(self.path),
+                },
+            )
+
+
+def _lock_dir() -> Path:
+    return Path.home() / ".cache" / "conductor" / "locks"
+
+
+def _format_seconds(value: float) -> str:
+    if float(value).is_integer():
+        return str(int(value))
+    return f"{value:g}"
+
+
+def _default_process_snapshot(provider: str) -> StartupProcessSnapshot:
+    if os.name != "posix":
+        return 0, "process snapshot unavailable on this platform"
+    user = os.environ.get("USER")
+    if not user:
+        return 0, "USER is not set; process snapshot skipped"
+    try:
+        result = subprocess.run(
+            ["ps", "-u", user, "-o", "pid=,ppid=,command="],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return 0, f"process snapshot failed: {exc}"
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        return 0, f"process snapshot exited {result.returncode}: {detail[:160]}"
+
+    current_pid = os.getpid()
+    matches: list[str] = []
+    for line in result.stdout.splitlines():
+        parts = line.strip().split(maxsplit=2)
+        if len(parts) < 3:
+            continue
+        try:
+            pid = int(parts[0])
+        except ValueError:
+            continue
+        if pid == current_pid:
+            continue
+        command = parts[2]
+        executable = command.split(maxsplit=1)[0]
+        if Path(executable).name != provider:
+            continue
+        matches.append(f"pid={pid} {command[:120]}")
+    return len(matches), "; ".join(matches) if matches else "none"
+
+
+def _emit_timeout_diagnostic(
+    *,
+    provider: str,
+    waited_sec: float,
+    snapshot_provider: SnapshotProvider | None,
+    session_log: SessionLog | None,
+) -> None:
+    try:
+        count, detail = (
+            snapshot_provider()
+            if snapshot_provider is not None
+            else _default_process_snapshot(provider)
+        )
+    except Exception as exc:  # noqa: BLE001 - diagnostics must not block startup.
+        count, detail = 0, f"process snapshot failed: {exc!r}"
+
+    seconds = _format_seconds(waited_sec)
+    sys.stderr.write(
+        f"[conductor] {provider} startup lock contended; waited {seconds}s. "
+        f"{count} other {provider} processes alive ({detail}). "
+        "Proceeding without startup lock.\n"
+    )
+    sys.stderr.flush()
+    if session_log is not None:
+        session_log.emit(
+            "provider_startup_lock",
+            {
+                "provider": provider,
+                "action": "timeout",
+                "waited_sec": waited_sec,
+                "live_process_count": count,
+                "live_processes": detail,
+            },
+        )
+
+
+@contextlib.contextmanager
+def provider_startup_lock(
+    provider: str,
+    *,
+    timeout_sec: float = STARTUP_LOCK_TIMEOUT_SEC,
+    session_log: SessionLog | None = None,
+    snapshot_provider: SnapshotProvider | None = None,
+) -> Iterator[StartupLockHandle]:
+    """Serialize one provider's CLI startup across conductor processes."""
+
+    if os.name != "posix" or fcntl is None:
+        yield StartupLockHandle(
+            provider=provider,
+            path=None,
+            acquired=False,
+            waited_sec=0.0,
+            _session_log=session_log,
+        )
+        return
+
+    lock_path = _lock_dir() / f"{provider}-startup.lock"
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        fh = lock_path.open("a+", encoding="utf-8")
+    except OSError as exc:
+        sys.stderr.write(
+            f"[conductor] {provider} startup lock unavailable at {lock_path}: "
+            f"{exc}. Proceeding without startup lock.\n"
+        )
+        sys.stderr.flush()
+        if session_log is not None:
+            session_log.emit(
+                "provider_startup_lock",
+                {
+                    "provider": provider,
+                    "action": "unavailable",
+                    "path": str(lock_path),
+                    "error": str(exc),
+                },
+            )
+        yield StartupLockHandle(
+            provider=provider,
+            path=lock_path,
+            acquired=False,
+            waited_sec=0.0,
+            _session_log=session_log,
+        )
+        return
+    start = time.monotonic()
+    handle = StartupLockHandle(
+        provider=provider,
+        path=lock_path,
+        acquired=False,
+        waited_sec=0.0,
+        _fh=fh,
+        _session_log=session_log,
+    )
+    try:
+        while True:
+            try:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError as exc:
+                if exc.errno not in (errno.EACCES, errno.EAGAIN):
+                    raise
+                waited = time.monotonic() - start
+                if waited >= timeout_sec:
+                    handle.waited_sec = waited
+                    _emit_timeout_diagnostic(
+                        provider=provider,
+                        waited_sec=timeout_sec,
+                        snapshot_provider=snapshot_provider,
+                        session_log=session_log,
+                    )
+                    yield handle
+                    return
+                time.sleep(min(0.05, max(0.0, timeout_sec - waited)))
+                continue
+            else:
+                handle.acquired = True
+                handle.waited_sec = time.monotonic() - start
+                if session_log is not None:
+                    session_log.emit(
+                        "provider_startup_lock",
+                        {
+                            "provider": provider,
+                            "action": "acquired",
+                            "path": str(lock_path),
+                            "waited_sec": round(handle.waited_sec, 3),
+                        },
+                    )
+                yield handle
+                return
+    finally:
+        handle.release()
+        fh.close()
+
+
+def release_startup_lock(handle: object) -> None:
+    release = getattr(handle, "release", None)
+    if callable(release):
+        release()
+
+
+def claude_startup_lock(
+    timeout_sec: float = STARTUP_LOCK_TIMEOUT_SEC,
+    *,
+    session_log: SessionLog | None = None,
+    snapshot_provider: SnapshotProvider | None = None,
+) -> contextlib.AbstractContextManager[StartupLockHandle]:
+    """Serialize Claude CLI startups across all conductor processes for this user.
+
+    File: ~/.cache/conductor/locks/claude-startup.lock
+    Held only during the startup window (release as soon as first output arrives
+    or initial probe completes). Mid-task / long-running phases are NOT held.
+    """
+
+    return provider_startup_lock(
+        "claude",
+        timeout_sec=timeout_sec,
+        session_log=session_log,
+        snapshot_provider=snapshot_provider,
+    )
+
+
+def codex_startup_lock(
+    timeout_sec: float = STARTUP_LOCK_TIMEOUT_SEC,
+    *,
+    session_log: SessionLog | None = None,
+    snapshot_provider: SnapshotProvider | None = None,
+) -> contextlib.AbstractContextManager[StartupLockHandle]:
+    return provider_startup_lock(
+        "codex",
+        timeout_sec=timeout_sec,
+        session_log=session_log,
+        snapshot_provider=snapshot_provider,
+    )
+
+
+def gemini_startup_lock(
+    timeout_sec: float = STARTUP_LOCK_TIMEOUT_SEC,
+    *,
+    session_log: SessionLog | None = None,
+    snapshot_provider: SnapshotProvider | None = None,
+) -> contextlib.AbstractContextManager[StartupLockHandle]:
+    return provider_startup_lock(
+        "gemini",
+        timeout_sec=timeout_sec,
+        session_log=session_log,
+        snapshot_provider=snapshot_provider,
+    )

--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from conductor.providers._startup_lock import claude_startup_lock
 from conductor.providers.cli_auth import (
     AuthPromptTracker,
     CapturedProcessResult,
@@ -162,6 +163,20 @@ def _probe_claude_lock_files(errors: list[str]) -> list[Path]:
         errors.append(f"claude lock-file probe failed: {e}")
         return []
     return sorted(path for path in candidates if path.is_file())
+
+
+def _claude_startup_lock_snapshot() -> tuple[int, str]:
+    probe = probe_claude_state()
+    details: list[str] = [
+        f"pid={proc.pid} ppid={proc.ppid} {proc.command[:120]}"
+        for proc in probe.live_processes
+    ]
+    if probe.lock_files:
+        details.append(
+            "lock_files=" + ",".join(str(path) for path in probe.lock_files[:5])
+        )
+    details.extend(probe.probe_errors)
+    return len(probe.live_processes), "; ".join(details) if details else "none"
 
 
 class ClaudeProvider:
@@ -763,6 +778,10 @@ class ClaudeProvider:
                     session_log=session_log,
                     tracker=tracker,
                     popen_factory=subprocess.Popen,
+                    startup_lock=claude_startup_lock(
+                        session_log=session_log,
+                        snapshot_provider=_claude_startup_lock_snapshot,
+                    ),
                 )
             except ProviderStartupStalledError as e:
                 probe = probe_claude_state()

--- a/src/conductor/providers/cli_auth.py
+++ b/src/conductor/providers/cli_auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import queue
 import re
@@ -12,6 +13,7 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from conductor.providers._startup_lock import release_startup_lock
 from conductor.providers.interface import (
     ProviderHTTPError,
     ProviderStalledError,
@@ -198,177 +200,188 @@ def run_subprocess_with_live_stderr(
     session_log: SessionLog | None = None,
     tracker: AuthPromptTracker,
     popen_factory,
+    startup_lock: contextlib.AbstractContextManager | None = None,
 ) -> CapturedProcessResult:
     """Run a subprocess while inspecting stderr for auth prompts live."""
 
     start = time.monotonic()
-    process = popen_factory(
-        args,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        cwd=cwd,
-        env=env,
-    )
+    lock_context = startup_lock or contextlib.nullcontext()
+    with lock_context as startup_lock_handle:
+        process = popen_factory(
+            args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=cwd,
+            env=env,
+        )
 
-    parts: dict[str, list[str]] = {"stdout": [], "stderr": []}
-    stream_done = {"stdout": False, "stderr": False}
-    stream_q: queue.Queue[tuple[str, str | None]] = queue.Queue()
+        parts: dict[str, list[str]] = {"stdout": [], "stderr": []}
+        stream_done = {"stdout": False, "stderr": False}
+        stream_q: queue.Queue[tuple[str, str | None]] = queue.Queue()
 
-    def read_stream(name: str, pipe) -> None:
+        def read_stream(name: str, pipe) -> None:
+            try:
+                read = getattr(pipe, "read", None)
+                while True:
+                    chunk = read(1) if read is not None else pipe.readline()
+                    if chunk == "":
+                        break
+                    stream_q.put((name, chunk))
+            finally:
+                stream_q.put((name, None))
+
+        stdout_thread = threading.Thread(
+            target=read_stream, args=("stdout", process.stdout), daemon=True
+        )
+        stderr_thread = threading.Thread(
+            target=read_stream, args=("stderr", process.stderr), daemon=True
+        )
+        stdout_thread.start()
+        stderr_thread.start()
+
+        last_output = start
+        saw_output = False
+        provider_label = provider_name or str(args[0])
+        stderr_tail = ""
         try:
-            read = getattr(pipe, "read", None)
             while True:
-                chunk = read(1) if read is not None else pipe.readline()
-                if chunk == "":
-                    break
-                stream_q.put((name, chunk))
-        finally:
-            stream_q.put((name, None))
-
-    stdout_thread = threading.Thread(
-        target=read_stream, args=("stdout", process.stdout), daemon=True
-    )
-    stderr_thread = threading.Thread(
-        target=read_stream, args=("stderr", process.stderr), daemon=True
-    )
-    stdout_thread.start()
-    stderr_thread.start()
-
-    last_output = start
-    saw_output = False
-    provider_label = provider_name or str(args[0])
-    stderr_tail = ""
-    while True:
-        now = time.monotonic()
-        if timeout is not None and now - start > timeout:
-            _terminate_process(process)
-            stdout_thread.join(timeout=1)
-            stderr_thread.join(timeout=1)
-            _drain_stream_queue(stream_q, parts, tracker)
-            raise subprocess.TimeoutExpired(
-                cmd=args,
-                timeout=timeout,
-                output="".join(parts["stdout"]),
-                stderr="".join(parts["stderr"]),
-            )
-
-        if (
-            first_output_timeout_sec is not None
-            and not saw_output
-            and stream_q.empty()
-            and now - start > first_output_timeout_sec
-        ):
-            _terminate_process(process)
-            stdout_thread.join(timeout=1)
-            stderr_thread.join(timeout=1)
-            _drain_stream_queue(stream_q, parts, tracker)
-            elapsed = time.monotonic() - start
-            reason = (
-                "no_initial_provider_output_within_"
-                f"{_format_stall_seconds(first_output_timeout_sec)}s"
-            )
-            if session_log is not None:
-                session_log.emit(
-                    "error",
-                    {
-                        "provider": provider_label,
-                        "reason": reason,
-                        "phase": "first_output",
-                        "last_event": "provider_started",
-                        "silent_sec": round(elapsed, 1),
-                    },
-                )
-            raise ProviderStartupStalledError(
-                provider=provider_label,
-                timeout_sec=first_output_timeout_sec,
-            )
-
-        if (
-            max_stall_sec is not None
-            and stream_q.empty()
-            and now - last_output > max_stall_sec
-        ):
-            _terminate_process(process)
-            stdout_thread.join(timeout=1)
-            stderr_thread.join(timeout=1)
-            _drain_stream_queue(stream_q, parts, tracker)
-            elapsed = time.monotonic() - last_output
-            last_event = (
-                "provider_output"
-                if parts["stdout"] or parts["stderr"]
-                else "provider_started"
-            )
-            reason = (
-                "no_provider_response_within_"
-                f"{_format_stall_seconds(max_stall_sec)}s"
-            )
-            if session_log is not None:
-                session_log.emit(
-                    "error",
-                    {
-                        "provider": provider_label,
-                        "reason": reason,
-                        "last_event": last_event,
-                        "silent_sec": round(elapsed, 1),
-                    },
-                )
-            raise ProviderStalledError(
-                f"{provider_label} CLI stalled after {elapsed:.0f}s with no output"
-            )
-
-        try:
-            stream_name, item = stream_q.get(timeout=0.05)
-        except queue.Empty:
-            if all(stream_done.values()) and process.poll() is not None:
-                break
-            continue
-
-        if item is None:
-            stream_done[stream_name] = True
-            if all(stream_done.values()) and process.poll() is not None:
-                break
-            continue
-
-        parts[stream_name].append(item)
-        saw_output = True
-        last_output = time.monotonic()
-        if stream_name == "stderr":
-            tracker.observe_text(item, source="stderr")
-            stderr_tail = append_recent_text(stderr_tail, item)
-            signal = detect_retriable_provider_failure(
-                stderr_tail,
-                source="stderr",
-            )
-            if signal is not None:
-                _terminate_process(process)
-                stdout_thread.join(timeout=1)
-                stderr_thread.join(timeout=1)
-                _drain_stream_queue(stream_q, parts, tracker)
-                if session_log is not None:
-                    session_log.emit(
-                        "error",
-                        {
-                            "provider": provider_label,
-                            "reason": "provider_terminal_failure",
-                            "category": signal.category,
-                            "source": signal.source,
-                            "status_code": signal.status_code,
-                            "detail": signal.detail,
-                        },
+                now = time.monotonic()
+                if timeout is not None and now - start > timeout:
+                    _terminate_process(process)
+                    stdout_thread.join(timeout=1)
+                    stderr_thread.join(timeout=1)
+                    _drain_stream_queue(stream_q, parts, tracker)
+                    raise subprocess.TimeoutExpired(
+                        cmd=args,
+                        timeout=timeout,
+                        output="".join(parts["stdout"]),
+                        stderr="".join(parts["stderr"]),
                     )
-                raise ProviderHTTPError(signal.error_message(provider_label))
 
-    returncode = process.wait()
-    stdout_thread.join(timeout=1)
-    stderr_thread.join(timeout=1)
-    _drain_stream_queue(stream_q, parts, tracker)
-    return CapturedProcessResult(
-        returncode=returncode,
-        stdout="".join(parts["stdout"]),
-        stderr="".join(parts["stderr"]),
-        duration_ms=int((time.monotonic() - start) * 1000),
-    )
+                if (
+                    first_output_timeout_sec is not None
+                    and not saw_output
+                    and stream_q.empty()
+                    and now - start > first_output_timeout_sec
+                ):
+                    _terminate_process(process)
+                    stdout_thread.join(timeout=1)
+                    stderr_thread.join(timeout=1)
+                    _drain_stream_queue(stream_q, parts, tracker)
+                    elapsed = time.monotonic() - start
+                    reason = (
+                        "no_initial_provider_output_within_"
+                        f"{_format_stall_seconds(first_output_timeout_sec)}s"
+                    )
+                    if session_log is not None:
+                        session_log.emit(
+                            "error",
+                            {
+                                "provider": provider_label,
+                                "reason": reason,
+                                "phase": "first_output",
+                                "last_event": "provider_started",
+                                "silent_sec": round(elapsed, 1),
+                            },
+                        )
+                    raise ProviderStartupStalledError(
+                        provider=provider_label,
+                        timeout_sec=first_output_timeout_sec,
+                    )
+
+                if (
+                    max_stall_sec is not None
+                    and stream_q.empty()
+                    and now - last_output > max_stall_sec
+                ):
+                    _terminate_process(process)
+                    stdout_thread.join(timeout=1)
+                    stderr_thread.join(timeout=1)
+                    _drain_stream_queue(stream_q, parts, tracker)
+                    elapsed = time.monotonic() - last_output
+                    last_event = (
+                        "provider_output"
+                        if parts["stdout"] or parts["stderr"]
+                        else "provider_started"
+                    )
+                    reason = (
+                        "no_provider_response_within_"
+                        f"{_format_stall_seconds(max_stall_sec)}s"
+                    )
+                    if session_log is not None:
+                        session_log.emit(
+                            "error",
+                            {
+                                "provider": provider_label,
+                                "reason": reason,
+                                "last_event": last_event,
+                                "silent_sec": round(elapsed, 1),
+                            },
+                        )
+                    raise ProviderStalledError(
+                        f"{provider_label} CLI stalled after "
+                        f"{elapsed:.0f}s with no output"
+                    )
+
+                try:
+                    stream_name, item = stream_q.get(timeout=0.05)
+                except queue.Empty:
+                    if all(stream_done.values()) and process.poll() is not None:
+                        break
+                    continue
+
+                if item is None:
+                    stream_done[stream_name] = True
+                    if all(stream_done.values()) and process.poll() is not None:
+                        break
+                    continue
+
+                if not saw_output:
+                    release_startup_lock(startup_lock_handle)
+                parts[stream_name].append(item)
+                saw_output = True
+                last_output = time.monotonic()
+                if stream_name != "stderr":
+                    continue
+
+                tracker.observe_text(item, source="stderr")
+                stderr_tail = append_recent_text(stderr_tail, item)
+                signal = detect_retriable_provider_failure(
+                    stderr_tail,
+                    source="stderr",
+                )
+                if signal is not None:
+                    _terminate_process(process)
+                    stdout_thread.join(timeout=1)
+                    stderr_thread.join(timeout=1)
+                    _drain_stream_queue(stream_q, parts, tracker)
+                    if session_log is not None:
+                        session_log.emit(
+                            "error",
+                            {
+                                "provider": provider_label,
+                                "reason": "provider_terminal_failure",
+                                "category": signal.category,
+                                "source": signal.source,
+                                "status_code": signal.status_code,
+                                "detail": signal.detail,
+                            },
+                        )
+                    raise ProviderHTTPError(signal.error_message(provider_label))
+
+            returncode = process.wait()
+            stdout_thread.join(timeout=1)
+            stderr_thread.join(timeout=1)
+            _drain_stream_queue(stream_q, parts, tracker)
+            return CapturedProcessResult(
+                returncode=returncode,
+                stdout="".join(parts["stdout"]),
+                stderr="".join(parts["stderr"]),
+                duration_ms=int((time.monotonic() - start) * 1000),
+            )
+        finally:
+            release_startup_lock(startup_lock_handle)
 
 
 def _drain_stream_queue(

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING
 from conductor import __version__ as _conductor_version
 from conductor.offline_mode import _cache_dir
 from conductor.orphan_detect import find_orphan_codex_processes, format_orphan_hints
+from conductor.providers._startup_lock import codex_startup_lock, release_startup_lock
 from conductor.providers.cli_auth import AuthPromptTracker
 from conductor.providers.interface import (
     CallResponse,
@@ -909,15 +910,25 @@ class CodexProvider:
         session_log: SessionLog | None,
     ) -> CallResponse:
         start = time.monotonic()
-        process = subprocess.Popen(
-            args,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            cwd=cwd,
-            env=os.environ.copy(),
+        startup_lock_context = codex_startup_lock(
+            session_log=session_log,
+            snapshot_provider=self._codex_startup_lock_snapshot,
         )
+        startup_lock_handle = startup_lock_context.__enter__()
+        try:
+            process = subprocess.Popen(
+                args,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                cwd=cwd,
+                env=os.environ.copy(),
+            )
+        except BaseException:
+            release_startup_lock(startup_lock_handle)
+            startup_lock_context.__exit__(*sys.exc_info())
+            raise
         # Pipe the prompt via stdin and close — codex exec reads until EOF.
         # If write blocks (huge prompt + slow consumer), we'd hang here, but
         # codex's own ingestion is fast and the prompt fits in the pipe
@@ -1125,6 +1136,7 @@ class CodexProvider:
                         break
                     continue
 
+                release_startup_lock(startup_lock_handle)
                 if stream_name == "stderr":
                     stderr_parts.append(item)
                     last_output = time.monotonic()
@@ -1203,6 +1215,8 @@ class CodexProvider:
                             )
                             session_id_emitted = True
         finally:
+            release_startup_lock(startup_lock_handle)
+            startup_lock_context.__exit__(None, None, None)
             done_event.set()
             if timeout_thread is not None:
                 timeout_thread.join(timeout=0.1)
@@ -1381,6 +1395,12 @@ class CodexProvider:
             except Exception as exc:  # noqa: BLE001
                 sys.stderr.write(f"[conductor] orphan detection failed: {exc!r}\n")
         return message
+
+    def _codex_startup_lock_snapshot(self) -> tuple[int, str]:
+        orphans = find_orphan_codex_processes(self._cli)
+        if not orphans:
+            return 0, "no stale codex startup processes detected"
+        return len(orphans), format_orphan_hints(orphans)
 
     def _save_forensic_envelope(
         self,

--- a/src/conductor/providers/gemini.py
+++ b/src/conductor/providers/gemini.py
@@ -21,6 +21,7 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from conductor.providers._startup_lock import gemini_startup_lock
 from conductor.providers.cli_auth import (
     AuthPromptTracker,
     CapturedProcessResult,
@@ -567,6 +568,7 @@ class GeminiProvider:
                     session_log=session_log,
                     tracker=tracker,
                     popen_factory=subprocess.Popen,
+                    startup_lock=gemini_startup_lock(session_log=session_log),
                 )
             else:
                 completed = subprocess.run(

--- a/tests/test_startup_lock.py
+++ b/tests/test_startup_lock.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import errno
+import os
+import threading
+import time
+
+import pytest
+
+from conductor.providers import _startup_lock
+from conductor.providers._startup_lock import claude_startup_lock
+from conductor.providers.cli_auth import AuthPromptTracker, run_subprocess_with_live_stderr
+
+pytestmark = pytest.mark.skipif(os.name != "posix", reason="flock is POSIX-only")
+
+
+class _DelayedPipe:
+    def __init__(
+        self,
+        text: str,
+        *,
+        first_delay: float = 0.0,
+        on_eof=None,
+    ) -> None:
+        self._text = text
+        self._first_delay = first_delay
+        self._on_eof = on_eof
+        self._sent = False
+        self._closed = False
+
+    def read(self, size: int = -1) -> str:
+        if self._closed:
+            return ""
+        if not self._sent:
+            self._sent = True
+            if self._first_delay:
+                time.sleep(self._first_delay)
+            return self._text
+        self._closed = True
+        if self._on_eof is not None:
+            self._on_eof()
+        return ""
+
+    def readline(self) -> str:
+        return self.read()
+
+
+class _StartupFakePopen:
+    def __init__(self, stdout_delay: float) -> None:
+        self.returncode: int | None = None
+        self._finished = threading.Event()
+        self.stdout = _DelayedPipe(
+            "ok\n",
+            first_delay=stdout_delay,
+            on_eof=self._finish,
+        )
+        self.stderr = _DelayedPipe("", on_eof=self._finish)
+
+    def _finish(self) -> None:
+        if self.returncode is None:
+            self.returncode = 0
+            self._finished.set()
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def wait(self, timeout: float | None = None) -> int:
+        self.returncode = 0
+        self._finished.set()
+        return 0
+
+    def terminate(self) -> None:
+        self.returncode = -15
+        self._finished.set()
+
+    def kill(self) -> None:
+        self.returncode = -9
+        self._finished.set()
+
+
+def test_live_subprocess_startup_lock_serializes_popen_until_first_output(
+    monkeypatch, tmp_path
+) -> None:
+    lock_state = {"locked": False}
+    lock_guard = threading.Lock()
+
+    def fake_flock(_fd: int, op: int) -> None:
+        with lock_guard:
+            if op & _startup_lock.fcntl.LOCK_UN:
+                lock_state["locked"] = False
+                return
+            if not (op & _startup_lock.fcntl.LOCK_EX):
+                return
+            if lock_state["locked"]:
+                raise OSError(errno.EAGAIN, "locked")
+            lock_state["locked"] = True
+
+    monkeypatch.setattr(_startup_lock, "_lock_dir", lambda: tmp_path)
+    monkeypatch.setattr(_startup_lock.fcntl, "flock", fake_flock)
+
+    popen_times: list[float] = []
+    popen_guard = threading.Lock()
+
+    def run_one(stdout_delay: float) -> None:
+        def popen_factory(*_args, **_kwargs):
+            with popen_guard:
+                popen_times.append(time.monotonic())
+            return _StartupFakePopen(stdout_delay)
+
+        run_subprocess_with_live_stderr(
+            args=["claude"],
+            cwd=None,
+            env=None,
+            timeout=3,
+            provider_name="claude",
+            tracker=AuthPromptTracker("claude"),
+            popen_factory=popen_factory,
+            startup_lock=claude_startup_lock(timeout_sec=1),
+        )
+
+    first = threading.Thread(target=run_one, args=(0.12,))
+    second = threading.Thread(target=run_one, args=(0.0,))
+
+    first.start()
+    time.sleep(0.02)
+    second.start()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert len(popen_times) == 2
+    assert popen_times[1] - popen_times[0] >= 0.08
+
+
+def test_startup_lock_timeout_emits_diagnostic_and_proceeds(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    def always_locked(_fd: int, op: int) -> None:
+        if op & _startup_lock.fcntl.LOCK_UN:
+            return
+        raise OSError(errno.EAGAIN, "locked")
+
+    monkeypatch.setattr(_startup_lock, "_lock_dir", lambda: tmp_path)
+    monkeypatch.setattr(_startup_lock.fcntl, "flock", always_locked)
+
+    with claude_startup_lock(
+        timeout_sec=0.01,
+        snapshot_provider=lambda: (2, "pid=111 claude; pid=222 claude"),
+    ) as handle:
+        assert handle.acquired is False
+
+    captured = capsys.readouterr()
+    assert (
+        "[conductor] claude startup lock contended; waited 0.01s. "
+        "2 other claude processes alive (pid=111 claude; pid=222 claude)."
+    ) in captured.err
+    assert "Proceeding without startup lock." in captured.err


### PR DESCRIPTION
Adds per-provider POSIX flock around the startup window for claude/codex/gemini. Lock released on first stdout/stderr byte; mid-task work runs unlocked. Fail-soft on timeout (30s) with diagnostic. This **prevents** the parallel-stall class instead of recovering from it (#146/#210 are the recovery layer). Closes #222.