### PR TITLE
feat: repo-scope CLAUDE.md uses @~/.conductor/ import (drift→0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,45 +160,6 @@ Use `--permission-profile read-only` for inspect-only exec work (`Read,Grep,Glob
 
 Because the child has the same ambient authority as the parent, prompts should still be explicit about ownership: whether the child may edit files, run tests, use network, or perform git operations. For PR workflows in this repo, the parent agent still owns commit, push, and PR creation unless the user explicitly delegates those steps.
 
-<!-- conductor:begin v0.8.7 -->
-## Conductor delegation
-
-This project has [conductor](https://github.com/autumngarage/conductor)
-available for delegating tasks to other LLMs from inside an agent loop.
-You can shell out to it instead of trying to do everything yourself.
-
-Quick reference:
-
-- Quick factual/background ask:
-  `conductor ask --kind research --effort minimal --brief-file /tmp/brief.md`.
-- Deeper synthesis/research:
-  `conductor ask --kind research --effort medium --brief-file /tmp/brief.md`.
-- Code explanation or small coding judgment:
-  `conductor ask --kind code --effort low --brief-file /tmp/brief.md`.
-- Repo-changing implementation/debugging:
-  `conductor ask --kind code --effort high --brief-file /tmp/brief.md`.
-- Merge/PR/diff review:
-  `conductor ask --kind review --base <ref> --brief-file /tmp/review.md`.
-- Architecture/product judgment needing multiple views:
-  `conductor ask --kind council --effort medium --brief-file /tmp/brief.md`.
-- `conductor list` — show configured providers and their tags.
-
-Conductor does not inherit your conversation context. For delegation,
-write a complete brief with goal, context, scope, constraints, expected
-output, and validation; use `--brief-file` for nontrivial `exec` tasks.
-Default to `conductor ask`; use provider-specific `call` / `exec` only
-when the user explicitly asks for a provider or the semantic API does not
-fit.
-
-Providers commonly worth delegating to:
-
-- `kimi` — long-context summarization, cheap second opinions.
-- `gemini` — web search, multimodal.
-- `claude` / `codex` — strongest reasoning / coding agent loops.
-- `ollama` — local, offline, privacy-sensitive.
-- `council` kind — OpenRouter-only multi-model deliberation and synthesis.
-
-Full delegation guidance (when to delegate, when not to, error handling):
-
-    ~/.conductor/delegation-guidance.md
+<!-- conductor:begin v0.10.1 -->
+@~/.conductor/delegation-guidance.md
 <!-- conductor:end -->

--- a/src/conductor/agent_wiring.py
+++ b/src/conductor/agent_wiring.py
@@ -764,25 +764,18 @@ def wire_gemini_md(cwd: Path | None = None, *, version: str) -> AgentsMdReport:
 
 
 def wire_claude_md_repo(cwd: Path | None = None, *, version: str) -> AgentsMdReport:
-    """Inject an inline delegation block into repo-scope ``./CLAUDE.md``.
+    """Inject conductor's delegation @-import into repo-scope ``./CLAUDE.md``.
 
-    Uses inlined content (identical body to AGENTS.md / GEMINI.md), NOT the
-    ``@`` import used by ``wire_claude_code(patch_claude_md=True)`` for
-    user-scope ``~/.claude/CLAUDE.md``.
-
-    Why: repo-scope CLAUDE.md is typically tracked in git. An ``@``-import
-    pointing at ``/Users/<name>/.conductor/…`` would travel into every other
-    contributor's checkout and fail to resolve on their machine. Inline
-    content is self-contained markdown that works regardless of where
-    ``~/.conductor/`` lives on any given machine — the loss is that repos
-    don't auto-pick-up upstream guidance changes the way user-scope does,
-    but that's the correct trade for shared files.
+    The block content is a single ``@~/.conductor/delegation-guidance.md``
+    import line. Claude Code expands ``~`` per-user, so the same checked-in
+    block resolves correctly on every contributor's machine. Drift goes to
+    zero: ``brew upgrade conductor`` updates the user-scope target, and
+    every repo's import re-resolves to the new content automatically.
     """
-    from conductor import _agent_templates as templates
-
     cwd = cwd or Path.cwd()
     path = cwd / "CLAUDE.md"
-    inject_sentinel_block(path, templates.AGENTS_MD_BLOCK, version=version)
+    import_line = "@~/.conductor/delegation-guidance.md"
+    inject_sentinel_block(path, import_line, version=version)
     return AgentsMdReport(path=path, patched=True)
 
 

--- a/src/conductor/providers/_startup_lock.py
+++ b/src/conductor/providers/_startup_lock.py
@@ -73,7 +73,9 @@ class StartupLockHandle:
 
 
 def _lock_dir() -> Path:
-    return Path.home() / ".cache" / "conductor" / "locks"
+    cache_home = os.environ.get("XDG_CACHE_HOME")
+    root = Path(cache_home) if cache_home else Path.home() / ".cache"
+    return root / "conductor" / "locks"
 
 
 def _format_seconds(value: float) -> str:
@@ -268,7 +270,8 @@ def claude_startup_lock(
 ) -> contextlib.AbstractContextManager[StartupLockHandle]:
     """Serialize Claude CLI startups across all conductor processes for this user.
 
-    File: ~/.cache/conductor/locks/claude-startup.lock
+    File: $XDG_CACHE_HOME/conductor/locks/claude-startup.lock, or
+    ~/.cache/conductor/locks/claude-startup.lock when XDG_CACHE_HOME is unset.
     Held only during the startup window (release as soon as first output arrives
     or initial probe completes). Mid-task / long-running phases are NOT held.
     """

--- a/tests/test_agent_wiring.py
+++ b/tests/test_agent_wiring.py
@@ -23,6 +23,13 @@ def _assert_no_trailing_whitespace(path):
     assert bad_lines == []
 
 
+def _sentinel_body(text: str) -> str:
+    lines = text.splitlines()
+    begin = next(idx for idx, line in enumerate(lines) if line.startswith("<!-- conductor:begin "))
+    end = lines.index("<!-- conductor:end -->", begin + 1)
+    return "\n".join(lines[begin + 1:end])
+
+
 @pytest.fixture(autouse=True)
 def _isolated_homes(tmp_path, monkeypatch):
     """Point every path helper at tmp_path; chdir so repo-scoped checks
@@ -272,7 +279,7 @@ def test_wire_claude_code_writes_all_artifacts():
     assert claude_md.exists()
     text = claude_md.read_text(encoding="utf-8")
     assert "conductor:begin v0.3.2" in text
-    assert "@" in text and "delegation-guidance.md" in text
+    assert _sentinel_body(text) == f"@{aw.conductor_home()}/delegation-guidance.md"
 
 
 def test_wire_claude_code_patch_false_leaves_claude_md_alone():
@@ -665,13 +672,7 @@ def test_wire_gemini_md_preserves_user_content():
     assert "conductor:begin" in text
 
 
-def test_wire_claude_md_repo_injects_inline_block():
-    """Repo-scope CLAUDE.md gets the INLINE block (not an @-import).
-
-    Repo CLAUDE.md is typically tracked in git; baking an
-    ``@/Users/<name>/.conductor/...`` absolute path into it would break on
-    every other contributor's checkout. So it must be self-contained.
-    """
+def test_wire_claude_md_repo_injects_import_line():
     from pathlib import Path
 
     report = aw.wire_claude_md_repo(version="0.4.2")
@@ -679,11 +680,30 @@ def test_wire_claude_md_repo_injects_inline_block():
     assert report.path == path
     text = path.read_text(encoding="utf-8")
     assert "conductor:begin v0.4.2" in text
-    assert "Conductor delegation" in text
-    # Must NOT contain an absolute-path @-import — that would be
-    # machine-local and break for other contributors on git pull.
-    home_prefix = str(aw.conductor_home())
-    assert f"@{home_prefix}" not in text
+    assert _sentinel_body(text) == "@~/.conductor/delegation-guidance.md"
+
+
+def test_wire_claude_md_repo_replaces_embedded_block_preserving_user_content():
+    from conductor import _agent_templates as templates
+
+    path = Path.cwd() / "CLAUDE.md"
+    path.write_text(
+        "# My Claude rules\n\n"
+        "<!-- conductor:begin v0.4.1 -->\n"
+        f"{templates.AGENTS_MD_BLOCK}\n"
+        "<!-- conductor:end -->\n\n"
+        "Keep this local rule.\n",
+        encoding="utf-8",
+    )
+
+    aw.wire_claude_md_repo(version="0.4.2")
+
+    text = path.read_text(encoding="utf-8")
+    assert "# My Claude rules" in text
+    assert "Keep this local rule." in text
+    assert "conductor:begin v0.4.2" in text
+    assert _sentinel_body(text) == "@~/.conductor/delegation-guidance.md"
+    assert "Conductor delegation" not in _sentinel_body(text)
 
 
 def test_wire_claude_md_repo_vs_user_scope_independent(tmp_path):
@@ -696,6 +716,9 @@ def test_wire_claude_md_repo_vs_user_scope_independent(tmp_path):
     repo_path = tmp_path / "repo" / "CLAUDE.md"
     assert user_path.exists() and "conductor:begin" in user_path.read_text(encoding="utf-8")
     assert repo_path.exists() and "conductor:begin" in repo_path.read_text(encoding="utf-8")
+    assert _sentinel_body(repo_path.read_text(encoding="utf-8")) == (
+        "@~/.conductor/delegation-guidance.md"
+    )
 
 
 def test_wire_cursor_writes_managed_rule_file():

--- a/tests/test_startup_lock.py
+++ b/tests/test_startup_lock.py
@@ -78,6 +78,12 @@ class _StartupFakePopen:
         self._finished.set()
 
 
+def test_startup_lock_dir_honors_xdg_cache_home(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+
+    assert _startup_lock._lock_dir() == tmp_path / "cache" / "conductor" / "locks"
+
+
 def test_live_subprocess_startup_lock_serializes_popen_until_first_output(
     monkeypatch, tmp_path
 ) -> None:

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -1004,10 +1004,7 @@ def test_init_patch_gemini_md_yes_creates_block(mocker, tmp_path):
     assert "Conductor delegation" in text
 
 
-def test_init_patch_claude_md_repo_yes_creates_inline_block(mocker, tmp_path):
-    """Repo-scope CLAUDE.md wire uses inline content, not an @-import to
-    a user's local ~/.conductor/ path (would break on other machines when
-    the file is committed to git)."""
+def test_init_patch_claude_md_repo_yes_creates_import_block(mocker, tmp_path):
     _stub_all_providers_unconfigured(mocker)
     result = CliRunner().invoke(
         main,
@@ -1018,9 +1015,8 @@ def test_init_patch_claude_md_repo_yes_creates_inline_block(mocker, tmp_path):
     assert repo_claude.exists()
     text = repo_claude.read_text(encoding="utf-8")
     assert "conductor:begin" in text
-    assert "Conductor delegation" in text
-    # No absolute-path @-import that would be machine-local.
-    assert f"@{tmp_path}" not in text
+    assert "@~/.conductor/delegation-guidance.md" in text
+    assert "Conductor delegation" not in text
 
 
 def test_init_wire_cursor_yes_writes_rule(mocker, tmp_path):


### PR DESCRIPTION
Closes part of #232 (Sub-1 / "A").

`wire_claude_md_repo()` now writes a single `@~/.conductor/delegation-guidance.md` import line inside the sentinel block, replacing the inlined ~200-line content. Claude Code expands `~` per-user (verified at <https://code.claude.com/docs/en/configuration.md>), so the same checked-in block resolves correctly on every contributor's machine. Per-repo Claude-Code drift goes to permanent zero — `brew upgrade conductor` updates the user-scope target, every repo's import re-resolves automatically.

Validation hardening: startup-lock paths now honor `XDG_CACHE_HOME`, matching the rest of the cache-aware test harness and preventing validation runs from contending with unrelated live user Claude sessions.

Out of scope (will be follow-up PRs):
- GEMINI.md (deferred pending verification of `~` expansion in Gemini CLI).
- AGENTS.md (multi-tool format; imports aren't standard).
- Cursor `.mdc` rules (don't support imports; stay embedded; Sub-3 pre-commit hook will keep them fresh).
- Existing repos' CLAUDE.md files migrate to the import line on next `conductor init` / `refresh-consumers`. The block-replacement machinery already handles this; tests cover the embedded-→-import migration shape.

Self-check block from `uv run conductor init -y --remaining`:

```md
<!-- conductor:begin v0.10.1 -->
@~/.conductor/delegation-guidance.md
<!-- conductor:end -->
```

Tested:
- Fresh CLAUDE.md → sentinel block contains only the import line.
- CLAUDE.md with prior embedded content → block is rewritten to the import; user content outside the markers preserved.
- User-scope `wire_claude_code(patch_claude_md=True)` behavior unchanged.
- Startup locks honor `XDG_CACHE_HOME` during validation.
- `uv run pytest`
- `uv run ruff check src/ tests/`

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
