### PR TITLE
chore: refresh-consumers branch name uses chore/ type prefix

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -7018,7 +7018,7 @@ def refresh_consumers(
         click.echo("No consumer repos configured.")
         return
 
-    branch = branch_name or f"conductor-refresh-v{__version__.split('+', 1)[0]}"
+    branch = branch_name or f"chore/conductor-refresh-v{__version__.split('+', 1)[0]}"
     results = [_refresh_one_consumer_repo(path, branch=branch) for path in consumer_paths]
 
     failed = False

--- a/tests/test_cli_phase5.py
+++ b/tests/test_cli_phase5.py
@@ -984,6 +984,36 @@ def test_refresh_consumers_commits_updated_repo_integration(mocker, tmp_path):
     ).stdout
 
 
+def test_refresh_consumers_default_branch_uses_typed_prefix(mocker, tmp_path):
+    """Default branch name should have the `chore/` type prefix so that
+    consumer repos with the standard `<type>/<slug>` branch-naming pre-push
+    hook accept the push (closes conductor#273)."""
+    _stub_all_unconfigured(mocker)
+    version = cli_mod.__version__.split("+", 1)[0]
+
+    consumer = tmp_path / "consumer-default-branch"
+    consumer.mkdir()
+    _git(consumer, "init", "-q", "-b", "main")
+    _git(consumer, "config", "user.email", "conductor-test@example.com")
+    _git(consumer, "config", "user.name", "Conductor Test")
+
+    from conductor import agent_wiring
+
+    agent_wiring.wire_agents_md(cwd=consumer, version="0.8.0")
+    _git(consumer, "add", "AGENTS.md")
+    _git(consumer, "commit", "-m", "Initial conductor integration")
+
+    result = CliRunner().invoke(
+        main,
+        ["refresh-consumers", "--paths", str(consumer)],
+    )
+
+    assert result.exit_code == 0, result.output
+    expected_branch = f"chore/conductor-refresh-v{version}"
+    assert f"branch: {expected_branch}" in result.output, result.output
+    assert _git(consumer, "branch", "--show-current").stdout.strip() == expected_branch
+
+
 def test_refresh_consumers_reads_config_file(mocker, tmp_path):
     _stub_all_unconfigured(mocker)
     consumer = tmp_path / "consumer-from-config"


### PR DESCRIPTION
Closes #273.

`refresh-consumers` previously generated branch names of the form
`conductor-refresh-v0.10.X`, which fails the standard `<type>/<slug>`
branch-naming pre-push hook in most autumn-garage consumer repos
(sentinel, cortex, outrider, vesper, vanguard — all of them, except
touchstone itself which doesn't enforce its own convention on its own
pushes). The push gets blocked at the hook and the auto-PR flow
collapses.

Surfaced during the v0.10.2 install verification when 5 of 6 consumer
repos refused the default-named branch and the operator had to rename
each one before pushing.

Fix: change the default to `chore/conductor-refresh-v{version}`.
"chore" is the right type for a non-functional dependency / integration
refresh. The `--branch` operator override stays available.

Tested: new regression test asserts the default branch name has the
`chore/` prefix; the test fails on main (current default) and passes
on this branch.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
