### PR TITLE
fix: smoke job tap-refresh command (v0.10.0 workflow failure)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,12 @@ jobs:
 
           expected_version="${RELEASE_TAG#v}"
 
-          brew update --force --quiet autumngarage/conductor
+          # Re-tap to force a fresh fetch of the (just-bumped) tap repo;
+          # `brew update <name>` interprets <name> as a formula to upgrade,
+          # which fails with "no available formula" before the install step
+          # has had a chance to install it.
+          brew untap autumngarage/conductor || true
+          brew tap autumngarage/conductor
 
           formula_version="$(
             brew info --json=v2 autumngarage/conductor/conductor \


### PR DESCRIPTION
v0.10.0 release workflow caught this on first run of the new smoke job — `brew update <name>` was misinterpreted as upgrading a formula. Fix: untap+retap to force a fresh tap-repo fetch. The tap-bump itself was fine (v0.10.0 IS at the tap and installs cleanly), only the smoke validation step failed.