### PR TITLE
fix: --max-stall-seconds ignores codex subagent_message heartbeats

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -1613,6 +1613,7 @@ def _invoke_with_fallback(
     max_iterations: int | None = None,
     max_iterations_explicit: bool = False,
     write_validation: bool = True,
+    strict_stall: bool = False,
 ) -> tuple[CallResponse, list[str]]:
     """Try the decision's ranked providers in order; fallback on retryable errors.
 
@@ -1768,6 +1769,7 @@ def _invoke_with_fallback(
                         resume_session_id=resume_session_id,
                         session_log=session_log,
                         attachments=attachments,
+                        strict_stall=strict_stall,
                     )
                 elif isinstance(provider, OllamaProvider):
                     _ensure_supports_attachments(provider, attachments)
@@ -4702,6 +4704,15 @@ def review(
     ),
 )
 @click.option(
+    "--strict-stall",
+    is_flag=True,
+    default=False,
+    help=(
+        "Codex exec only. Reset --max-stall-seconds only on tool-use/tool-result "
+        "events and stderr, ignoring assistant text and turn-boundary events."
+    ),
+)
+@click.option(
     "--start-timeout",
     "start_timeout_sec",
     default=None,
@@ -4847,6 +4858,7 @@ def exec_cmd(
     cwd: str | None,
     timeout_sec: int | None,
     max_stall_sec: int | None,
+    strict_stall: bool,
     start_timeout_sec: float | None,
     max_iterations: int | None,
     retry_on_stall: int,
@@ -5053,6 +5065,7 @@ def exec_cmd(
                 max_iterations=max_iterations_value,
                 max_iterations_explicit=max_iterations_explicit,
                 write_validation=write_validation,
+                strict_stall=strict_stall,
             )
         except UnsupportedCapability as e:
             if session_log is not None:
@@ -5222,6 +5235,7 @@ def exec_cmd(
                     resume_session_id=resume_session_id,
                     session_log=session_log,
                     attachments=attachments,
+                    strict_stall=strict_stall,
                 )
             elif isinstance(provider, OllamaProvider):
                 response = provider.exec(

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -68,6 +68,21 @@ CODEX_STARTUP_PROBE_CONFIG = (
     "model_reasoning_effort=low",
 )
 CODEX_STARTUP_READY_EVENTS = frozenset({"thread.started", "turn.started"})
+CODEX_STALL_INITIAL_EVENTS = frozenset(
+    {"session.created", "thread.started", "turn.started"}
+)
+CODEX_STALL_BOUNDARY_EVENTS = frozenset({"turn.completed", "turn.failed"})
+CODEX_STALL_TOOL_EVENTS = frozenset({"tool_use", "tool_result"})
+CODEX_STALL_KNOWN_NON_PROGRESS_EVENTS = frozenset(
+    {
+        "error",
+        "item.started",
+        "session.created",
+        "subagent_message",
+        "thread.started",
+        "turn.started",
+    }
+)
 CODEX_STREAM_POLL_INTERVAL_SEC = 0.05
 CODEX_STREAM_EXIT_READER_JOIN_SEC = 0.2
 
@@ -673,6 +688,52 @@ class CodexProvider:
                 },
             )
 
+    def _codex_stall_progress_kind(self, raw_line: str) -> str | None:
+        """Classify Codex JSONL events that prove the session is progressing."""
+        try:
+            event = json.loads(raw_line)
+        except json.JSONDecodeError:
+            _LOG.debug("ignoring non-JSON codex stdout line for stall watchdog: %r", raw_line)
+            return None
+        if not isinstance(event, dict):
+            _LOG.debug("ignoring non-object codex stdout line for stall watchdog: %r", raw_line)
+            return None
+
+        kind = event.get("type")
+        if not isinstance(kind, str) or not kind:
+            _LOG.debug("ignoring codex stdout event without string type: %r", event)
+            return None
+
+        item = event.get("item") or {}
+        if not isinstance(item, dict):
+            item = {}
+        item_type = item.get("type")
+        item_type_text = str(item_type) if item_type is not None else ""
+
+        if kind in CODEX_STALL_TOOL_EVENTS:
+            return "tool"
+        if item_type_text and (
+            "tool" in item_type_text
+            or item_type_text in {"function_call", "function_call_output"}
+        ):
+            return "tool"
+
+        if kind == "item.completed" and item_type == "agent_message":
+            if item.get("text"):
+                return "content"
+            return None
+        if item_type == "agent_message" and (event.get("delta") or item.get("delta")):
+            return "content"
+
+        if kind in CODEX_STALL_BOUNDARY_EVENTS:
+            return "boundary"
+        if kind in CODEX_STALL_INITIAL_EVENTS:
+            return "initial"
+
+        if kind not in CODEX_STALL_KNOWN_NON_PROGRESS_EVENTS:
+            _LOG.debug("codex stdout event does not reset stall watchdog: %s", kind)
+        return None
+
     def _read_session_log_progress(
         self,
         *,
@@ -806,6 +867,7 @@ class CodexProvider:
         resume_session_id: str | None = None,
         session_log: SessionLog | None = None,
         attachments: tuple[Path, ...] = (),
+        strict_stall: bool = False,
     ) -> CallResponse:
         return self._run(
             task,
@@ -820,6 +882,7 @@ class CodexProvider:
             resume_session_id=resume_session_id,
             session_log=session_log,
             attachments=attachments,
+            strict_stall=strict_stall,
         )
 
     def _run(
@@ -837,6 +900,7 @@ class CodexProvider:
         resume_session_id: str | None = None,
         session_log: SessionLog | None = None,
         attachments: tuple[Path, ...] = (),
+        strict_stall: bool = False,
     ) -> CallResponse:
         # Cheap PATH check on the hot path; auth state surfaces as a CLI
         # exit failure below if needed. configured() (with auth probe) is
@@ -911,6 +975,7 @@ class CodexProvider:
                 liveness_interval_sec=liveness_interval_sec,
                 output_path=output_path,
                 session_log=session_log,
+                strict_stall=strict_stall,
             )
 
         start = time.monotonic()
@@ -992,6 +1057,7 @@ class CodexProvider:
         liveness_interval_sec: float,
         output_path: Path,
         session_log: SessionLog | None,
+        strict_stall: bool,
     ) -> CallResponse:
         start = time.monotonic()
         startup_lock_context = codex_startup_lock(
@@ -1084,6 +1150,7 @@ class CodexProvider:
         last_liveness = start
         heartbeat_log_offset = 0
         session_id_emitted = False
+        initial_stall_event_seen = False
         stdout_event_buffer = ""
         stderr_failure_tail = ""
         try:
@@ -1256,14 +1323,23 @@ class CodexProvider:
                     continue
 
                 stdout_parts.append(item)
-                last_output = time.monotonic()
-                last_liveness = last_output
                 stdout_event_buffer += item
                 while "\n" in stdout_event_buffer:
                     line, stdout_event_buffer = stdout_event_buffer.split("\n", 1)
                     line = f"{line}\n"
                     auth_tracker.observe_json_line(line, source="stdout")
                     self._emit_stream_event(line, session_log=session_log)
+                    progress_kind = self._codex_stall_progress_kind(line)
+                    if progress_kind == "initial":
+                        if not initial_stall_event_seen:
+                            last_output = time.monotonic()
+                            last_liveness = last_output
+                            initial_stall_event_seen = True
+                    elif progress_kind is not None and (
+                        not strict_stall or progress_kind == "tool"
+                    ):
+                        last_output = time.monotonic()
+                        last_liveness = last_output
                     signal = detect_retriable_provider_failure(
                         line,
                         source="stdout",

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -2062,6 +2062,76 @@ def test_codex_exec_streams_output_resets_stall_clock(mocker):
     assert fake.terminated is False
 
 
+def test_codex_exec_stall_watchdog_ignores_subagent_message_heartbeats(mocker):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    lines = [
+        '{"type":"session.created","session_id":"sess-subagent-heartbeats"}\n',
+        *[
+            '{"type":"subagent_message","message":"still waiting"}\n'
+            for _ in range(20)
+        ],
+    ]
+    fake = _FakePopen(
+        stdout_schedule=[(0.02, line) for line in lines],
+        hang_after_stdout=True,
+    )
+    _patch_codex_popen(mocker, fake)
+
+    started = time.monotonic()
+    with pytest.raises(ProviderStalledError) as exc:
+        CodexProvider().exec("hi", max_stall_sec=0.08, liveness_interval_sec=0)
+    elapsed = time.monotonic() - started
+
+    assert "codex CLI stalled" in str(exc.value)
+    assert fake.terminated is True
+    assert elapsed < 0.3
+
+
+def test_codex_exec_stall_watchdog_resets_on_tool_use_amid_heartbeats(mocker):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    lines = [
+        '{"type":"session.created","session_id":"sess-tool-progress"}\n',
+        '{"type":"subagent_message","message":"still waiting"}\n',
+        '{"type":"tool_use","name":"Read","arguments":{"path":"README.md"}}\n',
+        '{"type":"subagent_message","message":"still waiting"}\n',
+        '{"type":"item.completed","item":{"type":"agent_message","text":"done"}}\n',
+        '{"type":"turn.completed","usage":{"input_tokens":5,"output_tokens":2}}\n',
+    ]
+    fake = _FakePopen(stdout_schedule=[(0.04, line) for line in lines])
+    _patch_codex_popen(mocker, fake)
+
+    response = CodexProvider().exec("hi", max_stall_sec=0.11, liveness_interval_sec=0)
+
+    assert response.text == "done"
+    assert response.session_id == "sess-tool-progress"
+    assert fake.terminated is False
+
+
+def test_codex_exec_strict_stall_ignores_assistant_text_progress(mocker):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    lines = [
+        '{"type":"session.created","session_id":"sess-strict-stall"}\n',
+        '{"type":"item.completed","item":{"type":"agent_message","text":"working"}}\n',
+        '{"type":"turn.completed","usage":{"input_tokens":5,"output_tokens":2}}\n',
+    ]
+    fake = _FakePopen(
+        stdout_schedule=[(0.05, line) for line in lines],
+        hang_after_stdout=True,
+    )
+    _patch_codex_popen(mocker, fake)
+
+    with pytest.raises(ProviderStalledError) as exc:
+        CodexProvider().exec(
+            "hi",
+            max_stall_sec=0.08,
+            liveness_interval_sec=0,
+            strict_stall=True,
+        )
+
+    assert "codex CLI stalled" in str(exc.value)
+    assert fake.terminated is True
+
+
 def test_codex_exec_returns_after_process_exit_when_stdout_reader_lingers(
     mocker, capsys
 ):


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->


Closes #266.
