### PR TITLE
fix: --remaining now refreshes Cursor rule too

### DIFF
--- a/src/conductor/wizard.py
+++ b/src/conductor/wizard.py
@@ -1409,7 +1409,7 @@ def _wire_cursor_section(
     wc = (
         wire_cursor_flag
         if wire_cursor_flag is not None
-        else ("ask" if interactive else "no")
+        else ("ask" if interactive else decision)
     )
     if wc == "ask":
         verb = "refresh" if already_written else "write"

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -605,6 +605,45 @@ def test_init_remaining_skips_configured(mocker):
     assert "codex" in result.output.lower()
 
 
+def test_init_remaining_refreshes_all_repo_wiring(mocker):
+    import conductor
+    from conductor import agent_wiring as aw
+    from conductor.providers import (
+        ClaudeProvider,
+        CodexProvider,
+        GeminiProvider,
+        KimiProvider,
+        OllamaProvider,
+        OpenRouterProvider,
+    )
+
+    for cls in (
+        ClaudeProvider,
+        CodexProvider,
+        GeminiProvider,
+        KimiProvider,
+        OllamaProvider,
+        OpenRouterProvider,
+    ):
+        mocker.patch.object(cls, "configured", lambda self: (True, None))
+
+    old_version = "0.8.2"
+    aw.wire_agents_md(version=old_version)
+    aw.wire_gemini_md(version=old_version)
+    aw.wire_claude_md_repo(version=old_version)
+    cursor = aw.wire_cursor(version=old_version).path
+
+    result = CliRunner().invoke(main, ["init", "-y", "--remaining"])
+
+    assert result.exit_code == 0, result.output
+    expected = aw._canonical_wiring_version(conductor.__version__)
+    versions_by_kind = {artifact.kind: artifact.version for artifact in aw.detect().managed}
+    assert versions_by_kind["agents-md-import"] == expected
+    assert versions_by_kind["gemini-md-import"] == expected
+    assert versions_by_kind["claude-md-repo-import"] == expected
+    assert aw.read_managed_version(cursor) == expected
+
+
 def test_init_only_unknown_provider_errors():
     result = CliRunner().invoke(main, ["init", "--only", "nonexistent"])
     assert result.exit_code == 2


### PR DESCRIPTION
Closes part of #232 (Sub-2 / "D").

`conductor init -y --remaining` previously skipped
`.cursor/rules/conductor-delegation.mdc` while refreshing every other
wired file. Diagnosed: the Cursor section defaulted non-interactive runs to
"no" instead of inheriting the top-level wiring decision. Fix: make the
Cursor non-interactive default follow the same decision path as repo-scoped
sentinel wiring.

Regression test asserts that with all four wired-file types at an
outdated version stamp, `--remaining` refreshes all four; the test
fails on main (current behavior) and passes on this branch.

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
