### PR TITLE
fix: harden codex-coding-agent template against parallel-swarm footguns

### DIFF
--- a/src/conductor/_agent_templates.py
+++ b/src/conductor/_agent_templates.py
@@ -298,14 +298,25 @@ loop rather than answering single-shot.
 
 When invoked:
 
-1. Write a structured brief file — Codex will run its own loop and you
-   are giving it the initial prompt, not mid-conversation context. Include:
-   Goal, Context, Scope, Constraints, Expected Output, and Validation.
-2. Run (always include the watchdog flags for unattended runs):
+1. Write a structured brief file at a UNIQUE path. Use `mktemp` so
+   parallel dispatches don't clobber each other:
+
+       brief_path=$(mktemp -t conductor-brief-XXXXXXXX.md)
+       # then write the brief to "$brief_path"
+
+   The brief is the initial prompt for Codex's own loop, not
+   mid-conversation context. Include: Goal, Context, Scope,
+   Constraints, Expected Output, and Validation. Never hardcode
+   `/tmp/conductor-brief.md` — N parallel codex-coding-agents writing
+   to the same path silently overwrite each other.
+
+2. Run conductor exec in the FOREGROUND. Do NOT pass
+   `run_in_background=true` to your Bash tool. Wait for the JSON
+   result and parse it before returning:
 
        conductor exec --with codex --tools Read,Grep,Glob,Edit,Write,Bash \\
            --max-stall-seconds 600 --timeout 1800 \\
-           --brief-file /tmp/conductor-brief.md --json
+           --brief-file "$brief_path" --json
 
    `--max-stall-seconds 600` kills the run if codex produces no output
    for 10 minutes (the documented silent-hang failure mode — see
@@ -313,6 +324,20 @@ When invoked:
    `--timeout 1800` is a 30-minute wall-clock cap. Both can be tuned
    per task: a larger refactor can take longer, a one-line fix should
    not. Without these flags the run can hang indefinitely.
+
+   If you background the call and return, conductor will keep running
+   but its output will be lost; the parent agent will see a successful
+   completion notification despite no PR being shipped. This is a
+   silent failure mode — never do it.
+
+   IF THE HARNESS AUTO-BACKGROUNDS YOUR FOREGROUND CALL: some agent
+   harnesses silently background long-running Bash calls past an
+   internal threshold. Watch for a notification telling you the call
+   was backgrounded. If it happens, do NOT exit. Use the harness's
+   monitor primitive (e.g. `BashOutput` in Claude Code) to poll the
+   background task ID until it reports completion, then read the JSON
+   output. Stay alive for the duration; otherwise your stream
+   watchdog will fire while codex is still producing useful work.
 
 3. Parse the JSON, extract `text`, and return it verbatim prefixed with
    "From Codex:". Note `session_id` in the JSON if present — callers can

--- a/tests/test_agent_template_drift.py
+++ b/tests/test_agent_template_drift.py
@@ -31,6 +31,15 @@ EXPECTED_TEMPLATE_COVERAGE = {
         "Write",
         "codex",
         "conductor exec",
+        # Hardening tokens — see conductor#241, #242, #250.
+        # #242: use a unique brief path; never the hardcoded shared path.
+        "mktemp",
+        # #241: explicitly forbid backgrounding the call.
+        "run_in_background",
+        "FOREGROUND",
+        # #250: handle the case where the harness auto-backgrounds.
+        "AUTO-BACKGROUNDS",
+        "BashOutput",
     },
     "ollama-offline": {
         "--offline",


### PR DESCRIPTION
Closes #241, #242, #250.

Updates SUBAGENT_CODEX_CODING_AGENT to address three failure modes
that surfaced during the open-issues completion swarm on 2026-05-07:

- #241: agent voluntarily backgrounds the conductor exec call and
  abandons the ship leg. Fix: explicit "Run conductor exec in the
  FOREGROUND. Do NOT pass run_in_background=true" instruction, plus
  a one-line note that backgrounding is a silent failure mode.

- #242: hardcoded /tmp/conductor-brief.md collides under parallel
  dispatch (last-writer-wins, silent). Fix: use mktemp for a
  per-call unique path; instruction explicitly says never hardcode
  the shared path.

- #250: even with foreground invocation, the Claude Code harness
  may silently auto-background long-running Bash calls past an
  internal threshold, after which the agent has no signal to wait
  on and stalls until the stream watchdog kills it. Fix: document
  the auto-background recovery path — use BashOutput to monitor
  the background task ID until it reports completion, then read
  the JSON. Don't idle.

The tests/test_agent_template_drift.py drift test gains hardening
tokens (mktemp, run_in_background, FOREGROUND, AUTO-BACKGROUNDS,
BashOutput) so any future template edit that drops these
guardrails fails in CI.

These three fixes are interim hardening of the existing stack;
the systemic replacement is proposed in #257 (conductor swarm
first-class primitive). Until that lands, the next parallel
swarm runs against the hardened template.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
