### PR TITLE
chore: demote refresh-consumers to manual backstop

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -6198,11 +6198,20 @@ def doctor(as_json: bool) -> None:
                 display = path
             version_note = f" (v{entry['version']})" if entry["version"] else ""
             click.echo(f"    {display}{version_note}")
-        click.echo("  Refresh with:")
+        click.echo("  Auto refresh paths:")
+        click.echo(
+            "    brew upgrade conductor       # CLAUDE.md @-import self-heals on upgrade"
+        )
+        click.echo(
+            "    conductor init --hooks       # refresh embed-only files on commit"
+        )
+        click.echo("  Immediate manual fallback:")
         click.echo("    conductor init -y --remaining")
         click.echo(
-            "  Install the auto-refresh hook with `conductor init --hooks` "
-            "to make refreshes happen on commit."
+            "    conductor refresh-consumers  # force-refresh configured consumer repos"
+        )
+        click.echo(
+            "  Prefer the auto paths unless an immediate cross-repo refresh is needed."
         )
 
     git_state = payload["git_state"]
@@ -6668,7 +6677,16 @@ def refresh_consumers(
     config_file: Path | None,
     branch_name: str | None,
 ) -> None:
-    """Refresh Conductor integration blocks in explicitly configured repos."""
+    """Refresh Conductor integration blocks in explicitly configured repos.
+
+    Manual force-refresh backstop. After `brew upgrade conductor`, drift should
+    self-heal via the CLAUDE.md @-import path and, for embed-only files
+    (Cursor .mdc, AGENTS.md, GEMINI.md), the opt-in pre-commit refresh hook
+    installed by `conductor init --hooks`.
+
+    Use `refresh-consumers` only when you need an immediate cross-repo refresh
+    without waiting for the next commit in each repo.
+    """
     try:
         consumer_paths = _resolve_consumer_repo_paths(paths, config_file)
     except ValueError as e:

--- a/tests/test_cli_phase5.py
+++ b/tests/test_cli_phase5.py
@@ -729,8 +729,17 @@ def test_doctor_warns_before_next_steps_when_one_integration_file_is_behind(
     assert result.exit_code == 0, result.output
     assert "⚠ Repo integration files behind binary (v0.9.0):" in result.output
     assert "    AGENTS.md (v0.8.9)" in result.output
+    assert "  Auto refresh paths:" in result.output
+    assert "    brew upgrade conductor" in result.output
+    assert "    conductor init --hooks" in result.output
+    assert "  Immediate manual fallback:" in result.output
     assert "    conductor init -y --remaining" in result.output
-    assert "conductor init --hooks" in result.output
+    assert "    conductor refresh-consumers" in result.output
+    assert (
+        result.output.index("Auto refresh paths:")
+        < result.output.index("Immediate manual fallback:")
+        < result.output.index("conductor refresh-consumers")
+    )
     assert (
         result.output.index("Repo integration files behind binary")
         < result.output.index("Next steps:")
@@ -924,6 +933,16 @@ def test_refresh_consumers_defaults_to_empty():
     result = CliRunner().invoke(main, ["refresh-consumers"])
     assert result.exit_code == 0, result.output
     assert "No consumer repos configured." in result.output
+
+
+def test_refresh_consumers_help_positions_command_as_manual_backstop():
+    result = CliRunner().invoke(main, ["refresh-consumers", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "Refresh Conductor integration blocks" in result.output
+    assert "Manual force-refresh backstop" in result.output
+    assert "CLAUDE.md @-import" in result.output
+    assert "conductor init --hooks" in result.output
+    assert "Use `refresh-consumers` only" in result.output
 
 
 def test_refresh_consumers_commits_updated_repo_integration(mocker, tmp_path):


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
