### PR TITLE
fix: terminate claude exec child group on watchdog exit

### DIFF
--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -782,6 +782,8 @@ class ClaudeProvider:
                         session_log=session_log,
                         snapshot_provider=_claude_startup_lock_snapshot,
                     ),
+                    start_new_session=True,
+                    cleanup_process_group=True,
                 )
             except ProviderStartupStalledError as e:
                 probe = probe_claude_state()

--- a/src/conductor/providers/cli_auth.py
+++ b/src/conductor/providers/cli_auth.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import contextlib
 import json
+import logging
+import os
 import queue
 import re
+import signal
 import subprocess
 import sys
 import threading
@@ -42,6 +45,7 @@ _AUTH_TEXT_SIGNALS = (
     "waiting for oauth",
     "login --with-api-key",
 )
+_LOG = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -201,12 +205,16 @@ def run_subprocess_with_live_stderr(
     tracker: AuthPromptTracker,
     popen_factory,
     startup_lock: contextlib.AbstractContextManager | None = None,
+    start_new_session: bool = False,
+    cleanup_process_group: bool = False,
 ) -> CapturedProcessResult:
     """Run a subprocess while inspecting stderr for auth prompts live."""
 
     start = time.monotonic()
     lock_context = startup_lock or contextlib.nullcontext()
     with lock_context as startup_lock_handle:
+        process: subprocess.Popen[str] | None = None
+        child_pgid: int | None = None
         process = popen_factory(
             args,
             stdout=subprocess.PIPE,
@@ -214,7 +222,9 @@ def run_subprocess_with_live_stderr(
             text=True,
             cwd=cwd,
             env=env,
+            start_new_session=start_new_session,
         )
+        child_pgid = process.pid if cleanup_process_group else None
 
         parts: dict[str, list[str]] = {"stdout": [], "stderr": []}
         stream_done = {"stdout": False, "stderr": False}
@@ -248,7 +258,7 @@ def run_subprocess_with_live_stderr(
             while True:
                 now = time.monotonic()
                 if timeout is not None and now - start > timeout:
-                    _terminate_process(process)
+                    _terminate_process(process, child_pgid=child_pgid)
                     stdout_thread.join(timeout=1)
                     stderr_thread.join(timeout=1)
                     _drain_stream_queue(stream_q, parts, tracker)
@@ -265,7 +275,7 @@ def run_subprocess_with_live_stderr(
                     and stream_q.empty()
                     and now - start > first_output_timeout_sec
                 ):
-                    _terminate_process(process)
+                    _terminate_process(process, child_pgid=child_pgid)
                     stdout_thread.join(timeout=1)
                     stderr_thread.join(timeout=1)
                     _drain_stream_queue(stream_q, parts, tracker)
@@ -295,7 +305,7 @@ def run_subprocess_with_live_stderr(
                     and stream_q.empty()
                     and now - last_output > max_stall_sec
                 ):
-                    _terminate_process(process)
+                    _terminate_process(process, child_pgid=child_pgid)
                     stdout_thread.join(timeout=1)
                     stderr_thread.join(timeout=1)
                     _drain_stream_queue(stream_q, parts, tracker)
@@ -352,7 +362,7 @@ def run_subprocess_with_live_stderr(
                     source="stderr",
                 )
                 if signal is not None:
-                    _terminate_process(process)
+                    _terminate_process(process, child_pgid=child_pgid)
                     stdout_thread.join(timeout=1)
                     stderr_thread.join(timeout=1)
                     _drain_stream_queue(stream_q, parts, tracker)
@@ -381,6 +391,9 @@ def run_subprocess_with_live_stderr(
                 duration_ms=int((time.monotonic() - start) * 1000),
             )
         finally:
+            if process is not None:
+                # Invariant: child claude processes do not outlive their conductor exec wrapper.
+                _terminate_process(process, child_pgid=child_pgid)
             release_startup_lock(startup_lock_handle)
 
 
@@ -401,7 +414,18 @@ def _drain_stream_queue(
             tracker.observe_text(item, source="stderr")
 
 
-def _terminate_process(process: subprocess.Popen[str]) -> None:
+def _terminate_process(
+    process: subprocess.Popen[str],
+    *,
+    child_pgid: int | None = None,
+) -> None:
+    if child_pgid is not None:
+        _terminate_process_group(process, child_pgid)
+        return
+    _terminate_direct_process(process)
+
+
+def _terminate_direct_process(process: subprocess.Popen[str]) -> None:
     if process.poll() is not None:
         return
     process.terminate()
@@ -411,3 +435,48 @@ def _terminate_process(process: subprocess.Popen[str]) -> None:
         if process.poll() is None:
             process.kill()
             process.wait()
+
+
+def _terminate_process_group(process: subprocess.Popen[str], child_pgid: int) -> None:
+    try:
+        os.killpg(child_pgid, signal.SIGTERM)
+    except ProcessLookupError:
+        _LOG.debug("process group already gone during cleanup: pgid=%s", child_pgid)
+        _terminate_direct_process(process)
+        return
+    except OSError:
+        _LOG.exception("failed to terminate process group: pgid=%s", child_pgid)
+    if process.poll() is None:
+        process.terminate()
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if not _process_group_exists(child_pgid):
+            return
+        if process.poll() is None:
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                process.wait(timeout=min(0.1, max(0.0, deadline - time.monotonic())))
+        else:
+            time.sleep(0.05)
+    try:
+        os.killpg(child_pgid, signal.SIGKILL)
+    except ProcessLookupError:
+        _LOG.debug("process group already gone during kill: pgid=%s", child_pgid)
+        return
+    except OSError:
+        _LOG.exception("failed to kill process group: pgid=%s", child_pgid)
+        return
+    if process.poll() is None:
+        process.kill()
+    with contextlib.suppress(subprocess.TimeoutExpired):
+        process.wait(timeout=1)
+
+
+def _process_group_exists(child_pgid: int) -> bool:
+    try:
+        os.killpg(child_pgid, 0)
+    except ProcessLookupError:
+        return False
+    except OSError:
+        _LOG.exception("failed to probe process group: pgid=%s", child_pgid)
+        return False
+    return True

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -10,6 +10,7 @@ import io
 import json
 import os
 import shutil
+import signal
 import subprocess
 import threading
 import time
@@ -74,6 +75,34 @@ def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
         capture_output=True,
         text=True,
     )
+
+
+def _pid_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _read_pid_file(path: Path) -> int:
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        if path.exists():
+            return int(path.read_text(encoding="utf-8"))
+        time.sleep(0.02)
+    raise AssertionError(f"pid file was not written: {path}")
+
+
+def _wait_for_pid_gone(pid: int, *, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _pid_exists(pid):
+            return True
+        time.sleep(0.02)
+    return not _pid_exists(pid)
 
 
 def _repo_with_linked_worktree(tmp_path: Path) -> tuple[Path, Path]:
@@ -693,6 +722,51 @@ def test_claude_exec_retry_on_stall_can_succeed_after_respawn(
     assert response.text == "hello from claude"
 
 
+@pytest.mark.skipif(os.name != "posix", reason="process groups are POSIX-only")
+def test_claude_exec_startup_stall_terminates_child_process_group(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    child_pid_file = tmp_path / "claude-child.pid"
+    fake_claude = tmp_path / "fake-claude"
+    fake_claude.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env python3",
+                "import os",
+                "import pathlib",
+                "import subprocess",
+                "import sys",
+                "import time",
+                "pidfile = pathlib.Path(os.environ['CONDUCTOR_TEST_CHILD_PID'])",
+                "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)'])",
+                "pidfile.write_text(str(child.pid), encoding='utf-8')",
+                "time.sleep(60)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake_claude.chmod(0o755)
+    monkeypatch.setenv("CONDUCTOR_TEST_CHILD_PID", str(child_pid_file))
+
+    child_pid: int | None = None
+    try:
+        with pytest.raises(ProviderStartupStalledError):
+            ClaudeProvider(
+                cli_command=str(fake_claude),
+                exec_first_output_timeout_sec=1,
+            ).exec("hi", timeout_sec=5, max_stall_sec=30)
+
+        child_pid = _read_pid_file(child_pid_file)
+        assert _wait_for_pid_gone(child_pid, timeout=2)
+    finally:
+        if child_pid is None and child_pid_file.exists():
+            child_pid = _read_pid_file(child_pid_file)
+        if child_pid is not None and _pid_exists(child_pid):
+            os.kill(child_pid, signal.SIGKILL)
+
+
 def test_cli_exec_retry_on_stall_wires_to_claude_provider(
     mocker,
     monkeypatch,
@@ -1134,6 +1208,8 @@ class _FakeScheduledPipe:
 
 
 class _FakePopen:
+    _next_pid = 500000
+
     def __init__(
         self,
         *,
@@ -1148,6 +1224,8 @@ class _FakePopen:
         self.args: list[str] | None = None
         self.cwd: str | Path | None = None
         self.env: dict[str, str] | None = None
+        self.pid = _FakePopen._next_pid
+        _FakePopen._next_pid += 1
         self.returncode: int | None = None
         self.terminated = False
         self.killed = False


### PR DESCRIPTION
Closes #231.

Spawn the claude subprocess in its own process group via start_new_session=True; on every wrapper exit (first-output stall, max-stall, SIGINT, normal completion via finally:), SIGTERM the group, wait up to 5s, then SIGKILL if needed. Coordinates with --retry-on-stall: the failed attempt's group is terminated before the retry spawns.

Invariant: child claude processes do not outlive their conductor exec wrapper.

Regression test asserts no orphan child after a watchdog-killed run against a synthetic stalling provider.

conductor#230 (--retry-on-stall default) is a separate concern and is intentionally not bundled.

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
