### PR TITLE
fix: merge-pr.sh removes the worktree of the merged branch

### DIFF
--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -136,6 +136,79 @@ worktree_path_for_branch() {
   return 0
 }
 
+main_worktree_path() {
+  local line key value
+
+  git worktree list --porcelain | while IFS= read -r line || [ -n "$line" ]; do
+    [ -n "$line" ] || break
+    key="${line%% *}"
+    value="${line#* }"
+    if [ "$key" = "worktree" ]; then
+      printf '%s\n' "$value"
+      break
+    fi
+  done
+}
+
+removable_worktree_path_for_branch() {
+  local branch="$1"
+  local branch_worktree main_worktree
+
+  branch_worktree="$(worktree_path_for_branch "$branch" | head -n 1)"
+  if [ -z "$branch_worktree" ]; then
+    return 0
+  fi
+  main_worktree="$(main_worktree_path)"
+  if [ "$branch_worktree" = "$main_worktree" ]; then
+    return 0
+  fi
+  printf '%s\n' "$branch_worktree"
+}
+
+git_common_dir_for_worktree() {
+  local path="$1"
+  local common_dir
+
+  common_dir="$(git -C "$path" rev-parse --git-common-dir)"
+  case "$common_dir" in
+    /*) printf '%s\n' "$common_dir" ;;
+    *) (cd "$path" && cd "$common_dir" && pwd) ;;
+  esac
+}
+
+worktree_has_uncommitted_changes() {
+  local path="$1"
+
+  [ -n "$(git -C "$path" status --porcelain)" ]
+}
+
+remove_clean_merged_branch_worktree() {
+  local path="$1"
+  local current_worktree common_git_dir
+
+  if [ -z "$path" ]; then
+    return 0
+  fi
+  if [ ! -d "$path" ]; then
+    echo "WARNING: merged branch worktree path no longer exists: $path" >&2
+    return 0
+  fi
+  if worktree_has_uncommitted_changes "$path"; then
+    echo "WARN: worktree at $path has uncommitted changes; not removing — operator action required" >&2
+    return 0
+  fi
+
+  current_worktree="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  if [ "$path" = "$current_worktree" ]; then
+    common_git_dir="$(git_common_dir_for_worktree "$path")"
+    cd /
+    git --git-dir="$common_git_dir" worktree remove "$path"
+  else
+    git worktree remove "$path"
+  fi
+  echo "==> Removed worktree at $path"
+}
+
 branch_has_clean_review_marker() {
   local branch="$1"
   local head_oid="$2"
@@ -234,7 +307,7 @@ checkout_default_ref_for_cleanup() {
 cleanup_local_pr_branch_after_merge() {
   local branch="$PR_HEAD_BRANCH"
   local reviewed_head="$REVIEWED_HEAD_OID"
-  local local_head pr_state
+  local local_head pr_state branch_worktree cleanup_git_dir
 
   if [ -z "$branch" ] || [ -z "$reviewed_head" ]; then
     echo "WARNING: Missing reviewed PR head metadata; skipping local branch cleanup." >&2
@@ -261,13 +334,17 @@ cleanup_local_pr_branch_after_merge() {
     echo "WARNING: PR #$PR_NUMBER is not confirmed MERGED (state: ${pr_state:-unknown}); leaving local branch '$branch' intact." >&2
     return 0
   fi
+  branch_worktree="$(removable_worktree_path_for_branch "$branch")"
+  cleanup_git_dir="$(git_common_dir_for_worktree "$(git rev-parse --show-toplevel)")"
 
   if ! checkout_default_ref_for_cleanup "$branch" "$reviewed_head"; then
     return 0
   fi
 
+  remove_clean_merged_branch_worktree "$branch_worktree"
+
   echo "==> Deleting local branch '$branch' after verified squash merge of $reviewed_head ..."
-  if git branch -D "$branch"; then
+  if git --git-dir="$cleanup_git_dir" branch -D "$branch"; then
     echo "==> Local branch '$branch' deleted."
   else
     echo "WARNING: Could not delete local branch '$branch' after verified merge." >&2

--- a/tests/test-merge-pr-worktree-handling.sh
+++ b/tests/test-merge-pr-worktree-handling.sh
@@ -33,6 +33,16 @@ git -C "$TEST_REPO" branch feature
 git -C "$TEST_REPO" worktree add -q "$FEATURE_WORKTREE" feature
 
 extract_function "worktree_path_for_branch" "$MERGE_SCRIPT" "$FUNCTIONS_FILE"
+extract_function "main_worktree_path" "$MERGE_SCRIPT" "$FUNCTIONS_FILE.tmp"
+cat "$FUNCTIONS_FILE.tmp" >> "$FUNCTIONS_FILE"
+extract_function "removable_worktree_path_for_branch" "$MERGE_SCRIPT" "$FUNCTIONS_FILE.tmp"
+cat "$FUNCTIONS_FILE.tmp" >> "$FUNCTIONS_FILE"
+extract_function "git_common_dir_for_worktree" "$MERGE_SCRIPT" "$FUNCTIONS_FILE.tmp"
+cat "$FUNCTIONS_FILE.tmp" >> "$FUNCTIONS_FILE"
+extract_function "worktree_has_uncommitted_changes" "$MERGE_SCRIPT" "$FUNCTIONS_FILE.tmp"
+cat "$FUNCTIONS_FILE.tmp" >> "$FUNCTIONS_FILE"
+extract_function "remove_clean_merged_branch_worktree" "$MERGE_SCRIPT" "$FUNCTIONS_FILE.tmp"
+cat "$FUNCTIONS_FILE.tmp" >> "$FUNCTIONS_FILE"
 # shellcheck source=/dev/null
 source "$FUNCTIONS_FILE"
 
@@ -43,6 +53,76 @@ if [ "$actual" != "$expected" ]; then
   printf 'FAIL: worktree_path_for_branch main returned wrong path\n' >&2
   printf 'expected: %s\n' "$expected" >&2
   printf 'actual:   %s\n' "$actual" >&2
+  exit 1
+fi
+
+main_worktree="$(cd "$TEST_REPO" && main_worktree_path)"
+if [ "$main_worktree" != "$expected" ]; then
+  printf 'FAIL: main_worktree_path returned wrong path\n' >&2
+  printf 'expected: %s\n' "$expected" >&2
+  printf 'actual:   %s\n' "$main_worktree" >&2
+  exit 1
+fi
+
+main_branch_removable="$(cd "$TEST_REPO" && removable_worktree_path_for_branch main)"
+if [ -n "$main_branch_removable" ]; then
+  printf 'FAIL: main worktree was considered removable\n' >&2
+  printf 'actual: %s\n' "$main_branch_removable" >&2
+  exit 1
+fi
+
+feature_branch_removable="$(cd "$TEST_REPO" && removable_worktree_path_for_branch feature)"
+expected_feature_worktree="$(git -C "$FEATURE_WORKTREE" rev-parse --show-toplevel)"
+if [ "$feature_branch_removable" != "$expected_feature_worktree" ]; then
+  printf 'FAIL: linked feature worktree was not considered removable\n' >&2
+  printf 'expected: %s\n' "$expected_feature_worktree" >&2
+  printf 'actual:   %s\n' "$feature_branch_removable" >&2
+  exit 1
+fi
+
+remove_output="$(cd "$TEST_REPO" && remove_clean_merged_branch_worktree "$FEATURE_WORKTREE")"
+if [ -d "$FEATURE_WORKTREE" ]; then
+  printf 'FAIL: clean feature worktree was not removed\n' >&2
+  exit 1
+fi
+if [ "$remove_output" != "==> Removed worktree at $FEATURE_WORKTREE" ]; then
+  printf 'FAIL: worktree removal printed wrong output\n' >&2
+  printf 'actual: %s\n' "$remove_output" >&2
+  exit 1
+fi
+
+CURRENT_WORKTREE="$TMP_ROOT/current-worktree"
+git -C "$TEST_REPO" branch current
+git -C "$TEST_REPO" worktree add -q "$CURRENT_WORKTREE" current
+current_output="$(cd "$CURRENT_WORKTREE" && remove_clean_merged_branch_worktree "$CURRENT_WORKTREE")"
+if [ -d "$CURRENT_WORKTREE" ]; then
+  printf 'FAIL: current clean worktree was not removed\n' >&2
+  exit 1
+fi
+if [ "$current_output" != "==> Removed worktree at $CURRENT_WORKTREE" ]; then
+  printf 'FAIL: current worktree removal printed wrong output\n' >&2
+  printf 'actual: %s\n' "$current_output" >&2
+  exit 1
+fi
+
+DIRTY_WORKTREE="$TMP_ROOT/dirty-worktree"
+git -C "$TEST_REPO" branch dirty
+git -C "$TEST_REPO" worktree add -q "$DIRTY_WORKTREE" dirty
+printf 'dirty\n' >> "$DIRTY_WORKTREE/README"
+dirty_stderr="$TMP_ROOT/dirty.stderr"
+dirty_output="$(cd "$TEST_REPO" && remove_clean_merged_branch_worktree "$DIRTY_WORKTREE" 2>"$dirty_stderr")"
+if [ ! -d "$DIRTY_WORKTREE" ]; then
+  printf 'FAIL: dirty feature worktree was removed\n' >&2
+  exit 1
+fi
+if [ -n "$dirty_output" ]; then
+  printf 'FAIL: dirty worktree removal printed stdout\n' >&2
+  printf 'actual: %s\n' "$dirty_output" >&2
+  exit 1
+fi
+if ! grep -Fq "WARN: worktree at $DIRTY_WORKTREE has uncommitted changes; not removing" "$dirty_stderr"; then
+  printf 'FAIL: dirty worktree removal did not warn clearly\n' >&2
+  cat "$dirty_stderr" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Closes #234.

After `gh pr merge --squash --delete-branch` succeeds, also resolve the
worktree (if any) for the just-merged branch and `git worktree remove`
it when it is not the current checkout and has no uncommitted changes.
Worktrees with uncommitted changes are preserved with a warning.

Touchstone has the same script vendored; this divergence is tracked
per the discipline in #192 / touchstone#171 and will be ported upstream
in a follow-up.

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
