### PR TITLE
feat: conductor git-cleanup + doctor flags stale branches and abandoned worktrees

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -47,6 +47,17 @@ from conductor.delegation_ledger import (
     read_delegations,
     record_delegation,
 )
+from conductor.git_state import (
+    DEFAULT_BRANCH_SCAN_LIMIT,
+    DEFAULT_KEEP_WORKTREE_DAYS,
+    AbandonedWorktree,
+    BranchScanLimit,
+    GitCleanupPlan,
+    GitStateError,
+    ProtectedRef,
+    StaleBranch,
+    scan_git_state,
+)
 from conductor.muted_providers import (
     MutedProvidersError,
     load_muted_provider_ids,
@@ -5567,6 +5578,7 @@ def _diagnostic_payload() -> dict:
         "credentials": env_info,
         "active_credentials": active_credentials,
         "agent_integration": _agent_integration_payload(),
+        "git_state": _git_state_doctor_payload(),
         "warnings": warnings,
     }
 
@@ -5661,6 +5673,279 @@ def _integration_version_skew_entries(
         )
     )
     return [entry for entry in managed_files if str(entry["path"]) in skewed_paths]
+
+
+def _stale_branch_payload(branch: StaleBranch) -> dict[str, str]:
+    return {
+        "name": branch.name,
+        "reason": branch.reason,
+        "last_commit": branch.last_commit,
+    }
+
+
+def _abandoned_worktree_payload(worktree: AbandonedWorktree) -> dict[str, object]:
+    return {
+        "path": str(worktree.path),
+        "branch": worktree.branch,
+        "reason": worktree.reason,
+        "last_commit": worktree.last_commit,
+    }
+
+
+def _protected_ref_payload(item: ProtectedRef) -> dict[str, str]:
+    return {
+        "kind": item.kind,
+        "name": item.name,
+        "reason": item.reason,
+    }
+
+
+def _git_cleanup_payload(plan: GitCleanupPlan) -> dict[str, object]:
+    return {
+        "stale_branches": [
+            _stale_branch_payload(branch) for branch in plan.stale_branches
+        ],
+        "abandoned_worktrees": [
+            _abandoned_worktree_payload(worktree)
+            for worktree in plan.abandoned_worktrees
+        ],
+        "protected": [_protected_ref_payload(item) for item in plan.protected],
+        "branch_scan": {
+            "checked": plan.branch_scan.checked,
+            "total": plan.branch_scan.total,
+            "limit": plan.branch_scan.limit,
+            "capped": plan.branch_scan.capped,
+        },
+    }
+
+
+def _git_state_doctor_payload() -> dict[str, object]:
+    try:
+        plan = scan_git_state(
+            keep_worktree_days=DEFAULT_KEEP_WORKTREE_DAYS,
+            branch_scan_limit=DEFAULT_BRANCH_SCAN_LIMIT,
+        )
+    except GitStateError as e:
+        return {
+            "stale_branches": [],
+            "abandoned_worktrees": [],
+            "branch_scan": {
+                "checked": 0,
+                "total": 0,
+                "limit": DEFAULT_BRANCH_SCAN_LIMIT,
+                "capped": False,
+            },
+            "error": str(e),
+        }
+    return {
+        "stale_branches": [
+            _stale_branch_payload(branch) for branch in plan.stale_branches
+        ],
+        "abandoned_worktrees": [
+            _abandoned_worktree_payload(worktree)
+            for worktree in plan.abandoned_worktrees
+        ],
+        "branch_scan": {
+            "checked": plan.branch_scan.checked,
+            "total": plan.branch_scan.total,
+            "limit": plan.branch_scan.limit,
+            "capped": plan.branch_scan.capped,
+        },
+        "error": None,
+    }
+
+
+def _format_worktree_age(worktree: AbandonedWorktree) -> str:
+    if worktree.last_commit_age_days is None:
+        return "last commit age unknown"
+    days = worktree.last_commit_age_days
+    unit = "day" if days == 1 else "days"
+    return f"last commit {days} {unit} ago"
+
+
+def _echo_branch_scan_cap(
+    branch_scan: dict[str, object] | BranchScanLimit,
+    *,
+    indent: str = "",
+) -> None:
+    if isinstance(branch_scan, dict):
+        capped = bool(branch_scan.get("capped"))
+        checked = branch_scan.get("checked")
+        total = branch_scan.get("total")
+    else:
+        capped = branch_scan.capped
+        checked = branch_scan.checked
+        total = branch_scan.total
+    if capped:
+        click.echo(f"{indent}(top {checked} of {total} branches checked)")
+
+
+def _run_git_cleanup_command(args: list[str], *, cwd: str | Path | None = None) -> tuple[bool, str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    detail = (result.stderr or result.stdout or "").strip()
+    return result.returncode == 0, detail
+
+
+@main.command("git-cleanup")
+@click.option(
+    "--execute",
+    is_flag=True,
+    default=False,
+    help="Actually delete stale branches and abandoned worktrees. Dry-run by default.",
+)
+@click.option(
+    "--branches-only",
+    is_flag=True,
+    default=False,
+    help="Only report or delete stale local branches.",
+)
+@click.option(
+    "--worktrees-only",
+    is_flag=True,
+    default=False,
+    help="Only report or remove abandoned worktrees.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit structured cleanup summary as JSON.",
+)
+@click.option(
+    "--keep-worktree-days",
+    default=DEFAULT_KEEP_WORKTREE_DAYS,
+    show_default=True,
+    type=click.IntRange(min=0),
+    help="Protect clean worktrees whose latest commit is newer than this many days.",
+)
+@click.option(
+    "--branch-scan-limit",
+    default=DEFAULT_BRANCH_SCAN_LIMIT,
+    show_default=True,
+    type=click.IntRange(min=1),
+    help="Check only this many recently updated local branches for tree equivalence.",
+)
+def git_cleanup(
+    execute: bool,
+    branches_only: bool,
+    worktrees_only: bool,
+    as_json: bool,
+    keep_worktree_days: int,
+    branch_scan_limit: int,
+) -> None:
+    """Clean stale local branches and abandoned worktrees."""
+    if branches_only and worktrees_only:
+        raise click.UsageError("--branches-only conflicts with --worktrees-only")
+    try:
+        plan = scan_git_state(
+            keep_worktree_days=keep_worktree_days,
+            branch_scan_limit=branch_scan_limit,
+        )
+    except GitStateError as e:
+        raise click.ClickException(str(e)) from e
+
+    stale_branches = [] if worktrees_only else plan.stale_branches
+    abandoned_worktrees = [] if branches_only else plan.abandoned_worktrees
+    payload_plan = GitCleanupPlan(
+        default_branch=plan.default_branch,
+        current_path=plan.current_path,
+        current_branch=plan.current_branch,
+        stale_branches=stale_branches,
+        abandoned_worktrees=abandoned_worktrees,
+        protected=plan.protected,
+        branch_scan=plan.branch_scan,
+    )
+
+    deleted_branches: list[str] = []
+    removed_worktrees: list[str] = []
+    errors: list[dict[str, str]] = []
+    if execute:
+        for item in plan.protected:
+            if item.kind == "worktree" and item.reason == "uncommitted changes":
+                click.echo(
+                    f"[conductor] cleanup warning: protected dirty worktree "
+                    f"{item.name} (uncommitted changes)",
+                    err=True,
+                )
+        for branch in stale_branches:
+            ok, detail = _run_git_cleanup_command(["branch", "-D", branch.name])
+            if ok:
+                deleted_branches.append(branch.name)
+            else:
+                msg = f"git branch -D {branch.name} failed"
+                if detail:
+                    msg = f"{msg}: {detail}"
+                click.echo(f"[conductor] cleanup error: {msg}", err=True)
+                errors.append({"target": branch.name, "error": msg})
+        for worktree in abandoned_worktrees:
+            ok, detail = _run_git_cleanup_command(
+                ["worktree", "remove", str(worktree.path)]
+            )
+            if ok:
+                removed_worktrees.append(str(worktree.path))
+            else:
+                msg = f"git worktree remove {worktree.path} failed"
+                if detail:
+                    msg = f"{msg}: {detail}"
+                click.echo(f"[conductor] cleanup error: {msg}", err=True)
+                errors.append({"target": str(worktree.path), "error": msg})
+
+    if as_json:
+        payload = _git_cleanup_payload(payload_plan)
+        payload["dry_run"] = not execute
+        payload["deleted_branches"] = deleted_branches
+        payload["removed_worktrees"] = removed_worktrees
+        payload["errors"] = errors
+        click.echo(json.dumps(payload, indent=2))
+        return
+
+    click.echo(f"Stale branches ({len(stale_branches)}):")
+    _echo_branch_scan_cap(plan.branch_scan, indent="  ")
+    if stale_branches:
+        for branch in stale_branches:
+            click.echo(
+                f"  - {branch.name} ({branch.reason} → {branch.last_commit})"
+            )
+    else:
+        click.echo("  (none)")
+
+    click.echo("")
+    click.echo(f"Abandoned worktrees ({len(abandoned_worktrees)}):")
+    if abandoned_worktrees:
+        for worktree in abandoned_worktrees:
+            branch_label = worktree.branch or "detached"
+            click.echo(
+                f"  - {worktree.path} (branch {branch_label}, "
+                f"{_format_worktree_age(worktree)}, clean)"
+            )
+    else:
+        click.echo("  (none)")
+
+    click.echo("")
+    click.echo("Protected (won't touch):")
+    if plan.protected:
+        for item in plan.protected:
+            click.echo(f"  - {item.name} ({item.reason})")
+    else:
+        click.echo("  (none)")
+
+    click.echo("")
+    if execute:
+        click.echo(
+            f"Deleted {len(deleted_branches)} branches and removed "
+            f"{len(removed_worktrees)} worktrees."
+        )
+        if errors:
+            click.echo(f"{len(errors)} cleanup operations failed; see stderr.")
+    else:
+        click.echo("Run with --execute to actually delete.")
 
 
 @main.command()
@@ -5854,6 +6139,34 @@ def doctor(as_json: bool) -> None:
             click.echo(f"    {display}{version_note}")
         click.echo("  Refresh with:")
         click.echo("    conductor init -y --remaining")
+
+    git_state = payload["git_state"]
+    stale_branches = git_state["stale_branches"]
+    abandoned_worktrees = git_state["abandoned_worktrees"]
+    if git_state.get("error"):
+        click.echo("")
+        click.echo("⚠ Local git state could not be checked:")
+        click.echo(f"    {git_state['error']}")
+    if stale_branches or abandoned_worktrees:
+        click.echo("")
+        click.echo("⚠ Local git state has drift:")
+        click.echo(f"    Stale branches ({len(stale_branches)}):")
+        _echo_branch_scan_cap(git_state["branch_scan"], indent="      ")
+        for branch in stale_branches:
+            click.echo(
+                f"      - {branch['name']} "
+                f"({branch['reason']} → {branch['last_commit']})"
+            )
+        click.echo(f"    Abandoned worktrees ({len(abandoned_worktrees)}):")
+        for worktree in abandoned_worktrees:
+            branch = worktree["branch"] or "detached"
+            click.echo(
+                f"      - {worktree['path']} "
+                f"(branch {branch}, {worktree['reason']})"
+            )
+        click.echo("  Refresh with:")
+        click.echo("    conductor git-cleanup           # dry-run (default)")
+        click.echo("    conductor git-cleanup --execute # actually delete")
 
     click.echo("")
     click.echo("Next steps:")

--- a/src/conductor/git_state.py
+++ b/src/conductor/git_state.py
@@ -1,0 +1,437 @@
+"""Local git-state predicates for branch and worktree cleanup.
+
+The branch scan is capped by recency for performance: by default only the
+50 most recently updated non-default local branches are checked with the
+tree-equivalence predicate. Callers receive ``BranchScanLimit`` metadata and
+must surface it when the cap hides older branches from detection.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+DEFAULT_BRANCH_SCAN_LIMIT = 50
+DEFAULT_KEEP_WORKTREE_DAYS = 7
+
+
+@dataclass(frozen=True)
+class GitStateError(RuntimeError):
+    """Raised when local git state cannot be read safely."""
+
+    message: str
+
+    def __str__(self) -> str:
+        return self.message
+
+
+@dataclass(frozen=True)
+class Worktree:
+    path: Path
+    head: str | None
+    branch: str | None
+    detached: bool = False
+    bare: bool = False
+    locked: bool = False
+    lock_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class StaleBranch:
+    name: str
+    reason: str
+    last_commit: str
+
+
+@dataclass(frozen=True)
+class AbandonedWorktree:
+    path: Path
+    branch: str | None
+    reason: str
+    last_commit: str | None
+    last_commit_age_days: int | None
+    clean: bool
+
+
+@dataclass(frozen=True)
+class ProtectedRef:
+    kind: str
+    name: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class BranchScanLimit:
+    checked: int
+    total: int
+    limit: int | None
+
+    @property
+    def capped(self) -> bool:
+        return self.limit is not None and self.total > self.checked
+
+
+@dataclass(frozen=True)
+class GitCleanupPlan:
+    default_branch: str
+    current_path: Path
+    current_branch: str | None
+    stale_branches: list[StaleBranch]
+    abandoned_worktrees: list[AbandonedWorktree]
+    protected: list[ProtectedRef]
+    branch_scan: BranchScanLimit
+
+
+def _git(
+    args: list[str],
+    *,
+    cwd: str | Path | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as e:
+        raise GitStateError(f"`git {' '.join(args)}` failed to start: {e}") from e
+    if check and result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        suffix = f": {detail}" if detail else ""
+        raise GitStateError(f"`git {' '.join(args)}` failed{suffix}")
+    return result
+
+
+def git_root(*, cwd: str | Path | None = None) -> Path:
+    return Path(_git(["rev-parse", "--show-toplevel"], cwd=cwd).stdout.strip())
+
+
+def default_branch(*, cwd: str | Path | None = None) -> str:
+    candidates = (
+        ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+        ["rev-parse", "--verify", "--quiet", "main"],
+        ["rev-parse", "--verify", "--quiet", "master"],
+    )
+    first = _git(candidates[0], cwd=cwd, check=False)
+    if first.returncode == 0:
+        raw = first.stdout.strip()
+        if raw.startswith("origin/"):
+            return raw.removeprefix("origin/")
+        if raw:
+            return raw
+    for branch, cmd in (("main", candidates[1]), ("master", candidates[2])):
+        if _git(cmd, cwd=cwd, check=False).returncode == 0:
+            return branch
+    raise GitStateError("could not resolve default branch (tried origin/HEAD, main, master)")
+
+
+def current_branch(*, cwd: str | Path | None = None) -> str | None:
+    raw = _git(["branch", "--show-current"], cwd=cwd).stdout.strip()
+    return raw or None
+
+
+def tree_equivalent_to(
+    branch: str,
+    base: str,
+    *,
+    cwd: str | Path | None = None,
+) -> bool:
+    """Return true when ``base`` currently contains ``branch``'s changed tree.
+
+    The check mirrors ``scripts/cleanup-branches.sh``: compare every path the
+    branch changed since merge-base, with rename detection disabled, against
+    the current base tree. That catches squash-merge/cherry-pick shape while
+    rejecting add-then-revert false positives.
+    """
+    merge_base = _git(["merge-base", base, branch], cwd=cwd, check=False)
+    if merge_base.returncode != 0 or not merge_base.stdout.strip():
+        return False
+    base_sha = merge_base.stdout.strip()
+    paths = _git(
+        ["diff", "--name-only", "--no-renames", "-z", base_sha, branch],
+        cwd=cwd,
+        check=False,
+    )
+    if paths.returncode != 0:
+        return False
+    for path in paths.stdout.split("\0"):
+        if not path:
+            continue
+        diff = _git(["diff", "--quiet", base, branch, "--", path], cwd=cwd, check=False)
+        if diff.returncode != 0:
+            return False
+    return True
+
+
+def list_worktrees(*, cwd: str | Path | None = None) -> list[Worktree]:
+    output = _git(["worktree", "list", "--porcelain"], cwd=cwd).stdout
+    entries: list[Worktree] = []
+    current: dict[str, object] = {}
+
+    def flush() -> None:
+        if not current:
+            return
+        path = current.get("path")
+        if path is None:
+            raise GitStateError("git worktree porcelain entry is missing path")
+        head = current.get("head")
+        branch = current.get("branch")
+        lock_reason = current.get("lock_reason")
+        entries.append(
+            Worktree(
+                path=Path(str(path)),
+                head=head if isinstance(head, str) else None,
+                branch=branch if isinstance(branch, str) else None,
+                detached=bool(current.get("detached")),
+                bare=bool(current.get("bare")),
+                locked=bool(current.get("locked")),
+                lock_reason=lock_reason if isinstance(lock_reason, str) else None,
+            )
+        )
+
+    for raw_line in output.splitlines():
+        if not raw_line:
+            flush()
+            current = {}
+            continue
+        key, _, value = raw_line.partition(" ")
+        if key == "worktree":
+            if current:
+                flush()
+                current = {}
+            current["path"] = value
+        elif key == "HEAD":
+            current["head"] = value
+        elif key == "branch":
+            current["branch"] = value.removeprefix("refs/heads/")
+        elif key == "detached":
+            current["detached"] = True
+        elif key == "bare":
+            current["bare"] = True
+        elif key == "locked":
+            current["locked"] = True
+            current["lock_reason"] = value or None
+    flush()
+    return entries
+
+
+def _local_branches_by_recency(
+    *,
+    cwd: str | Path | None,
+    exclude: set[str],
+    limit: int | None,
+) -> tuple[list[str], BranchScanLimit]:
+    raw = _git(
+        [
+            "for-each-ref",
+            "--sort=-committerdate",
+            "--format=%(refname:short)",
+            "refs/heads/",
+        ],
+        cwd=cwd,
+    ).stdout
+    all_branches = [line.strip() for line in raw.splitlines() if line.strip()]
+    candidates = [branch for branch in all_branches if branch not in exclude]
+    checked = candidates if limit is None else candidates[:limit]
+    return checked, BranchScanLimit(
+        checked=len(checked),
+        total=len(candidates),
+        limit=limit,
+    )
+
+
+def _last_commit(branch: str, *, cwd: str | Path | None) -> str:
+    return _git(["rev-parse", "--short", branch], cwd=cwd).stdout.strip()
+
+
+def _last_commit_datetime(ref: str, *, cwd: str | Path | None) -> datetime | None:
+    result = _git(["log", "-1", "--format=%cI", ref], cwd=cwd, check=False)
+    if result.returncode != 0:
+        return None
+    raw = result.stdout.strip()
+    if not raw:
+        return None
+    return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+
+
+def _is_clean(path: Path) -> bool:
+    return _git(["status", "--porcelain"], cwd=path).stdout == ""
+
+
+def _worktree_for_current_checkout(
+    worktrees: list[Worktree],
+    *,
+    cwd: str | Path | None,
+) -> Path:
+    root = git_root(cwd=cwd).resolve()
+    for worktree in worktrees:
+        if worktree.path.resolve() == root:
+            return worktree.path.resolve()
+    return root
+
+
+def find_stale_branches(
+    *,
+    base: str | None = None,
+    branch_scan_limit: int | None = DEFAULT_BRANCH_SCAN_LIMIT,
+    cwd: str | Path | None = None,
+) -> list[StaleBranch]:
+    plan = scan_git_state(
+        base=base,
+        keep_worktree_days=DEFAULT_KEEP_WORKTREE_DAYS,
+        branch_scan_limit=branch_scan_limit,
+        cwd=cwd,
+    )
+    return plan.stale_branches
+
+
+def find_abandoned_worktrees(
+    *,
+    keep_days: int = DEFAULT_KEEP_WORKTREE_DAYS,
+    base: str | None = None,
+    cwd: str | Path | None = None,
+) -> list[AbandonedWorktree]:
+    plan = scan_git_state(
+        base=base,
+        keep_worktree_days=keep_days,
+        branch_scan_limit=DEFAULT_BRANCH_SCAN_LIMIT,
+        cwd=cwd,
+    )
+    return plan.abandoned_worktrees
+
+
+def scan_git_state(
+    *,
+    base: str | None = None,
+    keep_worktree_days: int = DEFAULT_KEEP_WORKTREE_DAYS,
+    branch_scan_limit: int | None = DEFAULT_BRANCH_SCAN_LIMIT,
+    cwd: str | Path | None = None,
+) -> GitCleanupPlan:
+    """Classify local branches and worktrees for cleanup.
+
+    Branch tree-equivalence checks are O(N x diff). ``branch_scan_limit`` caps
+    checks to the most recently updated local branches (default 50); callers
+    must surface ``branch_scan.capped`` so older unchecked branches are not
+    silently hidden.
+    """
+    if keep_worktree_days < 0:
+        raise GitStateError("keep_worktree_days must be >= 0")
+    if branch_scan_limit is not None and branch_scan_limit < 1:
+        raise GitStateError("branch_scan_limit must be >= 1")
+
+    resolved_base = base or default_branch(cwd=cwd)
+    current = current_branch(cwd=cwd)
+    worktrees = list_worktrees(cwd=cwd)
+    current_path = _worktree_for_current_checkout(worktrees, cwd=cwd)
+    worktree_branches = {w.branch for w in worktrees if w.branch}
+    protected_names = {resolved_base, "main", "master", "HEAD"}
+    if current:
+        protected_names.add(current)
+
+    stale: list[StaleBranch] = []
+    protected: list[ProtectedRef] = []
+    checked_branches, branch_scan = _local_branches_by_recency(
+        cwd=cwd,
+        exclude=protected_names,
+        limit=branch_scan_limit,
+    )
+    for branch in checked_branches:
+        if branch in worktree_branches:
+            protected.append(ProtectedRef("branch", branch, "checked out in worktree"))
+            continue
+        if tree_equivalent_to(branch, resolved_base, cwd=cwd):
+            stale.append(
+                StaleBranch(
+                    name=branch,
+                    reason=f"squash-merged into {resolved_base}",
+                    last_commit=_last_commit(branch, cwd=cwd),
+                )
+            )
+        else:
+            protected.append(ProtectedRef("branch", branch, "unique unmerged commits"))
+
+    if current:
+        protected.append(ProtectedRef("branch", current, "current checkout"))
+    protected.append(ProtectedRef("branch", resolved_base, "default branch"))
+
+    abandoned: list[AbandonedWorktree] = []
+    cutoff = datetime.now(UTC) - timedelta(days=keep_worktree_days)
+    for worktree in worktrees:
+        path = worktree.path.resolve()
+        label = str(path)
+        if path == current_path:
+            protected.append(ProtectedRef("worktree", label, "current checkout"))
+            continue
+        if worktree.locked:
+            reason = "locked"
+            if worktree.lock_reason:
+                reason = f"locked: {worktree.lock_reason}"
+            protected.append(ProtectedRef("worktree", label, reason))
+            continue
+        if worktree.branch == resolved_base:
+            protected.append(ProtectedRef("worktree", label, "default branch"))
+            continue
+        if not path.exists():
+            protected.append(
+                ProtectedRef(
+                    "worktree",
+                    label,
+                    "missing path; run git worktree prune",
+                )
+            )
+            continue
+        if not _is_clean(path):
+            protected.append(ProtectedRef("worktree", label, "uncommitted changes"))
+            continue
+        ref = worktree.branch or worktree.head
+        if ref is None:
+            protected.append(ProtectedRef("worktree", label, "missing HEAD"))
+            continue
+
+        last_dt = _last_commit_datetime(ref, cwd=path)
+        age_days = (
+            max(0, (datetime.now(UTC) - last_dt).days)
+            if last_dt is not None
+            else None
+        )
+        last_commit = _last_commit(ref, cwd=path) if ref else None
+        if worktree.branch and tree_equivalent_to(worktree.branch, resolved_base, cwd=cwd):
+            abandoned.append(
+                AbandonedWorktree(
+                    path=path,
+                    branch=worktree.branch,
+                    reason=f"squash-merged into {resolved_base}",
+                    last_commit=last_commit,
+                    last_commit_age_days=age_days,
+                    clean=True,
+                )
+            )
+            continue
+        if last_dt is not None and last_dt < cutoff:
+            abandoned.append(
+                AbandonedWorktree(
+                    path=path,
+                    branch=worktree.branch,
+                    reason=f"last commit older than {keep_worktree_days} days",
+                    last_commit=last_commit,
+                    last_commit_age_days=age_days,
+                    clean=True,
+                )
+            )
+            continue
+        protected.append(ProtectedRef("worktree", label, "recent or unique work"))
+
+    return GitCleanupPlan(
+        default_branch=resolved_base,
+        current_path=current_path,
+        current_branch=current,
+        stale_branches=stale,
+        abandoned_worktrees=abandoned,
+        protected=protected,
+        branch_scan=branch_scan,
+    )

--- a/tests/test_cli_git_cleanup.py
+++ b/tests/test_cli_git_cleanup.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import pytest
+from click.testing import CliRunner
+
+from conductor.cli import main
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _git(repo: Path, *args: str, env: dict[str, str] | None = None) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _commit(repo: Path, message: str, *, when: datetime | None = None) -> None:
+    env = None
+    if when is not None:
+        env = {
+            **os.environ,
+            "GIT_AUTHOR_DATE": when.isoformat(),
+            "GIT_COMMITTER_DATE": when.isoformat(),
+        }
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-q", "-m", message, env=env)
+
+
+@pytest.fixture
+def repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "conductor-test@example.com")
+    _git(root, "config", "user.name", "Conductor Test")
+    _git(root, "config", "commit.gpgsign", "false")
+    (root / "README.md").write_text("base\n", encoding="utf-8")
+    _commit(root, "base")
+    monkeypatch.chdir(root)
+    monkeypatch.setenv("CONDUCTOR_HOME", str(tmp_path / ".conductor"))
+    monkeypatch.setenv(
+        "CONDUCTOR_CREDENTIALS_FILE", str(tmp_path / ".config" / "credentials.toml")
+    )
+    monkeypatch.setenv("CLAUDE_HOME", str(tmp_path / ".claude"))
+    monkeypatch.setattr("shutil.which", lambda _cmd: None)
+    for var in (
+        "OPENROUTER_API_KEY",
+        "CONDUCTOR_OLLAMA_MODEL",
+        "OLLAMA_BASE_URL",
+        "CLOUDFLARE_API_TOKEN",
+        "CLOUDFLARE_ACCOUNT_ID",
+        "DEEPSEEK_API_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    return root
+
+
+def _make_squash_merged_branch(repo: Path, name: str, filename: str) -> None:
+    _git(repo, "checkout", "-q", "-b", name)
+    (repo / filename).write_text(f"{name}\n", encoding="utf-8")
+    _commit(repo, name)
+    _git(repo, "checkout", "-q", "main")
+    (repo / filename).write_text(f"{name}\n", encoding="utf-8")
+    _commit(repo, f"squash {name}")
+
+
+def _make_unique_branch(repo: Path, name: str, filename: str, *, days_old: int = 0) -> None:
+    when = datetime.now(UTC) - timedelta(days=days_old)
+    _git(repo, "checkout", "-q", "-b", name)
+    (repo / filename).write_text(f"{name}\n", encoding="utf-8")
+    _commit(repo, name, when=when)
+    _git(repo, "checkout", "-q", "main")
+
+
+def test_git_cleanup_dry_run_shape_does_not_delete(repo: Path) -> None:
+    _make_squash_merged_branch(repo, "feat/stale", "stale.txt")
+
+    result = CliRunner().invoke(main, ["git-cleanup"])
+
+    assert result.exit_code == 0, result.output
+    assert "Stale branches (1):" in result.output
+    assert "feat/stale" in result.output
+    assert "Run with --execute to actually delete." in result.output
+    branches = _git(repo, "branch", "--format=%(refname:short)").splitlines()
+    assert "feat/stale" in branches
+
+
+def test_git_cleanup_execute_deletes_only_cleanup_candidates(repo: Path, tmp_path: Path) -> None:
+    _make_squash_merged_branch(repo, "feat/stale", "stale.txt")
+    _make_unique_branch(repo, "feat/old-worktree", "old.txt", days_old=10)
+    old_path = tmp_path / "old-worktree"
+    _git(repo, "worktree", "add", "-q", str(old_path), "feat/old-worktree")
+    _make_unique_branch(repo, "feat/keep", "keep.txt")
+
+    result = CliRunner().invoke(main, ["git-cleanup", "--execute"])
+
+    assert result.exit_code == 0, result.output
+    branches = _git(repo, "branch", "--format=%(refname:short)").splitlines()
+    assert "feat/stale" not in branches
+    assert "feat/keep" in branches
+    assert not old_path.exists()
+
+
+def test_git_cleanup_dirty_worktree_is_protected(repo: Path, tmp_path: Path) -> None:
+    _make_unique_branch(repo, "feat/dirty", "dirty.txt", days_old=10)
+    dirty_path = tmp_path / "dirty"
+    _git(repo, "worktree", "add", "-q", str(dirty_path), "feat/dirty")
+    (dirty_path / "dirty.txt").write_text("changed\n", encoding="utf-8")
+
+    result = CliRunner().invoke(main, ["git-cleanup", "--execute"])
+
+    assert result.exit_code == 0, result.output
+    assert dirty_path.exists()
+    assert "uncommitted changes" in result.output
+
+
+def test_git_cleanup_current_branch_and_worktree_are_protected(repo: Path) -> None:
+    _git(repo, "checkout", "-q", "-b", "feat/current")
+    (repo / "current.txt").write_text("current\n", encoding="utf-8")
+    _commit(repo, "current")
+
+    result = CliRunner().invoke(main, ["git-cleanup", "--execute"])
+
+    assert result.exit_code == 0, result.output
+    assert "feat/current (current checkout)" in result.output
+    assert f"{repo} (current checkout)" in result.output
+    assert _git(repo, "branch", "--show-current") == "feat/current"
+
+
+def test_git_cleanup_threshold_respected(repo: Path, tmp_path: Path) -> None:
+    _make_unique_branch(repo, "feat/recent", "recent.txt", days_old=5)
+    recent_path = tmp_path / "recent"
+    _git(repo, "worktree", "add", "-q", str(recent_path), "feat/recent")
+    _make_unique_branch(repo, "feat/old", "old.txt", days_old=10)
+    old_path = tmp_path / "old"
+    _git(repo, "worktree", "add", "-q", str(old_path), "feat/old")
+
+    result = CliRunner().invoke(main, ["git-cleanup", "--execute"])
+
+    assert result.exit_code == 0, result.output
+    assert recent_path.exists()
+    assert not old_path.exists()
+
+
+def test_git_cleanup_json_shape(repo: Path) -> None:
+    _make_squash_merged_branch(repo, "feat/stale", "stale.txt")
+
+    result = CliRunner().invoke(main, ["git-cleanup", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["dry_run"] is True
+    assert payload["stale_branches"][0]["name"] == "feat/stale"
+    assert payload["abandoned_worktrees"] == []
+    assert payload["protected"]
+
+
+def _stub_all_unconfigured(mocker) -> None:
+    from conductor.providers import (
+        ClaudeProvider,
+        CodexProvider,
+        DeepSeekChatProvider,
+        DeepSeekReasonerProvider,
+        GeminiProvider,
+        KimiProvider,
+        OllamaProvider,
+        OpenRouterProvider,
+    )
+
+    for cls in (
+        ClaudeProvider,
+        CodexProvider,
+        DeepSeekChatProvider,
+        DeepSeekReasonerProvider,
+        GeminiProvider,
+        KimiProvider,
+        OllamaProvider,
+        OpenRouterProvider,
+    ):
+        mocker.patch.object(
+            cls,
+            "configured",
+            lambda self, _cls=cls: (False, f"stub: {_cls.__name__} unset"),
+        )
+    mocker.patch("conductor.cli.credentials.keychain_has", return_value=False)
+
+
+def test_doctor_clean_state_has_no_local_git_warning(repo: Path, mocker) -> None:
+    _stub_all_unconfigured(mocker)
+
+    result = CliRunner().invoke(main, ["doctor"])
+
+    assert result.exit_code == 0, result.output
+    assert "Local git state has drift" not in result.output
+
+
+def test_doctor_warns_for_stale_branches_only(repo: Path, mocker) -> None:
+    _stub_all_unconfigured(mocker)
+    _make_squash_merged_branch(repo, "feat/stale", "stale.txt")
+
+    result = CliRunner().invoke(main, ["doctor"])
+
+    assert result.exit_code == 0, result.output
+    assert "⚠ Local git state has drift:" in result.output
+    assert "Stale branches (1):" in result.output
+    assert "feat/stale" in result.output
+    assert "Abandoned worktrees (0):" in result.output
+    assert "conductor git-cleanup --execute # actually delete" in result.output
+
+
+def test_doctor_warns_for_abandoned_worktrees_only(
+    repo: Path, tmp_path: Path, mocker
+) -> None:
+    _stub_all_unconfigured(mocker)
+    _make_unique_branch(repo, "feat/old", "old.txt", days_old=10)
+    old_path = tmp_path / "old"
+    _git(repo, "worktree", "add", "-q", str(old_path), "feat/old")
+
+    result = CliRunner().invoke(main, ["doctor"])
+
+    assert result.exit_code == 0, result.output
+    assert "Stale branches (0):" in result.output
+    assert "Abandoned worktrees (1):" in result.output
+    assert str(old_path) in result.output
+
+
+def test_doctor_warns_for_both_git_state_drifts(
+    repo: Path, tmp_path: Path, mocker
+) -> None:
+    _stub_all_unconfigured(mocker)
+    _make_squash_merged_branch(repo, "feat/stale", "stale.txt")
+    _make_unique_branch(repo, "feat/old", "old.txt", days_old=10)
+    old_path = tmp_path / "old"
+    _git(repo, "worktree", "add", "-q", str(old_path), "feat/old")
+
+    result = CliRunner().invoke(main, ["doctor"])
+
+    assert result.exit_code == 0, result.output
+    assert "Stale branches (1):" in result.output
+    assert "Abandoned worktrees (1):" in result.output
+
+
+def test_doctor_json_includes_git_state(repo: Path, mocker) -> None:
+    _stub_all_unconfigured(mocker)
+    _make_squash_merged_branch(repo, "feat/stale", "stale.txt")
+
+    result = CliRunner().invoke(main, ["doctor", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["git_state"]["stale_branches"][0]["name"] == "feat/stale"
+    assert payload["git_state"]["abandoned_worktrees"] == []
+    assert payload["git_state"]["branch_scan"]["limit"] == 50
+
+
+def test_doctor_text_surfaces_git_state_scan_error(repo: Path, mocker) -> None:
+    _stub_all_unconfigured(mocker)
+    mocker.patch(
+        "conductor.cli._git_state_doctor_payload",
+        return_value={
+            "stale_branches": [],
+            "abandoned_worktrees": [],
+            "branch_scan": {
+                "checked": 0,
+                "total": 0,
+                "limit": 50,
+                "capped": False,
+            },
+            "error": "`git rev-parse --show-toplevel` failed",
+        },
+    )
+
+    result = CliRunner().invoke(main, ["doctor"])
+
+    assert result.exit_code == 0, result.output
+    assert "⚠ Local git state could not be checked:" in result.output
+    assert "`git rev-parse --show-toplevel` failed" in result.output

--- a/tests/test_git_state.py
+++ b/tests/test_git_state.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import pytest
+
+import conductor.git_state as git_state_mod
+from conductor.git_state import (
+    GitStateError,
+    list_worktrees,
+    scan_git_state,
+    tree_equivalent_to,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _git(repo: Path, *args: str, env: dict[str, str] | None = None) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _commit(repo: Path, message: str, *, when: datetime | None = None) -> None:
+    env = None
+    if when is not None:
+        env = {
+            **os.environ,
+            "GIT_AUTHOR_DATE": when.isoformat(),
+            "GIT_COMMITTER_DATE": when.isoformat(),
+        }
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-q", "-m", message, env=env)
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "conductor-test@example.com")
+    _git(repo, "config", "user.name", "Conductor Test")
+    _git(repo, "config", "commit.gpgsign", "false")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _commit(repo, "base")
+    return repo
+
+
+def test_tree_equivalent_to_detects_squash_shape(git_repo: Path) -> None:
+    _git(git_repo, "checkout", "-q", "-b", "feat/applied")
+    (git_repo / "feature.txt").write_text("same\n", encoding="utf-8")
+    _commit(git_repo, "feature")
+    _git(git_repo, "checkout", "-q", "main")
+    (git_repo / "feature.txt").write_text("same\n", encoding="utf-8")
+    _commit(git_repo, "squash equivalent")
+
+    assert tree_equivalent_to("feat/applied", "main", cwd=git_repo) is True
+
+
+def test_tree_equivalent_to_rejects_unique_branch(git_repo: Path) -> None:
+    _git(git_repo, "checkout", "-q", "-b", "feat/unique")
+    (git_repo / "feature.txt").write_text("unique\n", encoding="utf-8")
+    _commit(git_repo, "feature")
+    _git(git_repo, "checkout", "-q", "main")
+
+    assert tree_equivalent_to("feat/unique", "main", cwd=git_repo) is False
+
+
+def test_list_worktrees_parses_main_secondary_and_locked(git_repo: Path, tmp_path: Path) -> None:
+    _git(git_repo, "branch", "feat/worktree")
+    worktree_path = tmp_path / "secondary"
+    _git(git_repo, "worktree", "add", "-q", str(worktree_path), "feat/worktree")
+    _git(git_repo, "worktree", "lock", "--reason", "keep for test", str(worktree_path))
+
+    worktrees = list_worktrees(cwd=git_repo)
+
+    by_path = {w.path: w for w in worktrees}
+    assert git_repo in by_path
+    assert by_path[git_repo].branch == "main"
+    assert worktree_path in by_path
+    assert by_path[worktree_path].branch == "feat/worktree"
+    assert by_path[worktree_path].locked is True
+    assert by_path[worktree_path].lock_reason == "keep for test"
+
+
+def test_scan_git_state_respects_worktree_age_threshold(git_repo: Path, tmp_path: Path) -> None:
+    now = datetime.now(UTC)
+    _git(git_repo, "checkout", "-q", "-b", "feat/recent")
+    (git_repo / "recent.txt").write_text("recent\n", encoding="utf-8")
+    _commit(git_repo, "recent", when=now - timedelta(days=5))
+    _git(git_repo, "checkout", "-q", "main")
+    recent_path = tmp_path / "recent"
+    _git(git_repo, "worktree", "add", "-q", str(recent_path), "feat/recent")
+
+    _git(git_repo, "checkout", "-q", "-b", "feat/old")
+    (git_repo / "old.txt").write_text("old\n", encoding="utf-8")
+    _commit(git_repo, "old", when=now - timedelta(days=10))
+    _git(git_repo, "checkout", "-q", "main")
+    old_path = tmp_path / "old"
+    _git(git_repo, "worktree", "add", "-q", str(old_path), "feat/old")
+
+    plan = scan_git_state(cwd=git_repo, keep_worktree_days=7)
+
+    assert str(old_path.resolve()) in {
+        str(worktree.path) for worktree in plan.abandoned_worktrees
+    }
+    assert any(
+        item.kind == "worktree"
+        and item.name == str(recent_path.resolve())
+        and item.reason == "recent or unique work"
+        for item in plan.protected
+    )
+
+
+def test_scan_git_state_protects_default_branch_worktree(
+    git_repo: Path, tmp_path: Path
+) -> None:
+    _git(git_repo, "checkout", "-q", "-b", "feat/current")
+    default_path = tmp_path / "main-worktree"
+    _git(git_repo, "worktree", "add", "-q", str(default_path), "main")
+
+    plan = scan_git_state(cwd=git_repo)
+
+    assert not plan.abandoned_worktrees
+    assert any(
+        item.kind == "worktree"
+        and item.name == str(default_path.resolve())
+        and item.reason == "default branch"
+        for item in plan.protected
+    )
+
+
+def test_scan_git_state_protects_prunable_missing_worktree(
+    git_repo: Path, tmp_path: Path
+) -> None:
+    _git(git_repo, "branch", "feat/missing-worktree")
+    missing_path = tmp_path / "missing-worktree"
+    _git(git_repo, "worktree", "add", "-q", str(missing_path), "feat/missing-worktree")
+    shutil.rmtree(missing_path)
+
+    plan = scan_git_state(cwd=git_repo)
+
+    assert not plan.abandoned_worktrees
+    assert any(
+        item.kind == "worktree"
+        and item.name == str(missing_path.resolve())
+        and item.reason == "missing path; run git worktree prune"
+        for item in plan.protected
+    )
+
+
+def test_git_start_failure_is_converted_to_git_state_error(mocker) -> None:
+    mocker.patch.object(
+        git_state_mod.subprocess,
+        "run",
+        side_effect=FileNotFoundError("git missing"),
+    )
+
+    with pytest.raises(GitStateError, match="failed to start"):
+        scan_git_state()


### PR DESCRIPTION
feat: conductor git-cleanup + doctor flags git-state drift

Closes #234
Closes #236
Closes #235

Adds `conductor git-cleanup` (dry-run by default) for stale-branch and abandoned-worktree cleanup, and extends `conductor doctor` to warn on the same drift with a one-line refresh recommendation.

Both share the new `src/conductor/git_state.py` predicate module (tree-equivalence + worktree enumeration), so detection has one code path. Default abandonment threshold is 7 days; surface-cap is top-50 branches by recency for performance on large repos.

Tested behaviors:
- Dry-run shape, --execute deletes correct items, dirty worktree protected, current branch/worktree protected, default-branch worktree protected, threshold respected, --json shape.
- Doctor: clean / branches-only / worktrees-only / both, plus --json.

Validation:
- `uv run pytest` -> 942 passed, 15 skipped.
- `uv run ruff check src/ tests/` -> clean.
- `uv run conductor git-cleanup --help` shows the documented flags.
- Current checkout dry-run reports no stale branches and no abandoned worktrees after protecting default-branch worktrees.

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
