### PR TITLE
docs: surface same-process OAuth contention in delegation guidance

### DIFF
--- a/src/conductor/_agent_templates.py
+++ b/src/conductor/_agent_templates.py
@@ -108,17 +108,42 @@ Get JSON for scripting / piping into other tools:
 
 ## Providers at a glance
 
-| Provider | Best for                     | Cost   | Notes                        |
+| Provider | Best for                     | Cost   | Auth                         |
 |----------|------------------------------|--------|------------------------------|
-| kimi     | long-context, cheap reviews  | $      | OpenRouter-backed            |
-| gemini   | web search, multimodal       | $$     | Google AI Studio or gcloud   |
-| claude   | strongest reasoning          | $$$    | your Claude subscription     |
-| codex    | coding agent                 | $$$    | your ChatGPT subscription    |
-| ollama   | private, offline             | free   | runs locally                 |
+| kimi     | long-context, cheap reviews  | $      | env var (OpenRouter-backed)  |
+| gemini   | web search, multimodal       | $$     | env var or gcloud            |
+| claude   | strongest reasoning          | $$$    | OAuth (Claude subscription)  |
+| codex    | coding agent                 | $$$    | OAuth (ChatGPT subscription) |
+| ollama   | private, offline             | free   | local (no auth)              |
 
 Discover what's currently configured:
 
     conductor list
+
+## Caveat: same-process OAuth contention
+
+When you delegate from inside an active Claude Code session (or any agent
+shell that already holds a `claude` / `codex` OAuth session), prefer the
+**env-var-auth providers** (`openrouter`, `kimi`, `deepseek`, `gemini`) for
+headless paths.
+
+The OAuth-CLI providers (`claude`, `codex`) hold a per-process session
+lock for their CLI's auth state. A second invocation of the same CLI
+inside the same session contends with the parent's lock and stalls at
+first_output (typically a ~300s timeout) before failing. Conductor's
+diagnostic now identifies this clearly ("auth-lock or session-state
+contention"), but you can avoid the stall entirely by routing headless
+delegations to env-var-auth providers.
+
+Two practical defaults:
+
+- `conductor exec --with codex` from inside a Claude Code session →
+  prefer `--with openrouter` (or `--auto --kind code`) instead.
+- `conductor call --with claude` from inside another Claude session →
+  prefer `--with openrouter` or `--with kimi`.
+
+The `--with claude` / `--with codex` paths still work when invoked from
+a non-OAuth-holding shell (e.g. a CI runner, a non-Claude-Code terminal).
 
 ## Subagents available
 


### PR DESCRIPTION
Closes part of #256 (Pattern 4 — OAuth contention docs nudge).

When delegating from inside an active Claude Code session (or any
agent shell that already holds a `claude` / `codex` OAuth session),
the OAuth-CLI providers (`claude`, `codex`) deadlock on the parent
process's session lock and stall at first_output (~300s) before
failing.

Conductor's diagnostic identifies the cause clearly, but operators
lose time discovering the failure mode empirically. This adds a
"Same-process OAuth contention" section to the delegation guidance
with concrete routing alternatives — env-var-auth providers
(openrouter, kimi, deepseek, gemini) for headless paths from inside
an OAuth-holding shell.

The provider table's "Notes" column is renamed to "Auth" so the
distinction is visible at a glance.

This is part of #256's punch list. Patterns 2 (#261) and 1 sub-fix 1
(#264) already shipped. Sub-fixes 2 and 3 of Pattern 1, plus Pattern
3, are deferred to follow-up issues.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
