### PR TITLE
feat: --max-iterations on conductor exec, scales default with --effort

### DIFF
--- a/docs/consumers.md
+++ b/docs/consumers.md
@@ -105,7 +105,9 @@ Current enforcement support:
 
 If the workflow only needs review with no file mutation, prefer `conductor review` or `conductor ask --kind review`. Use `exec --permission-profile read-only` only for agentic inspection workflows that need the multi-turn exec machinery.
 
-`conductor exec --help` is the canonical reference for agentic code/edit mode. Its stable exec-specific flags are: --tools, --permission-profile, --sandbox, --cwd, --timeout, --max-stall-seconds, --start-timeout, --log-file, --preflight, --no-preflight, and --allow-short-brief. `--sandbox` remains parseable for compatibility but is deprecated and ignored.
+`conductor exec --help` is the canonical reference for agentic code/edit mode. Its stable exec-specific flags are: --tools, --permission-profile, --sandbox, --cwd, --timeout, --max-stall-seconds, --start-timeout, --max-iterations, --log-file, --preflight, --no-preflight, and --allow-short-brief. `--sandbox` remains parseable for compatibility but is deprecated and ignored.
+
+`--max-iterations <n>` is an exec-only Conductor-managed tool-use loop cap. If unset, it defaults from base 10 by effective `--effort`: unset/minimal=10, low=15, medium=20, high=30, max=40.
 
 ## Flags
 

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -158,6 +158,20 @@ PROFILE_PRECEDENCE_TEXT = (
 )
 DEFAULT_EXEC_MAX_STALL_SEC = 360
 MIN_EXEC_BRIEF_CHARS = 300
+DEFAULT_EXEC_MAX_ITERATIONS = 10
+EXEC_MAX_ITERATION_MULTIPLIERS = {
+    "minimal": 1.0,
+    "low": 1.5,
+    "medium": 2.0,
+    "high": 3.0,
+    "max": 4.0,
+}
+EXEC_MAX_ITERATIONS_HELP = (
+    "Maximum Conductor-managed tool-use loop iterations. Default scales with "
+    "--effort from base 10: minimal=10, low=15, medium=20, high=30, max=40. "
+    "If --effort is unset, preserves the legacy cap of 10."
+)
+EXEC_MAX_ITERATION_PROVIDER_IDS = frozenset({"openrouter", "ollama"})
 GIT_RECOVERY_COMMAND_TIMEOUT_SEC = 2.0
 GIT_RECOVERY_MAX_COMMITS = 5
 GIT_RECOVERY_MAX_STATUS_PATHS = 8
@@ -503,6 +517,32 @@ def _parse_effort(raw: str | None) -> str | int:
             f"Did you mean '{hint}'?"
         )
     return raw
+
+
+def _resolve_exec_max_iterations(
+    explicit_max_iterations: int | None,
+    *,
+    raw_effort: str | None,
+) -> int:
+    if explicit_max_iterations is not None:
+        return explicit_max_iterations
+    if raw_effort is None:
+        return DEFAULT_EXEC_MAX_ITERATIONS
+    effort = raw_effort.strip()
+    multiplier = EXEC_MAX_ITERATION_MULTIPLIERS.get(effort, 1.0)
+    return int(DEFAULT_EXEC_MAX_ITERATIONS * multiplier)
+
+
+def _provider_supports_exec_max_iterations(provider_id: str) -> bool:
+    return provider_id in EXEC_MAX_ITERATION_PROVIDER_IDS
+
+
+def _exec_max_iterations_unsupported_message(provider_id: str) -> str:
+    supported = ", ".join(sorted(EXEC_MAX_ITERATION_PROVIDER_IDS))
+    return (
+        "--max-iterations only applies to Conductor-managed tool-use loops "
+        f"({supported}); {provider_id} cannot honor it."
+    )
 
 
 def _validate_tools(raw: str | None) -> frozenset[str]:
@@ -1544,6 +1584,8 @@ def _invoke_with_fallback(
     session_log: SessionLog | None = None,
     models_by_provider: dict[str, tuple[str, ...]] | None = None,
     attachments: tuple[Path, ...] = (),
+    max_iterations: int | None = None,
+    max_iterations_explicit: bool = False,
     write_validation: bool = True,
 ) -> tuple[CallResponse, list[str]]:
     """Try the decision's ranked providers in order; fallback on retryable errors.
@@ -1619,6 +1661,22 @@ def _invoke_with_fallback(
             idx += 1
             continue
         candidate_models = (models_by_provider or {}).get(candidate.name)
+        if (
+            mode == "exec"
+            and max_iterations_explicit
+            and not _provider_supports_exec_max_iterations(candidate.name)
+        ):
+            message = _exec_max_iterations_unsupported_message(candidate.name)
+            if not silent:
+                click.echo(f"[conductor] {candidate.name} skipped: {message}", err=True)
+            if session_log is not None:
+                session_log.emit(
+                    "provider_skipped",
+                    {"provider": candidate.name, "reason": message},
+                )
+            fallbacks.append(candidate.name)
+            idx += 1
+            continue
         if session_log is not None:
             session_log.bind_provider(candidate.name)
             session_log.emit(
@@ -1652,6 +1710,7 @@ def _invoke_with_fallback(
                         max_stall_sec=max_stall_sec,
                         resume_session_id=resume_session_id,
                         session_log=session_log,
+                        max_iterations=max_iterations,
                         write_validation=write_validation,
                     )
                 elif isinstance(provider, ClaudeProvider):
@@ -1697,6 +1756,7 @@ def _invoke_with_fallback(
                         max_stall_sec=max_stall_sec,
                         resume_session_id=resume_session_id,
                         session_log=session_log,
+                        max_iterations=max_iterations,
                         write_validation=write_validation,
                     )
                 else:
@@ -4607,6 +4667,12 @@ def review(
     ),
 )
 @click.option(
+    "--max-iterations",
+    default=None,
+    type=click.IntRange(min=1),
+    help=EXEC_MAX_ITERATIONS_HELP,
+)
+@click.option(
     "--retry-on-stall",
     default=1,
     type=click.IntRange(min=0),
@@ -4724,6 +4790,7 @@ def exec_cmd(
     timeout_sec: int | None,
     max_stall_sec: int | None,
     start_timeout_sec: float | None,
+    max_iterations: int | None,
     retry_on_stall: int,
     task: str | None,
     task_file: str | None,
@@ -4807,6 +4874,11 @@ def exec_cmd(
         permission_profile=permission_profile_value,
     )
     sandbox_value = _validate_sandbox(sandbox, warn=sandbox is not None)
+    max_iterations_value = _resolve_exec_max_iterations(
+        max_iterations,
+        raw_effort=effort,
+    )
+    max_iterations_explicit = max_iterations is not None
     effort_value = _parse_effort(effort)
     start_timeout_sec = _normalize_start_timeout_sec(start_timeout_sec)
     dispatch_started_at = time.monotonic()
@@ -4838,6 +4910,12 @@ def exec_cmd(
         except (NoConfiguredProvider, InvalidRouterRequest, MutedProvidersError) as e:
             click.echo(f"conductor: {e}", err=True)
             sys.exit(2)
+        if max_iterations_explicit and not _provider_supports_exec_max_iterations(
+            decision.provider
+        ):
+            raise click.UsageError(
+                _exec_max_iterations_unsupported_message(decision.provider)
+            )
         if exclusion_message and not silent_route:
             click.echo(exclusion_message, err=True)
         _ensure_permission_profile_supported(
@@ -4853,6 +4931,14 @@ def exec_cmd(
         _emit_session_route_decision(session_log, decision)
         print_caller_banner(decision.provider, silent=silent_route or as_json)
         _emit_route_log(decision, verbose=verbose_route, silent=silent_route or as_json)
+        if (
+            _provider_supports_exec_max_iterations(decision.provider)
+            and not (silent_route or as_json)
+        ):
+            click.echo(
+                f"[conductor] agent loop iteration cap: {max_iterations_value}",
+                err=True,
+            )
         timeout_sec, max_stall_sec = _scale_dispatch_defaults(
             provider_id=decision.provider,
             timeout_sec=timeout_sec,
@@ -4906,6 +4992,8 @@ def exec_cmd(
                 resume_session_id=resume_session_id,
                 session_log=session_log,
                 attachments=attachments,
+                max_iterations=max_iterations_value,
+                max_iterations_explicit=max_iterations_explicit,
                 write_validation=write_validation,
             )
         except UnsupportedCapability as e:
@@ -4966,6 +5054,10 @@ def exec_cmd(
             provider = get_provider(provider_id)
         except KeyError as e:
             raise click.UsageError(str(e)) from e
+        if max_iterations_explicit and not _provider_supports_exec_max_iterations(
+            provider_id
+        ):
+            raise click.UsageError(_exec_max_iterations_unsupported_message(provider_id))
         _ensure_permission_profile_supported(
             provider,
             provider_id=provider_id,
@@ -4983,6 +5075,14 @@ def exec_cmd(
         )
         session_log.bind_provider(provider_id)
         print_caller_banner(provider_id, silent=silent_route or as_json)
+        if (
+            _provider_supports_exec_max_iterations(provider_id)
+            and not (silent_route or as_json)
+        ):
+            click.echo(
+                f"[conductor] agent loop iteration cap: {max_iterations_value}",
+                err=True,
+            )
         timeout_sec, max_stall_sec = _scale_dispatch_defaults(
             provider_id=provider_id,
             timeout_sec=timeout_sec,
@@ -5038,6 +5138,7 @@ def exec_cmd(
                     max_stall_sec=max_stall_sec,
                     resume_session_id=resume_session_id,
                     session_log=session_log,
+                    max_iterations=max_iterations_value,
                     write_validation=write_validation,
                 )
             elif isinstance(provider, ClaudeProvider):
@@ -5081,6 +5182,7 @@ def exec_cmd(
                     max_stall_sec=max_stall_sec,
                     resume_session_id=resume_session_id,
                     session_log=session_log,
+                    max_iterations=max_iterations_value,
                     write_validation=write_validation,
                 )
             else:

--- a/src/conductor/providers/ollama.py
+++ b/src/conductor/providers/ollama.py
@@ -502,6 +502,7 @@ class OllamaProvider:
         max_stall_sec: int | None = None,
         resume_session_id: str | None = None,
         session_log: SessionLog | None = None,
+        max_iterations: int | None = None,
         write_validation: bool = True,
     ) -> CallResponse:
         # accepted for API parity; only codex implements stall-watchdog today
@@ -540,9 +541,10 @@ class OllamaProvider:
         context_ceiling = int(
             self.max_context_tokens * (1 - OLLAMA_CONTEXT_SAFETY_MARGIN)
         )
+        iteration_cap = max_iterations or OLLAMA_MAX_TOOL_ITERATIONS
 
         start = time.monotonic()
-        while iteration < OLLAMA_MAX_TOOL_ITERATIONS:
+        while iteration < iteration_cap:
             iteration += 1
             payload: dict = {
                 "model": model,
@@ -686,9 +688,8 @@ class OllamaProvider:
 
         if hit_cap:
             final_text = (final_text or "(no content)") + (
-                f"\n\n[conductor: tool-use loop hit max iterations "
-                f"({OLLAMA_MAX_TOOL_ITERATIONS}); model kept requesting tools. "
-                "Re-run with a narrower task or a larger budget.]"
+                f"\n\n[conductor] Reached --max-iterations cap ({iteration_cap}). "
+                "Re-run with --max-iterations <larger> or split the brief."
             )
         if hit_context_budget:
             final_text = (final_text or "(no content)") + (

--- a/src/conductor/providers/openrouter.py
+++ b/src/conductor/providers/openrouter.py
@@ -360,6 +360,7 @@ class OpenRouterProvider:
         max_stall_sec: int | None = None,
         resume_session_id: str | None = None,
         session_log: SessionLog | None = None,
+        max_iterations: int | None = None,
         write_validation: bool = True,
     ) -> CallResponse:
         if resume_session_id:
@@ -425,9 +426,10 @@ class OpenRouterProvider:
         validation_failures: list[dict[str, object]] = []
         repo_changing_task = _is_repo_changing_tool_task(effective_task_tags, tools)
         git_status_before = _git_clean_status(workdir) if repo_changing_task else None
+        iteration_cap = max_iterations or OPENROUTER_MAX_TOOL_ITERATIONS
 
         start = time.monotonic()
-        while iteration < OPENROUTER_MAX_TOOL_ITERATIONS:
+        while iteration < iteration_cap:
             iteration += 1
             payload: dict = {
                 **target_payload,
@@ -557,9 +559,8 @@ class OpenRouterProvider:
 
         if hit_cap:
             final_text = (final_text or "(no content)") + (
-                f"\n\n[conductor: OpenRouter tool-use loop hit max iterations "
-                f"({OPENROUTER_MAX_TOOL_ITERATIONS}); model kept requesting tools. "
-                "Re-run with a narrower task or a larger budget.]"
+                f"\n\n[conductor] Reached --max-iterations cap ({iteration_cap}). "
+                "Re-run with --max-iterations <larger> or split the brief."
             )
 
         git_status_after = _git_clean_status(workdir) if repo_changing_task else None
@@ -571,6 +572,7 @@ class OpenRouterProvider:
             bash_failures=bash_failures,
             validation_failures=validation_failures,
             hit_cap=hit_cap,
+            iteration_cap=iteration_cap,
             git_status_before=git_status_before,
             git_status_after=git_status_after,
         )
@@ -748,6 +750,7 @@ def _execution_status(
     bash_failures: list[dict[str, object]],
     validation_failures: list[dict[str, object]],
     hit_cap: bool,
+    iteration_cap: int,
     git_status_before: dict[str, object] | None,
     git_status_after: dict[str, object] | None,
 ) -> dict[str, object]:
@@ -775,6 +778,7 @@ def _execution_status(
         "bash_failures": bash_failures,
         "validation_failures": validation_failures,
         "hit_iteration_cap": hit_cap,
+        "iteration_cap": iteration_cap,
         "git_status_before": git_status_before,
         "git_status_after": git_status_after,
     }
@@ -783,7 +787,11 @@ def _execution_status(
 def _execution_failure_message(status: dict[str, object]) -> str | None:
     state = status.get("state")
     if state == "iteration-cap":
-        return "tool-use loop hit max iterations before completing the code task"
+        cap = status.get("iteration_cap")
+        return (
+            f"Reached --max-iterations cap ({cap}). Re-run with "
+            "--max-iterations <larger> or split the brief."
+        )
     if state == "validation-failed":
         return "validation command failed after edits"
     if state == "tool-error":

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -79,6 +79,7 @@ DOCUMENTED_EXEC_FLAGS: frozenset[str] = frozenset(
         "--timeout",
         "--max-stall-seconds",
         "--start-timeout",
+        "--max-iterations",
         "--log-file",
         "--preflight",
         "--no-preflight",

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -25,7 +25,11 @@ import respx
 from click.testing import CliRunner
 
 from conductor import offline_mode
-from conductor.cli import SANDBOX_DEPRECATION_WARNING, main
+from conductor.cli import (
+    SANDBOX_DEPRECATION_WARNING,
+    _resolve_exec_max_iterations,
+    main,
+)
 from conductor.network_profile import NetworkProfile
 from conductor.openrouter_model_stacks import OPENROUTER_CODING_HIGH
 from conductor.providers import (
@@ -1602,7 +1606,6 @@ def test_exec_auto_cheapest_code_review_offline_keeps_ollama(mocker):
     assert result.exit_code == 0, result.output
     assert ollama_exec.called
     assert "excluding ollama from fallback chain" not in result.stderr
-    assert "→ ollama" in result.stderr
 
 
 def test_exec_auto_cheapest_network_probe_offline_keeps_ollama_primary(mocker):
@@ -2091,6 +2094,91 @@ def test_exec_cli_max_stall_seconds_zero_disables_watchdog(mocker):
 
     assert result.exit_code == 0, result.output
     assert exec_mock.call_args.kwargs["max_stall_sec"] is None
+
+
+@pytest.mark.parametrize(
+    ("effort", "expected"),
+    [
+        ("minimal", 10),
+        ("low", 15),
+        ("medium", 20),
+        ("high", 30),
+        ("max", 40),
+    ],
+)
+def test_exec_max_iterations_default_scales_by_effort(effort, expected):
+    assert _resolve_exec_max_iterations(None, raw_effort=effort) == expected
+
+
+def test_exec_max_iterations_unset_effort_preserves_legacy_cap():
+    assert _resolve_exec_max_iterations(None, raw_effort=None) == 10
+
+
+def test_exec_max_iterations_explicit_override_ignores_effort(mocker):
+    _stub_all_configured(mocker, {"openrouter"})
+    exec_mock = mocker.patch.object(
+        OpenRouterProvider, "exec", return_value=_fake_response("openrouter")
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--with",
+            "openrouter",
+            "--max-iterations",
+            "100",
+            "--effort",
+            "minimal",
+            "--task",
+            "do it",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert exec_mock.call_args.kwargs["max_iterations"] == 100
+    assert "[conductor] agent loop iteration cap: 100" in result.stderr
+
+
+def test_exec_max_iterations_explicit_rejects_unsupported_provider(mocker):
+    _stub_all_configured(mocker, {"codex"})
+    exec_mock = mocker.patch.object(
+        CodexProvider, "exec", return_value=_fake_response("codex")
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--with",
+            "codex",
+            "--max-iterations",
+            "5",
+            "--task",
+            "do it",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert not exec_mock.called
+    assert "--max-iterations only applies" in result.output
+    assert "codex cannot honor it" in result.output
+
+
+def test_exec_max_iterations_banner_only_for_supporting_providers(mocker):
+    _stub_all_configured(mocker, {"codex"})
+    exec_mock = mocker.patch.object(
+        CodexProvider, "exec", return_value=_fake_response("codex")
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["exec", "--with", "codex", "--task", "do it"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert exec_mock.called
+    assert "agent loop iteration cap" not in result.stderr
 
 
 def test_exec_cli_start_timeout_flag_propagates_to_claude(mocker):

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -564,11 +564,15 @@ def test_exec_iteration_cap(tmp_path):
             tools=frozenset({"Read"}),
             sandbox="read-only",
             cwd=str(tmp_path),
+            max_iterations=3,
         )
     assert resp.usage["hit_iteration_cap"] is True
-    assert resp.usage["tool_iterations"] == 10
-    assert route.call_count == 10
-    assert "max iterations" in resp.text.lower()
+    assert resp.usage["tool_iterations"] == 3
+    assert route.call_count == 3
+    assert (
+        "[conductor] Reached --max-iterations cap (3). Re-run with "
+        "--max-iterations <larger> or split the brief."
+    ) in resp.text
 
 
 def test_exec_workspace_write_runs_edit(tmp_path):

--- a/tests/test_openrouter.py
+++ b/tests/test_openrouter.py
@@ -849,13 +849,16 @@ def test_exec_code_task_iteration_cap_raises_status(configured, tmp_path):
                 task_tags=("code", "tool-use"),
                 sandbox="none",
                 cwd=str(tmp_path),
+                max_iterations=4,
             )
 
     status = exc.value.status
     assert status["state"] == "iteration-cap"
     assert status["hit_iteration_cap"] is True
-    assert status["tool_calls"] == OPENROUTER_MAX_TOOL_ITERATIONS
-    assert len(requests) == OPENROUTER_MAX_TOOL_ITERATIONS
+    assert status["iteration_cap"] == 4
+    assert status["tool_calls"] == 4
+    assert len(requests) == 4
+    assert "Reached --max-iterations cap (4)" in str(exc.value)
 
 
 def test_exec_with_tools_rejects_model_and_models_together(configured):


### PR DESCRIPTION
Adds an exec-only --max-iterations flag for Conductor-managed tool-use loops. When unset, the cap is derived from the legacy default of 10 iterations and the effective effort policy: unset/minimal=10, low=15, medium=20, high=30, max=40. Explicit --max-iterations overrides the effort-derived cap.

OpenRouter and Ollama now receive the per-run cap, include iteration_cap in OpenRouter execution status, and report cap exits as: Reached --max-iterations cap (N). Re-run with --max-iterations <larger> or split the brief.

Validation: uv run pytest; uv run ruff check src/ tests/; uv run conductor exec --help.

Closes #1

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
