### PR TITLE
fix: conductor exec --resume drops deprecated --sandbox flag

### DIFF
--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -89,10 +89,71 @@ _EFFORT_TO_CODEX_FLAG = {
     "max": "high",  # codex's ceiling
 }
 
+_CODEX_EXEC_RESUME_OPTION_ARITY = {
+    "-c": 1,
+    "--config": 1,
+    "--all": 0,
+    "--dangerously-bypass-approvals-and-sandbox": 0,
+    "--disable": 1,
+    "--enable": 1,
+    "--ephemeral": 0,
+    "--ignore-rules": 0,
+    "--ignore-user-config": 0,
+    "-i": 1,
+    "--image": 1,
+    "--json": 0,
+    "--last": 0,
+    "-m": 1,
+    "--model": 1,
+    "-o": 1,
+    "--output-last-message": 1,
+    "--skip-git-repo-check": 0,
+}
+_CODEX_EXEC_RESUME_DROPPED_OPTION_ARITY = {
+    "--sandbox": 1,
+}
+
 
 def _codex_output_path(resume_session_id: str | None) -> Path:
     sessionish = resume_session_id or uuid.uuid4().hex
     return _cache_dir() / f"codex-exec-{sessionish}.json"
+
+
+def _filter_codex_exec_resume_args(args: list[str]) -> list[str]:
+    """Return argv accepted by `codex exec resume`.
+
+    The resume subcommand has a narrower flag surface than `codex exec`.
+    Keep the known accepted flags explicit so compatibility-only parent flags
+    do not leak into resume and fail before the provider can do useful work.
+    """
+    filtered: list[str] = []
+    index = 0
+    while index < len(args):
+        item = args[index]
+        if item == "-" or not item.startswith("-"):
+            filtered.append(item)
+            index += 1
+            continue
+
+        if item in _CODEX_EXEC_RESUME_DROPPED_OPTION_ARITY:
+            value_count = _CODEX_EXEC_RESUME_DROPPED_OPTION_ARITY[item]
+            _LOG.debug("dropping unsupported codex exec resume option %s", item)
+            index += 1 + value_count
+            continue
+
+        accepted_value_count = _CODEX_EXEC_RESUME_OPTION_ARITY.get(item)
+        if accepted_value_count is None:
+            raise ProviderError(
+                f"internal error: codex exec resume option is not allowlisted: {item}"
+            )
+        if index + accepted_value_count >= len(args):
+            raise ProviderError(
+                f"internal error: codex exec resume option {item} is missing a value"
+            )
+        filtered.append(item)
+        filtered.extend(args[index + 1 : index + 1 + accepted_value_count])
+        index += 1 + accepted_value_count
+    return filtered
 
 
 def _format_compact_count(value: int) -> str:
@@ -891,6 +952,9 @@ class CodexProvider:
 
         for attachment in attachments:
             args.extend(["-i", str(attachment)])
+
+        if resume_session_id:
+            args = _filter_codex_exec_resume_args(args)
 
         if timeout_sec_override is _USE_DEFAULT:
             timeout = self._timeout_sec

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import io
 import json
+import logging
 import os
 import shutil
 import signal
@@ -1880,6 +1881,30 @@ def test_codex_exec_ignores_conductor_sandbox_modes(mocker, conductor_sandbox):
     assert fake.args is not None
     assert "--sandbox" in fake.args
     assert fake.args[fake.args.index("--sandbox") + 1] == "danger-full-access"
+
+
+def test_codex_exec_resume_drops_unsupported_sandbox_flag(mocker, caplog):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    fake = _FakePopen(
+        stdout_schedule=[(0, line) for line in CODEX_NDJSON.splitlines(keepends=True)]
+    )
+    _patch_codex_popen(mocker, fake)
+    caplog.set_level(logging.DEBUG, logger="conductor.providers.codex")
+
+    CodexProvider().exec(
+        "hi",
+        sandbox="workspace-write",
+        resume_session_id="sess-resume-1",
+    )
+
+    assert fake.args is not None
+    assert fake.args[:5] == ["codex", "exec", "resume", "sess-resume-1", "-"]
+    assert "--sandbox" not in fake.args
+    assert "--json" in fake.args
+    assert "-o" in fake.args
+    assert (
+        "dropping unsupported codex exec resume option --sandbox" in caplog.text
+    )
 
 
 def test_codex_exec_worktree_cwd_allows_git_add_and_commit(mocker, tmp_path: Path):


### PR DESCRIPTION
Closes #267.

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
