### PR TITLE
chore: agent-template + delegation-guidance docs hygiene

### DIFF
--- a/src/conductor/_agent_templates.py
+++ b/src/conductor/_agent_templates.py
@@ -120,6 +120,31 @@ Discover what's currently configured:
 
     conductor list
 
+## Caveat: ollama is offline-only by default
+
+When you pick by capability tags (`--auto --tags …` or `--prefer cheapest`),
+conductor's auto-router excludes ollama at any plan position when online —
+the rule fires whether ollama would be the primary or a fallback. The goal
+is to prevent accidentally loading a 25 GB local model when frontier
+providers are reachable.
+
+Three ways to invoke ollama anyway:
+
+- `conductor call --with ollama …` — explicit by name. Bypasses the rule.
+- `conductor call --auto --tags ollama …` — name-as-tag passthrough.
+  Conductor recognizes any provider name in `--tags` as an explicit
+  selection signal. (Note: ollama doesn't actually have a tag named
+  `ollama`; this is the special-case detection. `--tags local` or
+  `--tags cheap` alone — tags ollama legitimately has — does NOT
+  bypass the rule.)
+- `conductor call --offline …` — operator stated offline (or the
+  offline-mode sticky flag fired on a network probe).
+
+If you see the stderr line `[conductor] excluding ollama from fallback
+chain (online; ollama is offline-only — pass --offline to override)`,
+that is the rule firing. Pick one of the three escape hatches above if
+you actually want ollama.
+
 ## Caveat: same-process OAuth contention
 
 When you delegate from inside an active Claude Code session (or any agent
@@ -370,6 +395,22 @@ When invoked:
    the watchdog, conductor's stderr message will name a forensic
    envelope path (under `~/.cache/conductor/codex-*.json`) — surface
    that path to the parent agent so the failure can be triaged.
+
+When briefing codex on a task that ships a PR via `scripts/open-pr.sh
+--auto-merge`, include this guidance in the brief so codex doesn't
+need to discover it empirically:
+
+- **PR title equals commit subject.** `open-pr.sh` derives the PR title
+  from `git log -1 --format=%s`. If the brief specifies a PR title,
+  codex must use THAT EXACT STRING as the commit subject; otherwise
+  the PR title and the brief's specified title will diverge and the
+  operator (or a follow-up agent) has to correct the metadata
+  post-merge.
+- **One closing keyword per issue.** `Closes #A, #B, #C` only
+  auto-closes #A — GitHub requires each issue to have its own keyword.
+  Use the form `Closes #A.\\nCloses #B.\\nCloses #C.` (each on its own
+  line, each with its own `Closes`/`Fixes`/`Resolves`). The wrong form
+  leaves stragglers open and forces manual cleanup after merge.
 
 If the task is a quick one-shot question (no file tools needed), route
 it to a single-turn provider instead — `exec` mode carries more setup

--- a/tests/test_agent_template_drift.py
+++ b/tests/test_agent_template_drift.py
@@ -40,6 +40,10 @@ EXPECTED_TEMPLATE_COVERAGE = {
         # #250: handle the case where the harness auto-backgrounds.
         "AUTO-BACKGROUNDS",
         "BashOutput",
+        # #270: tie PR title to commit subject under open-pr.sh.
+        "PR title equals commit subject",
+        # #268: one closing keyword per issue (don't comma-chain).
+        "One closing keyword per issue",
     },
     "ollama-offline": {
         "--offline",


### PR DESCRIPTION
Closes #268.
Closes #270.
Closes #272.

Three small docs/template gaps surfaced during the v0.10.2 install
verification:

- #268: GitHub auto-close requires one closing keyword per issue
  (`Closes #A.\nCloses #B.`) — comma-chained `Closes #A, #B` only
  closes #A. Five PRs in the recent swarm hit this and required
  manual close-cleanup.
- #270: `scripts/open-pr.sh --auto-merge` derives the PR title from
  the commit subject; codex didn't know this, so its commit subject
  and the brief's specified PR title diverged on PR #269 and codex
  had to correct the metadata post-merge.
- #272: The `--tags ollama` carve-out is name-passthrough, not
  tag-match. Operators reading the exclusion docs assume ollama has
  a tag named `ollama` (it doesn't); they try `--tags local` and
  hit the exclusion-stderr unexpectedly.

All three are pure docs additions to the embedded templates in
`_agent_templates.py`. The drift test gains assertions on the new
tokens so a future template edit that drops these guardrails fails
in CI.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
