### PR TITLE
chore: default --retry-on-stall to 1

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -4396,12 +4396,12 @@ def review(
 )
 @click.option(
     "--retry-on-stall",
-    default=0,
+    default=1,
     type=click.IntRange(min=0),
     help=(
-        "Claude exec only: retry this many times if the provider stalls before "
-        "its first output byte. Never retries after first output, to avoid "
-        "duplicating side effects."
+        "Claude exec only. Default: 1. Retry once if the provider stalls before "
+        "its first output byte. The retry is safe: no observable side effects "
+        "can have occurred before first output. Set to 0 to disable."
     ),
 )
 @click.option(

--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -806,11 +806,19 @@ class ClaudeProvider:
                             "probe": probe.as_dict(),
                         },
                     )
-                self._sleep_before_startup_retry(
-                    timeout,
-                    start=overall_start,
-                    args=args,
-                )
+                try:
+                    self._sleep_before_startup_retry(
+                        timeout,
+                        start=overall_start,
+                        args=args,
+                    )
+                except subprocess.TimeoutExpired:
+                    raise self._startup_stall_with_diagnostic(
+                        e,
+                        probe=probe,
+                        attempts=attempt,
+                        retry_on_stall=retry_on_stall,
+                    ) from e
                 attempt += 1
 
     def _remaining_timeout(
@@ -862,9 +870,17 @@ class ClaudeProvider:
             else " No *.lock or *.tmp files found directly under ~/.claude."
         )
         recovery_text = (
-            " Retry attempts were exhausted."
+            (
+                " Retry attempts were exhausted. Set `--retry-on-stall` higher "
+                "(default: 1, which has already retried once) to allow conductor "
+                "to re-spawn again."
+            )
             if retry_on_stall
-            else " Or add `--retry-on-stall 1` to allow conductor to re-spawn."
+            else (
+                " Automatic startup-stall retry is disabled. Set "
+                "`--retry-on-stall` to 1 or higher to allow conductor to "
+                "re-spawn."
+            )
         )
         message = (
             f"conductor: claude exec stalled at first_output "

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -652,7 +652,8 @@ def test_claude_exec_startup_stall_diagnostic_includes_processes_and_locks(
     assert "PIDs: 123, 456" in message
     assert "auth.lock" in message
     assert "session.tmp" in message
-    assert "--retry-on-stall 1" in message
+    assert "Automatic startup-stall retry is disabled" in message
+    assert "--retry-on-stall" in message
 
 
 def test_claude_exec_retry_on_stall_respawns_once_then_reports_diagnostic(
@@ -767,7 +768,7 @@ def test_claude_exec_startup_stall_terminates_child_process_group(
             os.kill(child_pid, signal.SIGKILL)
 
 
-def test_cli_exec_retry_on_stall_wires_to_claude_provider(
+def test_cli_exec_retry_on_stall_default_wires_to_claude_provider(
     mocker,
     monkeypatch,
     tmp_path,
@@ -798,8 +799,6 @@ def test_cli_exec_retry_on_stall_wires_to_claude_provider(
             "--no-preflight",
             "--start-timeout",
             "0.01",
-            "--retry-on-stall",
-            "1",
             "--task",
             "hi",
         ],
@@ -808,6 +807,45 @@ def test_cli_exec_retry_on_stall_wires_to_claude_provider(
     assert result.exit_code == 0, result.output
     assert popen.call_count == 2
     assert "hello from claude" in result.output
+
+
+def test_cli_exec_retry_on_stall_zero_disables_retry(
+    mocker,
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".claude").mkdir()
+    mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
+    mocker.patch(
+        "conductor.providers.claude._run_ps_for_claude_probe",
+        return_value=(0, "123 1 claude -p hi\n", ""),
+    )
+    fake = _FakePopen(stdout_schedule=[], hang_after_stdout=True)
+    popen = mocker.patch(
+        "conductor.providers.claude.subprocess.Popen",
+        side_effect=lambda args, **kwargs: fake,
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--with",
+            "claude",
+            "--no-preflight",
+            "--start-timeout",
+            "0.01",
+            "--retry-on-stall",
+            "0",
+            "--task",
+            "hi",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert popen.call_count == 1
+    assert "Automatic startup-stall retry is disabled" in result.output
 
 
 def test_claude_exec_retry_on_stall_never_retries_mid_task_stall(
@@ -923,6 +961,8 @@ def test_claude_exec_start_timeout_fails_nonzero_with_error_shape(
             "--no-preflight",
             "--start-timeout",
             "0.03",
+            "--retry-on-stall",
+            "0",
             "--task",
             "hi",
             "--json",


### PR DESCRIPTION
chore: default --retry-on-stall to 1

Closes #230.

Changes the click default for `--retry-on-stall` from 0 to 1 so the
diagnostic-recommended workaround is the default behavior. The retry
is safe — no observable side effects can have occurred before the
provider's first output byte (which is the only condition under which
this flag retries). CI runs that prefer fail-fast can set
`--retry-on-stall 0` explicitly.

Updates the stall diagnostic message to reflect that the first retry
is automatic.

Pairs with #238 (orphan claude cleanup, conductor#231): together they
close prevention + recovery + diagnosis for parallel-swarm reliability.