### PR TITLE
fix: doctor codex probe accepts forward-progress events as readiness

### DIFF
--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -15,6 +15,7 @@ autumn-garage `plans/sentinel-conductor-migration.md`, future).
 from __future__ import annotations
 
 import json
+import logging
 import os
 import queue
 import shutil
@@ -57,6 +58,8 @@ from conductor.session_log import (
 if TYPE_CHECKING:
     from conductor.session_log import SessionLog
 
+_LOG = logging.getLogger(__name__)
+
 CODEX_DEFAULT_MODEL = "gpt-5.4"
 CODEX_REVIEW_MODEL = "codex-review"
 CODEX_REQUEST_TIMEOUT_SEC = 180.0
@@ -64,6 +67,7 @@ CODEX_STARTUP_PROBE_TIMEOUT_SEC = 8.0
 CODEX_STARTUP_PROBE_CONFIG = (
     "model_reasoning_effort=low",
 )
+CODEX_STARTUP_READY_EVENTS = frozenset({"thread.started", "turn.started"})
 CODEX_STREAM_POLL_INTERVAL_SEC = 0.05
 CODEX_STREAM_EXIT_READER_JOIN_SEC = 0.2
 
@@ -161,6 +165,34 @@ def _codex_startup_probe_failure(reason: str | None) -> bool:
     return bool(reason and "`codex exec` startup probe" in reason)
 
 
+def _codex_startup_ready_event(line: str) -> str | None:
+    try:
+        event = json.loads(line)
+    except json.JSONDecodeError:
+        _LOG.debug("ignoring non-JSON codex startup probe stdout line: %r", line)
+        return None
+    if not isinstance(event, dict):
+        _LOG.debug("ignoring non-object codex startup probe stdout line: %r", line)
+        return None
+    event_type = event.get("type")
+    if isinstance(event_type, str) and event_type in CODEX_STARTUP_READY_EVENTS:
+        return event_type
+    return None
+
+
+def _terminate_codex_startup_probe(process: subprocess.Popen[str]) -> None:
+    if process.poll() is not None:
+        return
+    try:
+        process.terminate()
+        process.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=1)
+    except OSError:
+        _LOG.debug("failed to terminate codex startup probe", exc_info=True)
+
+
 class CodexProvider:
     name = "codex"
     tags = ["strong-reasoning", "code-review", "tool-use"]
@@ -248,22 +280,15 @@ class CodexProvider:
             "for non-interactive use."
         )
 
-    @staticmethod
-    def _timeout_output(e: subprocess.TimeoutExpired) -> str:
-        stdout = e.stdout or e.output or ""
-        stderr = e.stderr or ""
-        if isinstance(stdout, bytes):
-            stdout = stdout.decode("utf-8", errors="replace")
-        if isinstance(stderr, bytes):
-            stderr = stderr.decode("utf-8", errors="replace")
-        return (stderr or stdout).strip()
-
     def _startup_probe(self) -> tuple[bool, str | None]:
         """Run the same codex exec startup path used by call().
 
         PATH and auth probes can pass while codex wedges before it emits any
         NDJSON, notably in the CLI's models-manager startup. This bounded
         probe keeps `conductor list` aligned with the path users actually run.
+        Codex readiness is forward progress: once the CLI emits a documented
+        startup event, the provider is authenticated and usable even if the
+        tiny probe turn has not completed yet.
         """
         with tempfile.TemporaryDirectory(prefix="conductor-codex-probe-") as tmpdir:
             output_path = Path(tmpdir) / "output.json"
@@ -281,15 +306,69 @@ class CodexProvider:
             for config in CODEX_STARTUP_PROBE_CONFIG:
                 args.extend(["-c", config])
             try:
-                result = subprocess.run(
+                process = subprocess.Popen(
                     args,
-                    input="Reply with OK.",
-                    capture_output=True,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
                     text=True,
-                    timeout=self._startup_probe_timeout_sec,
                 )
-            except subprocess.TimeoutExpired as e:
-                detail = self._timeout_output(e)
+            except (FileNotFoundError, OSError) as e:
+                return False, f"could not run `{self._cli} exec` startup probe: {e}"
+
+            if process.stdin is not None:
+                try:
+                    process.stdin.write("Reply with OK.")
+                    process.stdin.close()
+                except OSError:
+                    _LOG.debug("failed to write codex startup probe stdin", exc_info=True)
+
+            stdout_lines: list[str] = []
+            stderr_parts: list[str] = []
+            stdout_queue: queue.Queue[str | None] = queue.Queue()
+
+            def read_stdout() -> None:
+                assert process.stdout is not None
+                try:
+                    for line in process.stdout:
+                        stdout_queue.put(line)
+                finally:
+                    stdout_queue.put(None)
+
+            def read_stderr() -> None:
+                assert process.stderr is not None
+                stderr_parts.extend(process.stderr.readlines())
+
+            stdout_thread = threading.Thread(target=read_stdout, daemon=True)
+            stderr_thread = threading.Thread(target=read_stderr, daemon=True)
+            stdout_thread.start()
+            stderr_thread.start()
+
+            deadline = time.monotonic() + self._startup_probe_timeout_sec
+            stdout_eof = False
+            while time.monotonic() < deadline:
+                remaining = deadline - time.monotonic()
+                try:
+                    item = stdout_queue.get(
+                        timeout=min(CODEX_STREAM_POLL_INTERVAL_SEC, max(0.0, remaining))
+                    )
+                except queue.Empty:
+                    if process.poll() is not None and stdout_eof:
+                        break
+                    continue
+                if item is None:
+                    stdout_eof = True
+                    if process.poll() is not None:
+                        break
+                    continue
+                stdout_lines.append(item)
+                if _codex_startup_ready_event(item):
+                    _terminate_codex_startup_probe(process)
+                    return True, None
+
+            if process.poll() is None:
+                _terminate_codex_startup_probe(process)
+                detail = ("".join(stderr_parts) or "".join(stdout_lines)).strip()
                 reason = (
                     f"`{self._cli} exec` startup probe timed out after "
                     f"{self._startup_probe_timeout_sec:.0f}s"
@@ -297,17 +376,22 @@ class CodexProvider:
                 if detail:
                     reason = f"{reason}: {detail[:200]}"
                 return False, reason
-            except (FileNotFoundError, OSError) as e:
-                return False, f"could not run `{self._cli} exec` startup probe: {e}"
-        if result.returncode != 0:
-            detail = _codex_startup_probe_failure_detail(
-                result.stdout or "",
-                result.stderr or "",
-            )
-            return False, (
-                f"`{self._cli} exec` startup probe exited {result.returncode}: "
-                f"{detail[:200]}"
-            )
+
+            stdout_thread.join(timeout=CODEX_STREAM_EXIT_READER_JOIN_SEC)
+            stderr_thread.join(timeout=CODEX_STREAM_EXIT_READER_JOIN_SEC)
+            stdout = "".join(stdout_lines)
+            stderr = "".join(stderr_parts)
+            if process.returncode != 0:
+                detail = _codex_startup_probe_failure_detail(stdout, stderr)
+                return False, (
+                    f"`{self._cli} exec` startup probe exited {process.returncode}: "
+                    f"{detail[:200]}"
+                )
+            detail = (stderr or stdout).strip()
+            reason = f"`{self._cli} exec` startup probe exited before startup events"
+            if detail:
+                reason = f"{reason}: {detail[:200]}"
+            return False, reason
         return True, None
 
     def configured(self) -> tuple[bool, str | None]:

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -12,6 +12,7 @@ import os
 import shutil
 import signal
 import subprocess
+import textwrap
 import threading
 import time
 from pathlib import Path
@@ -60,6 +61,33 @@ def _fake_completed(stdout: str = "", stderr: str = "", returncode: int = 0):
     return subprocess.CompletedProcess(
         args=["stub"], returncode=returncode, stdout=stdout, stderr=stderr
     )
+
+
+def _write_fake_codex_cli(tmp_path: Path, exec_body: str) -> Path:
+    script = tmp_path / "fake-codex"
+    script.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env python3",
+                "import sys",
+                "import time",
+                "",
+                "if sys.argv[1:3] == ['login', 'status']:",
+                "    print('Logged in using ChatGPT')",
+                "    raise SystemExit(0)",
+                "",
+                "if sys.argv[1:3] == ['exec', '-']:",
+                "    sys.stdin.read()",
+                textwrap.indent(textwrap.dedent(exec_body).strip(), "    "),
+                "    raise SystemExit(0)",
+                "",
+                "raise SystemExit(f'unexpected args: {sys.argv[1:]}')",
+                "",
+            ]
+        )
+    )
+    script.chmod(0o755)
+    return script
 
 
 def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -1387,94 +1415,102 @@ def test_codex_configured_false_when_auth_probe_times_out(mocker):
     assert "could not verify" in reason
 
 
-def test_codex_configured_false_when_exec_startup_probe_times_out(mocker):
+def test_codex_configured_true_when_startup_probe_sees_thread_started(tmp_path):
+    cli = _write_fake_codex_cli(
+        tmp_path,
+        """
+        print('{"type":"thread.started","thread_id":"thread-123"}', flush=True)
+        time.sleep(60)
+        """,
+    )
+
+    ok, reason = CodexProvider(
+        cli_command=str(cli), startup_probe_timeout_sec=2
+    ).configured()
+
+    assert ok is True
+    assert reason is None
+
+
+def test_codex_configured_true_when_startup_probe_sees_turn_started(tmp_path):
+    cli = _write_fake_codex_cli(
+        tmp_path,
+        """
+        print('{"type":"turn.started"}', flush=True)
+        time.sleep(60)
+        """,
+    )
+
+    ok, reason = CodexProvider(
+        cli_command=str(cli), startup_probe_timeout_sec=2
+    ).configured()
+
+    assert ok is True
+    assert reason is None
+
+
+def test_codex_configured_false_when_exec_startup_probe_times_out(tmp_path):
     """Regression for #125: PATH + auth are not enough readiness.
 
     `conductor list` renders provider.configured(); codex must only report
-    ready when the real `codex exec` startup path also completes inside a
-    bounded timeout.
+    ready when the real `codex exec` startup path emits a forward-progress
+    event inside a bounded timeout.
     """
-    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    cli = _write_fake_codex_cli(
+        tmp_path,
+        """
+        print(
+            'codex_models_manager: failed to refresh available models',
+            file=sys.stderr,
+            flush=True,
+        )
+        time.sleep(60)
+        """,
+    )
 
-    def run(args, **kwargs):
-        if args == ["codex", "login", "status"]:
-            return _fake_completed(stdout="Logged in using ChatGPT")
-        if args[:3] == ["codex", "exec", "-"]:
-            raise subprocess.TimeoutExpired(
-                cmd=args,
-                timeout=kwargs["timeout"],
-                stderr=(
-                    "codex_models_manager: failed to refresh available models: "
-                    "timeout waiting for child process to exit"
-                ),
-            )
-        raise AssertionError(f"unexpected command: {args!r}")
-
-    captured = mocker.patch("conductor.providers.codex.subprocess.run", side_effect=run)
-
-    ok, reason = CodexProvider(startup_probe_timeout_sec=8).configured()
+    ok, reason = CodexProvider(
+        cli_command=str(cli), startup_probe_timeout_sec=0.2
+    ).configured()
 
     assert ok is False
-    assert "`codex exec` startup probe timed out after 8s" in reason
+    assert "`" + str(cli) + " exec` startup probe timed out after 0s" in reason
     assert "codex_models_manager" in reason
-    startup_call = captured.call_args_list[1]
-    assert startup_call.args[0][:3] == ["codex", "exec", "-"]
-    assert startup_call.kwargs["timeout"] == 8
-    assert startup_call.kwargs["input"] == "Reply with OK."
 
 
-def test_codex_startup_probe_avoids_minimal_reasoning_tool_conflicts(mocker):
-    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+def test_codex_configured_false_when_startup_probe_eofs_before_event(tmp_path):
+    cli = _write_fake_codex_cli(
+        tmp_path,
+        """
+        print('{"type":"turn.completed"}', flush=True)
+        """,
+    )
 
-    def run(args, **kwargs):
-        if args == ["codex", "login", "status"]:
-            return _fake_completed(stdout="Logged in using ChatGPT")
-        if args[:3] == ["codex", "exec", "-"]:
-            config_values = [
-                args[idx + 1] for idx, value in enumerate(args) if value == "-c"
-            ]
-            if "model_reasoning_effort=minimal" in config_values:
-                web_search_disabled = (
-                    "web_search='disabled'" in config_values
-                    or 'web_search="disabled"' in config_values
-                )
-                tools_disabled = (
-                    web_search_disabled
-                    and "features.image_generation=false" in config_values
-                )
-                if not tools_disabled:
-                    return _fake_completed(
-                        stdout=json.dumps(
-                            {
-                                "type": "error",
-                                "message": json.dumps(
-                                    {
-                                        "type": "error",
-                                        "error": {
-                                            "type": "invalid_request_error",
-                                            "message": (
-                                                "The following tools cannot be used with "
-                                                "reasoning.effort 'minimal': "
-                                                "image_gen, web_search."
-                                            ),
-                                            "param": "tools",
-                                        },
-                                        "status": 400,
-                                    },
-                                ),
-                            },
-                        ),
-                        returncode=1,
-                    )
-            return _fake_completed(stdout='{"type":"turn.completed"}\n')
-        raise AssertionError(f"unexpected command: {args!r}")
+    ok, reason = CodexProvider(
+        cli_command=str(cli), startup_probe_timeout_sec=2
+    ).configured()
 
-    captured = mocker.patch("conductor.providers.codex.subprocess.run", side_effect=run)
+    assert ok is False
+    assert "startup probe exited before startup events" in reason
+    assert "turn.completed" in reason
 
-    ok, reason = CodexProvider().configured()
+
+def test_codex_startup_probe_avoids_minimal_reasoning_tool_conflicts(tmp_path):
+    args_file = tmp_path / "args.txt"
+    cli = _write_fake_codex_cli(
+        tmp_path,
+        f"""
+        open({str(args_file)!r}, 'w').write('\\n'.join(sys.argv))
+        print('{{"type":"turn.started"}}', flush=True)
+        time.sleep(60)
+        """,
+    )
+
+    ok, reason = CodexProvider(
+        cli_command=str(cli), startup_probe_timeout_sec=2
+    ).configured()
 
     assert ok is True and reason is None
-    startup_args = captured.call_args_list[1].args[0]
+    startup_args = args_file.read_text().splitlines()
     config_values = [
         startup_args[idx + 1]
         for idx, value in enumerate(startup_args)
@@ -1486,57 +1522,46 @@ def test_codex_startup_probe_avoids_minimal_reasoning_tool_conflicts(mocker):
     assert "features.web_search=false" not in config_values
     assert "features.image_gen=false" not in config_values
 
-
-def test_codex_startup_probe_reports_api_error_instead_of_first_event(mocker):
-    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
-    stdout = "\n".join(
-        [
-            '{"type":"thread.started","thread_id":"thread-123"}',
-            '{"type":"turn.started"}',
-            json.dumps(
+def test_codex_startup_probe_reports_api_error_without_startup_event(tmp_path):
+    stdout = json.dumps(
+        {
+            "type": "error",
+            "message": json.dumps(
                 {
                     "type": "error",
-                    "message": json.dumps(
-                        {
-                            "type": "error",
-                            "error": {
-                                "type": "invalid_request_error",
-                                "message": (
-                                    "The following tools cannot be used with "
-                                    "reasoning.effort 'minimal': image_gen, web_search."
-                                ),
-                                "param": "tools",
-                            },
-                            "status": 400,
-                        }
-                    ),
+                    "error": {
+                        "type": "invalid_request_error",
+                        "message": (
+                            "The following tools cannot be used with "
+                            "reasoning.effort 'minimal': image_gen, web_search."
+                        ),
+                        "param": "tools",
+                    },
+                    "status": 400,
                 }
             ),
-            '{"type":"turn.failed"}',
-        ]
+        }
+    )
+    cli = _write_fake_codex_cli(
+        tmp_path,
+        f"""
+        print({stdout!r}, flush=True)
+        raise SystemExit(1)
+        """,
     )
 
-    def run(args, **kwargs):
-        if args == ["codex", "login", "status"]:
-            return _fake_completed(stdout="Logged in using ChatGPT")
-        if args[:3] == ["codex", "exec", "-"]:
-            return _fake_completed(stdout=stdout, returncode=1)
-        raise AssertionError(f"unexpected command: {args!r}")
-
-    mocker.patch("conductor.providers.codex.subprocess.run", side_effect=run)
-
-    ok, reason = CodexProvider().configured()
+    ok, reason = CodexProvider(
+        cli_command=str(cli), startup_probe_timeout_sec=2
+    ).configured()
 
     assert ok is False
-    assert "`codex exec` startup probe exited 1" in reason
+    assert f"`{cli} exec` startup probe exited 1" in reason
     assert "invalid_request_error" in reason
     assert "The following tools cannot be used" in reason
     assert "param=tools" in reason
-    assert "thread.started" not in reason
 
 
-def test_codex_startup_probe_reports_turn_failed_error_dict(mocker):
-    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+def test_codex_startup_probe_reports_turn_failed_error_dict(tmp_path):
     stdout = json.dumps(
         {
             "type": "turn.failed",
@@ -1547,17 +1572,17 @@ def test_codex_startup_probe_reports_turn_failed_error_dict(mocker):
             },
         }
     )
+    cli = _write_fake_codex_cli(
+        tmp_path,
+        f"""
+        print({stdout!r}, flush=True)
+        raise SystemExit(1)
+        """,
+    )
 
-    def run(args, **kwargs):
-        if args == ["codex", "login", "status"]:
-            return _fake_completed(stdout="Logged in using ChatGPT")
-        if args[:3] == ["codex", "exec", "-"]:
-            return _fake_completed(stdout=stdout, returncode=1)
-        raise AssertionError(f"unexpected command: {args!r}")
-
-    mocker.patch("conductor.providers.codex.subprocess.run", side_effect=run)
-
-    ok, reason = CodexProvider().configured()
+    ok, reason = CodexProvider(
+        cli_command=str(cli), startup_probe_timeout_sec=2
+    ).configured()
 
     assert ok is False
     assert "invalid_request_error: The request was rejected.: param=tools" in reason


### PR DESCRIPTION
Codex doctor readiness previously waited for the probe turn to complete, so a slow-but-authenticated CLI could emit thread.started or turn.started inside the deadline and still be reported NOT READY. The startup probe now streams stdout, treats thread.started and turn.started as forward-progress readiness events, logs malformed probe stdout at debug, and terminates the bounded probe process once readiness is established.

Tests cover thread.started readiness, turn.started readiness, timeout without events, EOF before a readiness event, and existing Codex startup error reporting.

Audit: reviewed CLI-backed readiness probes for claude (ClaudeProvider._auth_probe and health_probe), gemini (GeminiProvider._auth_probe and health_probe), and ollama (OllamaProvider.configured and health_probe). Claude and Gemini do not run an agent-loop startup probe for doctor readiness; they use auth/version checks. Ollama probes HTTP liveness. No same anti-pattern was found, so no follow-up provider fix is bundled.

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
