### PR TITLE
feat: opt-in --ground-citations flag for post-dispatch citation verification

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -2951,6 +2951,18 @@ def _emit_session_usage(
     )
 
 
+def _emit_grounding_warnings(text: str, worktree: str) -> None:
+    try:
+        from conductor.grounding import format_grounding_warning, ground_citations
+
+        report = ground_citations(text, worktree)
+        warning = format_grounding_warning(report)
+        if warning:
+            click.echo(warning, err=True)
+    except Exception as e:  # noqa: BLE001 - guardrail must not change exec outcome.
+        click.echo(f"[conductor] grounding check error: {e}", err=True)
+
+
 def _tail_record(record: SessionRecord) -> None:
     offset = 0
     current_path = record.log_path
@@ -4483,6 +4495,12 @@ def review(
         "brief is intentionally tiny or all context is supplied through files."
     ),
 )
+@click.option(
+    "--ground-citations",
+    is_flag=True,
+    default=False,
+    help="Warn when post-dispatch citation references do not resolve in the worktree.",
+)
 def exec_cmd(
     provider_id: str | None,
     profile: str | None,
@@ -4513,6 +4531,7 @@ def exec_cmd(
     offline: bool | None,
     preflight: bool,
     allow_short_brief: bool,
+    ground_citations: bool,
 ) -> None:
     """Run a task as an agent session with tool access (exec mode)."""
     timeout_is_default = _parameter_is_default("timeout_sec")
@@ -4909,6 +4928,8 @@ def exec_cmd(
         decision=decision,
         session_log=session_log,
     )
+    if ground_citations:
+        _emit_grounding_warnings(response.text, cwd or os.getcwd())
     _emit_call(
         response,
         as_json=as_json,

--- a/src/conductor/grounding.py
+++ b/src/conductor/grounding.py
@@ -16,10 +16,11 @@ Patterns recognised (pragmatic, not exhaustive):
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
-import sys
 from dataclasses import dataclass, field
+from pathlib import Path
 
 # --------------------------------------------------------------------------- #
 # Data types
@@ -38,7 +39,7 @@ _FUNC_CALL_PATH = re.compile(
 
 @dataclass(frozen=True)
 class Citation:
-    symbol: str
+    symbol: str | None
     path: str | None
     line: int | None
     raw: str
@@ -66,24 +67,38 @@ def parse_citations(text: str) -> list[Citation]:
 
     Returns deduplicated citations ordered by first appearance.
     """
-    seen: set[tuple[str, str | None]] = set()
+    seen: set[tuple[str | None, str | None, int | None]] = set()
     results: list[Citation] = []
+    occupied_spans: list[tuple[int, int]] = []
 
-    def _add(symbol: str, path: str | None, line_s: str | None, raw: str) -> None:
+    def _add(
+        symbol: str | None,
+        path: str | None,
+        line_s: str | None,
+        raw: str,
+    ) -> None:
         line = int(line_s) if line_s else None
-        key = (symbol, path)
+        key = (symbol, path, line)
         if key not in seen:
             seen.add(key)
             results.append(Citation(symbol=symbol, path=path, line=line, raw=raw))
 
+    symbol_matches: list[tuple[int, str | None, str | None, str | None, str]] = []
     for m in _BACKTICK_SYMBOL_PATH.finditer(text):
-        _add(m.group(1), m.group(2), m.group(3), m.group(0))
-
-    for m in _BARE_PATH_LINE.finditer(text):
-        _add(m.group(1), m.group(1), m.group(2), m.group(0))
-
+        symbol_matches.append((m.start(), m.group(1), m.group(2), m.group(3), m.group(0)))
+        occupied_spans.append(m.span())
     for m in _FUNC_CALL_PATH.finditer(text):
-        _add(m.group(1), m.group(2), m.group(3), m.group(0))
+        symbol_matches.append((m.start(), m.group(1), m.group(2), m.group(3), m.group(0)))
+        occupied_spans.append(m.span())
+
+    matches = symbol_matches
+    for m in _BARE_PATH_LINE.finditer(text):
+        if any(start <= m.start() and m.end() <= end for start, end in occupied_spans):
+            continue
+        matches.append((m.start(), None, m.group(1), m.group(2), m.group(0)))
+
+    for _, symbol, path, line_s, raw in sorted(matches, key=lambda item: item[0]):
+        _add(symbol, path, line_s, raw)
 
     return results
 
@@ -93,55 +108,80 @@ def parse_citations(text: str) -> list[Citation]:
 # --------------------------------------------------------------------------- #
 
 
-def _grep_symbol(symbol: str, worktree: str) -> bool:
-    """Return True if symbol appears anywhere under worktree."""
+def _grep_symbol(symbol: str, path: Path) -> bool:
+    """Return True if symbol appears under path."""
     try:
         result = subprocess.run(
-            ["grep", "-rF", "--quiet", symbol, worktree],
+            ["grep", "-rF", "--quiet", "--", symbol, str(path)],
             capture_output=True,
             timeout=10,
+            check=False,
         )
         return result.returncode == 0
     except (OSError, subprocess.TimeoutExpired) as e:
         raise RuntimeError(f"grep failed for symbol {symbol!r}: {e}") from e
 
 
-def _path_exists(path: str, worktree: str) -> bool:
-    """Return True if path exists relative to worktree (or as absolute)."""
-    import os
-
+def _resolve_path(path: str, worktree: Path) -> Path:
     if os.path.isabs(path):
-        return os.path.exists(path)
-    return os.path.exists(os.path.join(worktree, path))
+        return Path(path)
+    return worktree / path
+
+
+def _line_exists(path: Path, line: int) -> bool:
+    if line < 1:
+        return False
+    try:
+        with path.open("r", encoding="utf-8", errors="ignore") as fh:
+            for index, _ in enumerate(fh, start=1):
+                if index == line:
+                    return True
+    except OSError as e:
+        raise RuntimeError(f"could not read {path}: {e}") from e
+    return False
 
 
 def ground_citations(
-    citations: list[Citation],
-    worktree: str,
+    text: str,
+    worktree: str | os.PathLike[str],
 ) -> GroundingReport:
-    """Verify each citation against the worktree.
+    """Verify citation candidates in text against the worktree.
 
-    For citations with a path: first check path existence, then grep symbol.
-    For symbol-only citations: grep the worktree.
-    Grep failures (OSError, timeout) are collected as errors, not misses.
+    Path citations resolve only when the file exists and any cited line is in
+    range. Symbol citations with a path must resolve inside that path; symbol
+    citations without a path search the whole worktree. Grep/read failures are
+    collected as errors, not misses, so the caller can warn without changing the
+    dispatch exit code.
     """
     report = GroundingReport()
+    worktree_path = Path(worktree)
+    citations = parse_citations(text)
     for cit in citations:
         try:
-            if cit.path and not _path_exists(cit.path, worktree):
-                report.misses.append(
-                    GroundingMiss(
-                        citation=cit,
-                        reason=f"path not found: {cit.path}",
+            search_path = worktree_path
+            if cit.path:
+                search_path = _resolve_path(cit.path, worktree_path)
+                if not search_path.exists():
+                    report.misses.append(
+                        GroundingMiss(citation=cit, reason="file does not exist")
                     )
-                )
+                    continue
+                if cit.line is not None and not _line_exists(search_path, cit.line):
+                    report.misses.append(
+                        GroundingMiss(
+                            citation=cit,
+                            reason=f"line {cit.line} does not exist in {cit.path}",
+                        )
+                    )
+                    continue
+            if cit.symbol is None:
                 continue
-            found = _grep_symbol(cit.symbol, worktree)
-            if not found:
+            if not _grep_symbol(cit.symbol, search_path):
+                location = f" in {cit.path}" if cit.path else ""
                 report.misses.append(
                     GroundingMiss(
                         citation=cit,
-                        reason=f"symbol not found in worktree: {cit.symbol!r}",
+                        reason=f"symbol not found{location}",
                     )
                 )
         except RuntimeError as e:
@@ -154,22 +194,32 @@ def ground_citations(
 # --------------------------------------------------------------------------- #
 
 
-def report_grounding(report: GroundingReport) -> list[str]:
-    """Emit grounding warnings to stderr and return them for JSON injection.
+def _display_citation(citation: Citation) -> str:
+    if citation.symbol and citation.path:
+        symbol = citation.raw.split(" in ", 1)[0]
+        return f"`{symbol.strip('`')}` in {citation.path}"
+    if citation.path:
+        return citation.path
+    return f"`{citation.symbol}`"
 
-    Always writes to stderr. Caller injects the returned list into the JSON
-    payload when ``--json`` is active.
-    """
-    warnings: list[str] = []
 
-    for miss in report.misses:
-        msg = f"[grounding] unverified citation: {miss.citation.raw!r} — {miss.reason}"
-        warnings.append(msg)
-        print(f"conductor: WARNING {msg}", file=sys.stderr)
-
+def format_grounding_warning(report: GroundingReport) -> str | None:
+    """Return a structured warning block for grounding misses/errors."""
+    lines: list[str] = []
+    if report.misses:
+        lines.append(f"[conductor] grounding misses: {len(report.misses)}")
+        for miss in report.misses:
+            citation = _display_citation(miss.citation)
+            line_suffix = (
+                f":{miss.citation.line}"
+                if miss.citation.line is not None and miss.citation.path
+                else ""
+            )
+            if miss.citation.path:
+                citation = f"{citation}{line_suffix}"
+            lines.append(f"  - {citation} — {miss.reason}")
     for err in report.errors:
-        msg = f"[grounding] error: {err}"
-        warnings.append(msg)
-        print(f"conductor: WARNING {msg}", file=sys.stderr)
-
-    return warnings
+        if not lines:
+            lines.append(f"[conductor] grounding errors: {len(report.errors)}")
+        lines.append(f"  - grounding check error — {err}")
+    return "\n".join(lines) if lines else None

--- a/src/conductor/grounding.py
+++ b/src/conductor/grounding.py
@@ -1,0 +1,175 @@
+"""Citation grounding guardrail for conductor exec.
+
+After a dispatch completes, parse the output for citation patterns (symbol names,
+file paths with line numbers) and grep the worktree to verify they exist. Misses
+are emitted as warnings — the run is never failed, just flagged.
+
+Opt-in via ``conductor exec --ground-citations``. Off by default so existing
+callers are unaffected.
+
+Patterns recognised (pragmatic, not exhaustive):
+  - `symbol_name` in path/to/file.py:N   (backtick-quoted name + path:line)
+  - `symbol_name` in path/to/file.py     (backtick-quoted name + path, no line)
+  - path/to/file.py:N                    (bare path:line)
+  - symbol_name(...) followed by a path  (function call shape, best-effort)
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+
+# --------------------------------------------------------------------------- #
+# Data types
+# --------------------------------------------------------------------------- #
+
+_BACKTICK_SYMBOL_PATH = re.compile(
+    r"`([^`]+)`\s+in\s+([\w./\-]+\.py)(?::(\d+))?",
+)
+_BARE_PATH_LINE = re.compile(
+    r"\b([\w./\-]+\.py):(\d+)\b",
+)
+_FUNC_CALL_PATH = re.compile(
+    r"\b(\w[\w.]*)\([^)]*\)\s+(?:in\s+)?([\w./\-]+\.py)(?::(\d+))?",
+)
+
+
+@dataclass(frozen=True)
+class Citation:
+    symbol: str
+    path: str | None
+    line: int | None
+    raw: str
+
+
+@dataclass
+class GroundingMiss:
+    citation: Citation
+    reason: str
+
+
+@dataclass
+class GroundingReport:
+    misses: list[GroundingMiss] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+# --------------------------------------------------------------------------- #
+# Parser
+# --------------------------------------------------------------------------- #
+
+
+def parse_citations(text: str) -> list[Citation]:
+    """Extract citation candidates from dispatch output.
+
+    Returns deduplicated citations ordered by first appearance.
+    """
+    seen: set[tuple[str, str | None]] = set()
+    results: list[Citation] = []
+
+    def _add(symbol: str, path: str | None, line_s: str | None, raw: str) -> None:
+        line = int(line_s) if line_s else None
+        key = (symbol, path)
+        if key not in seen:
+            seen.add(key)
+            results.append(Citation(symbol=symbol, path=path, line=line, raw=raw))
+
+    for m in _BACKTICK_SYMBOL_PATH.finditer(text):
+        _add(m.group(1), m.group(2), m.group(3), m.group(0))
+
+    for m in _BARE_PATH_LINE.finditer(text):
+        _add(m.group(1), m.group(1), m.group(2), m.group(0))
+
+    for m in _FUNC_CALL_PATH.finditer(text):
+        _add(m.group(1), m.group(2), m.group(3), m.group(0))
+
+    return results
+
+
+# --------------------------------------------------------------------------- #
+# Grounder
+# --------------------------------------------------------------------------- #
+
+
+def _grep_symbol(symbol: str, worktree: str) -> bool:
+    """Return True if symbol appears anywhere under worktree."""
+    try:
+        result = subprocess.run(
+            ["grep", "-rF", "--quiet", symbol, worktree],
+            capture_output=True,
+            timeout=10,
+        )
+        return result.returncode == 0
+    except (OSError, subprocess.TimeoutExpired) as e:
+        raise RuntimeError(f"grep failed for symbol {symbol!r}: {e}") from e
+
+
+def _path_exists(path: str, worktree: str) -> bool:
+    """Return True if path exists relative to worktree (or as absolute)."""
+    import os
+
+    if os.path.isabs(path):
+        return os.path.exists(path)
+    return os.path.exists(os.path.join(worktree, path))
+
+
+def ground_citations(
+    citations: list[Citation],
+    worktree: str,
+) -> GroundingReport:
+    """Verify each citation against the worktree.
+
+    For citations with a path: first check path existence, then grep symbol.
+    For symbol-only citations: grep the worktree.
+    Grep failures (OSError, timeout) are collected as errors, not misses.
+    """
+    report = GroundingReport()
+    for cit in citations:
+        try:
+            if cit.path and not _path_exists(cit.path, worktree):
+                report.misses.append(
+                    GroundingMiss(
+                        citation=cit,
+                        reason=f"path not found: {cit.path}",
+                    )
+                )
+                continue
+            found = _grep_symbol(cit.symbol, worktree)
+            if not found:
+                report.misses.append(
+                    GroundingMiss(
+                        citation=cit,
+                        reason=f"symbol not found in worktree: {cit.symbol!r}",
+                    )
+                )
+        except RuntimeError as e:
+            report.errors.append(str(e))
+    return report
+
+
+# --------------------------------------------------------------------------- #
+# Reporter
+# --------------------------------------------------------------------------- #
+
+
+def report_grounding(report: GroundingReport) -> list[str]:
+    """Emit grounding warnings to stderr and return them for JSON injection.
+
+    Always writes to stderr. Caller injects the returned list into the JSON
+    payload when ``--json`` is active.
+    """
+    warnings: list[str] = []
+
+    for miss in report.misses:
+        msg = f"[grounding] unverified citation: {miss.citation.raw!r} — {miss.reason}"
+        warnings.append(msg)
+        print(f"conductor: WARNING {msg}", file=sys.stderr)
+
+    for err in report.errors:
+        msg = f"[grounding] error: {err}"
+        warnings.append(msg)
+        print(f"conductor: WARNING {msg}", file=sys.stderr)
+
+    return warnings

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -83,6 +83,7 @@ DOCUMENTED_EXEC_FLAGS: frozenset[str] = frozenset(
         "--preflight",
         "--no-preflight",
         "--allow-short-brief",
+        "--ground-citations",
     }
 )
 

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -85,11 +85,12 @@ def _fake_response(
     provider: str = "claude",
     model: str = "sonnet",
     *,
+    text: str = "hello",
     cost_usd: float | None = 0.01,
     output_tokens: int | None = 10,
 ) -> CallResponse:
     return CallResponse(
-        text="hello",
+        text=text,
         provider=provider,
         model=model,
         duration_ms=1234,
@@ -1515,6 +1516,90 @@ def test_exec_without_sandbox_does_not_warn(mocker):
 
     assert result.exit_code == 0, result.output
     assert SANDBOX_DEPRECATION_WARNING not in result.stderr
+
+
+def test_exec_ground_citations_default_skips_guardrail(mocker):
+    _stub_all_configured(mocker, {"codex"})
+    mocker.patch.object(CodexProvider, "exec", return_value=_fake_response("codex"))
+    grounding_mock = mocker.patch("conductor.cli._emit_grounding_warnings")
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--with",
+            "codex",
+            "--no-preflight",
+            "--allow-short-brief",
+            "--task",
+            "hi",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert not grounding_mock.called
+
+
+def test_exec_ground_citations_warns_to_stderr_not_stdout(mocker, tmp_path):
+    _stub_all_configured(mocker, {"codex"})
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "foo.py").write_text("def existing():\n    return 1\n", encoding="utf-8")
+    response_text = "Check `missing_symbol` in src/foo.py:1"
+    mocker.patch.object(
+        CodexProvider,
+        "exec",
+        return_value=_fake_response("codex", text=response_text),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--with",
+            "codex",
+            "--no-preflight",
+            "--allow-short-brief",
+            "--cwd",
+            str(tmp_path),
+            "--ground-citations",
+            "--task",
+            "hi",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.stdout == f"{response_text}\n"
+    assert "grounding misses: 1" in result.stderr
+    assert "`missing_symbol` in src/foo.py:1" in result.stderr
+    assert "grounding misses" not in result.stdout
+
+
+def test_exec_ground_citations_errors_warn_without_failing(mocker):
+    _stub_all_configured(mocker, {"codex"})
+    mocker.patch.object(CodexProvider, "exec", return_value=_fake_response("codex"))
+    mocker.patch(
+        "conductor.grounding.ground_citations",
+        side_effect=OSError("permission denied"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--with",
+            "codex",
+            "--no-preflight",
+            "--allow-short-brief",
+            "--ground-citations",
+            "--task",
+            "hi",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.stdout == "hello\n"
+    assert "[conductor] grounding check error: permission denied" in result.stderr
 
 
 def test_exec_permission_profile_auto_routes_to_enforcing_provider(mocker):

--- a/tests/test_grounding.py
+++ b/tests/test_grounding.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+from conductor.grounding import format_grounding_warning, ground_citations
+
+
+def test_ground_citations_handles_supported_patterns_hits_and_misses(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "foo.py").write_text("def foo_bar():\n    return 1\n", encoding="utf-8")
+    (src / "q.py").write_text("def qux():\n    return 2\n", encoding="utf-8")
+
+    report = ground_citations(
+        "\n".join(
+            [
+                "`foo_bar` in src/foo.py:1",
+                "`missing_symbol` in src/foo.py",
+                "src/foo.py:2",
+                "src/missing.py:13",
+                "qux() in src/q.py",
+                "absent() in src/q.py",
+            ]
+        ),
+        tmp_path,
+    )
+
+    warning = format_grounding_warning(report)
+
+    assert warning is not None
+    assert "[conductor] grounding misses: 3" in warning
+    assert "`missing_symbol` in src/foo.py — symbol not found in src/foo.py" in warning
+    assert "src/missing.py:13 — file does not exist" in warning
+    assert "`absent()` in src/q.py — symbol not found in src/q.py" in warning
+
+
+def test_ground_citations_empty_input_has_no_warning(tmp_path: Path) -> None:
+    report = ground_citations("", tmp_path)
+
+    assert report.misses == []
+    assert report.errors == []
+    assert format_grounding_warning(report) is None


### PR DESCRIPTION
feat: --ground-citations flag for post-dispatch citation verification

Closes #233.

Wires up the salvaged grounding-guardrail module
(`feat/grounding-guardrail-salvage`) with a `--ground-citations`
opt-in flag on `conductor exec`. After the dispatch completes, the
result text is parsed for citation patterns (`symbol` in path:line,
bare path:line, function-call shape) and verified against the
worktree via grep. Misses are emitted as a structured warning block
to stderr. The exit code is unchanged.

Default behavior (no flag) is byte-identical to today — the
grounding code is not invoked unless the flag is set.

Tests cover each pattern type, hits/misses, empty input, opt-out
default, and stderr-vs-stdout placement of the warning.

Validation:
- `uv run pytest`
- `uv run ruff check src/ tests/`
- `uv run conductor exec --with kimi --help | rg -- '--ground-citations'`
- Manual smoke: `conductor exec --with kimi --ground-citations` on a contrived missing citation emitted one grounding miss and exited 0; the same command without the flag emitted no grounding warning.

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
