### PR TITLE
fix: merge-pr.sh skips locked worktrees instead of failing under set -e

### DIFF
--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -182,9 +182,60 @@ worktree_has_uncommitted_changes() {
   [ -n "$(git -C "$path" status --porcelain)" ]
 }
 
+# Echoes the lock reason when the worktree at $path is locked; nothing
+# otherwise. A locked worktree may not be removed without --force or
+# unlocking — both inappropriate when the holder is an active agent
+# harness or another tool that will clean up on its own exit.
+worktree_lock_reason() {
+  local path="$1"
+  local current_path="" current_lock=""
+  local line key value
+
+  # Resolve $path the same way `git worktree list --porcelain` resolves
+  # its output, so symlinked TMPDIRs (e.g. /var → /private/var on macOS)
+  # don't cause spurious mismatches.
+  if [ -d "$path" ]; then
+    path="$(cd "$path" && pwd -P)"
+  fi
+
+  # Process substitution (not a pipe) so the variable mutations persist
+  # in this shell and survive past the loop. A bare `git ... | while`
+  # would lose the final-block state because the pipe spawns a subshell.
+  while IFS= read -r line || [ -n "$line" ]; do
+    if [ -z "$line" ]; then
+      if [ "$current_path" = "$path" ] && [ -n "$current_lock" ]; then
+        printf '%s\n' "$current_lock"
+        return 0
+      fi
+      current_path=""
+      current_lock=""
+      continue
+    fi
+
+    key="${line%% *}"
+    value="${line#* }"
+    case "$key" in
+      worktree) current_path="$value" ;;
+      locked)
+        # `locked` may be a bare key with no reason, or `locked <reason>`.
+        if [ "$line" = "locked" ]; then
+          current_lock="(no reason recorded)"
+        else
+          current_lock="$value"
+        fi
+        ;;
+    esac
+  done < <(git worktree list --porcelain)
+
+  if [ "$current_path" = "$path" ] && [ -n "$current_lock" ]; then
+    printf '%s\n' "$current_lock"
+  fi
+  return 0
+}
+
 remove_clean_merged_branch_worktree() {
   local path="$1"
-  local current_worktree common_git_dir
+  local current_worktree common_git_dir lock_reason
 
   if [ -z "$path" ]; then
     return 0
@@ -195,6 +246,11 @@ remove_clean_merged_branch_worktree() {
   fi
   if worktree_has_uncommitted_changes "$path"; then
     echo "WARN: worktree at $path has uncommitted changes; not removing — operator action required" >&2
+    return 0
+  fi
+  lock_reason="$(worktree_lock_reason "$path")"
+  if [ -n "$lock_reason" ]; then
+    echo "==> Worktree at $path is locked ($lock_reason); skipping removal — owner will clean up"
     return 0
   fi
 

--- a/tests/test-merge-pr-worktree-handling.sh
+++ b/tests/test-merge-pr-worktree-handling.sh
@@ -41,6 +41,8 @@ extract_function "git_common_dir_for_worktree" "$MERGE_SCRIPT" "$FUNCTIONS_FILE.
 cat "$FUNCTIONS_FILE.tmp" >> "$FUNCTIONS_FILE"
 extract_function "worktree_has_uncommitted_changes" "$MERGE_SCRIPT" "$FUNCTIONS_FILE.tmp"
 cat "$FUNCTIONS_FILE.tmp" >> "$FUNCTIONS_FILE"
+extract_function "worktree_lock_reason" "$MERGE_SCRIPT" "$FUNCTIONS_FILE.tmp"
+cat "$FUNCTIONS_FILE.tmp" >> "$FUNCTIONS_FILE"
 extract_function "remove_clean_merged_branch_worktree" "$MERGE_SCRIPT" "$FUNCTIONS_FILE.tmp"
 cat "$FUNCTIONS_FILE.tmp" >> "$FUNCTIONS_FILE"
 # shellcheck source=/dev/null
@@ -125,5 +127,41 @@ if ! grep -Fq "WARN: worktree at $DIRTY_WORKTREE has uncommitted changes; not re
   cat "$dirty_stderr" >&2
   exit 1
 fi
+
+# Locked worktree: simulates the swarm-shipping case where a Claude
+# Code agent harness locks the worktree it's running in. Removal must
+# skip cleanly with a one-line note and return 0 (not fail under set -e).
+LOCKED_WORKTREE="$TMP_ROOT/locked-worktree"
+git -C "$TEST_REPO" branch locked
+git -C "$TEST_REPO" worktree add -q "$LOCKED_WORKTREE" locked
+git -C "$TEST_REPO" worktree lock --reason "claude agent agent-test" "$LOCKED_WORKTREE"
+
+# Verify the helper sees the lock.
+detected_lock="$(cd "$TEST_REPO" && worktree_lock_reason "$LOCKED_WORKTREE")"
+if [ "$detected_lock" != "claude agent agent-test" ]; then
+  printf 'FAIL: worktree_lock_reason did not surface the lock reason\n' >&2
+  printf 'expected: claude agent agent-test\n' >&2
+  printf 'actual:   %s\n' "$detected_lock" >&2
+  exit 1
+fi
+
+locked_output="$(cd "$TEST_REPO" && remove_clean_merged_branch_worktree "$LOCKED_WORKTREE")"
+if [ ! -d "$LOCKED_WORKTREE" ]; then
+  printf 'FAIL: locked worktree was removed despite the lock\n' >&2
+  exit 1
+fi
+if [[ "$locked_output" != "==> Worktree at $LOCKED_WORKTREE is locked"* ]]; then
+  printf 'FAIL: locked worktree removal did not print expected note\n' >&2
+  printf 'actual: %s\n' "$locked_output" >&2
+  exit 1
+fi
+if [[ "$locked_output" != *"claude agent agent-test"* ]]; then
+  printf 'FAIL: locked worktree note did not include the lock reason\n' >&2
+  printf 'actual: %s\n' "$locked_output" >&2
+  exit 1
+fi
+
+# Clean up the lock so the trap can rm -rf the tmp tree.
+git -C "$TEST_REPO" worktree unlock "$LOCKED_WORKTREE" 2>/dev/null || true
 
 printf 'ok\n'


### PR DESCRIPTION
Closes #247.

When `bash scripts/open-pr.sh --auto-merge` runs from inside a worktree
that another tool has locked (most commonly a Claude Code agent harness
that locks the worktree it's running in), the squash-merge succeeds on
GitHub but the post-merge `git worktree remove` step fails with
`cannot remove a locked working tree, lock reason: ...`. Under `set -e`
this propagates as a non-zero exit code despite the merge succeeding.

Across the recent open-issues completion swarm this fired on five out
of six swarm-shipped PRs, every time forcing the operator (or an
orchestrating agent) to discount the failure language to learn the PR
actually merged.

Adds `worktree_lock_reason()`: parses `git worktree list --porcelain`
for the `locked` attribute on the requested path. Returns the reason
or empty.

`remove_clean_merged_branch_worktree()` now consults
`worktree_lock_reason` before attempting removal. If locked, it prints
a one-line note (`==> Worktree at $path is locked ($reason); skipping
removal — owner will clean up`) and returns 0. The lock holder is
expected to clean up on its own exit.

Path resolution: the helper canonicalizes the input path via `pwd -P`
so symlinked TMPDIRs (e.g. macOS `/var → /private/var`) don't cause
spurious mismatches against `git worktree list`'s resolved output.

Tested: extends `tests/test-merge-pr-worktree-handling.sh` with a
locked-worktree case asserting (a) `worktree_lock_reason` surfaces
the reason text, (b) the worktree directory is preserved after the
removal call, (c) the printed note includes the lock reason, and
(d) the function returns 0 (no `set -e` propagation).

This is interim hardening of the existing stack; the systemic
replacement is proposed in #257 (conductor swarm first-class
primitive).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
