### PR TITLE
feat: auto-refresh user-scope files on first conductor invocation after upgrade

### DIFF
--- a/src/conductor/agent_wiring.py
+++ b/src/conductor/agent_wiring.py
@@ -29,6 +29,9 @@ import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from packaging.version import InvalidVersion
+from packaging.version import parse as parse_version
+
 # --------------------------------------------------------------------------- #
 # Marker formats — the two shapes of "conductor owns this".
 # --------------------------------------------------------------------------- #
@@ -66,6 +69,24 @@ _REPO_SCOPED_KINDS = frozenset(
         "cursor-rule",
     }
 )
+_USER_SCOPED_KINDS = frozenset(
+    {
+        "guidance",
+        "slash-command",
+        "subagent",
+        "claude-md-import",
+    }
+)
+_VERSION_SCAN_BYTES = 512
+
+
+@dataclass(frozen=True)
+class UserScopeVersionDecision:
+    path: Path
+    kind: str
+    version: str | None
+    stale: bool
+    reason: str
 
 
 def _managed_comment(version: str) -> str:
@@ -101,6 +122,17 @@ def _canonical_wiring_version(version: str) -> str:
 
 def _wiring_versions_match(left: str, right: str) -> bool:
     return _canonical_wiring_version(left) == _canonical_wiring_version(right)
+
+
+def _wiring_version_is_older(version: str | None, *, binary_version: str) -> bool:
+    if version is None:
+        return False
+    current = parse_version(_canonical_wiring_version(binary_version))
+    try:
+        artifact_version = parse_version(_canonical_wiring_version(version))
+    except InvalidVersion:
+        return True
+    return artifact_version < current
 
 
 # --------------------------------------------------------------------------- #
@@ -259,6 +291,23 @@ def _candidate_sentinel_paths(*, cwd: Path | None = None) -> dict[Path, str]:
     }
 
 
+def _user_scope_candidate_artifacts() -> dict[Path, str]:
+    """User-scope files conductor refreshes automatically after upgrades."""
+    return {
+        path: kind
+        for path, kind in _candidate_artifacts().items()
+        if kind in _USER_SCOPED_KINDS
+    }
+
+
+def _user_scope_candidate_sentinel_paths() -> dict[Path, str]:
+    return {
+        path: kind
+        for path, kind in _candidate_sentinel_paths().items()
+        if kind in _USER_SCOPED_KINDS
+    }
+
+
 # --------------------------------------------------------------------------- #
 # Managed-file helpers — write/read/detect ownership.
 # --------------------------------------------------------------------------- #
@@ -297,6 +346,102 @@ def read_managed_version(path: Path) -> str | None:
 
 def is_managed_file(path: Path) -> bool:
     return read_managed_version(path) is not None
+
+
+def user_scope_version_decisions(
+    *,
+    binary_version: str,
+) -> tuple[UserScopeVersionDecision, ...]:
+    """Scan user-scope managed files for stale conductor version stamps.
+
+    The startup auto-refresh path calls this before eligible CLI commands, so
+    it intentionally reads only a small prefix from each candidate file.
+    Missing or user-owned files are not stale; only conductor-managed stamps
+    older than the running binary trigger a refresh.
+    """
+    decisions: list[UserScopeVersionDecision] = []
+    for path, kind in _user_scope_candidate_artifacts().items():
+        version = _read_managed_version_prefix(path)
+        decisions.append(
+            _user_scope_decision(
+                path=path,
+                kind=kind,
+                version=version,
+                exists=path.is_file(),
+                binary_version=binary_version,
+            )
+        )
+    for path, kind in _user_scope_candidate_sentinel_paths().items():
+        version = _read_sentinel_version_prefix(path)
+        decisions.append(
+            _user_scope_decision(
+                path=path,
+                kind=kind,
+                version=version,
+                exists=path.is_file(),
+                binary_version=binary_version,
+            )
+        )
+    return tuple(decisions)
+
+
+def is_user_scope_stale(*, binary_version: str) -> bool:
+    """Return True when any user-scope conductor-managed file is stale."""
+    return any(
+        decision.stale
+        for decision in user_scope_version_decisions(binary_version=binary_version)
+    )
+
+
+def _user_scope_decision(
+    *,
+    path: Path,
+    kind: str,
+    version: str | None,
+    exists: bool,
+    binary_version: str,
+) -> UserScopeVersionDecision:
+    if version is None:
+        reason = "missing" if not exists else "not conductor-managed"
+        return UserScopeVersionDecision(path, kind, None, False, reason)
+    stale = _wiring_version_is_older(version, binary_version=binary_version)
+    reason = "stale" if stale else "current"
+    return UserScopeVersionDecision(path, kind, version, stale, reason)
+
+
+def _read_prefix(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    with path.open("r", encoding="utf-8") as fh:
+        return fh.read(_VERSION_SCAN_BYTES)
+
+
+def _read_managed_version_prefix(path: Path) -> str | None:
+    text = _read_prefix(path)
+    if not text:
+        return None
+    first_line = text.splitlines()[0] if text.splitlines() else ""
+    if first_line.startswith(MANAGED_COMMENT_PREFIX):
+        return _extract_version(first_line, MANAGED_COMMENT_PREFIX)
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(MANAGED_FRONTMATTER_KEY):
+            return _extract_version(stripped, MANAGED_FRONTMATTER_KEY)
+    return None
+
+
+def _read_sentinel_version_prefix(path: Path) -> str | None:
+    text = _read_prefix(path)
+    if not text:
+        return None
+    idx = text.find(SENTINEL_BEGIN_PREFIX)
+    if idx == -1:
+        return None
+    rest = text[idx + len(SENTINEL_BEGIN_PREFIX) :]
+    end = rest.find(" -->")
+    if end == -1:
+        return None
+    return rest[:end].strip()
 
 
 def project_root_for_wiring_notice(cwd: Path | None = None) -> Path | None:

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -3316,11 +3316,69 @@ def _maybe_emit_agent_wiring_notice(ctx: click.Context) -> None:
         return
 
 
+AUTO_REFRESH_COMMANDS = frozenset(
+    {
+        "ask",
+        "call",
+        "doctor",
+        "exec",
+        "init",
+        "refresh-consumers",
+        "route",
+    }
+)
+
+
+def _env_flag_enabled(name: str) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return False
+    return value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def _maybe_auto_refresh_user_scope(ctx: click.Context) -> None:
+    command = ctx.invoked_subcommand
+    if command not in AUTO_REFRESH_COMMANDS:
+        return
+    if _env_flag_enabled("CONDUCTOR_NO_AUTO_REFRESH"):
+        return
+
+    debug = _env_flag_enabled("CONDUCTOR_DEBUG_AUTO_REFRESH")
+    try:
+        from conductor import agent_wiring
+
+        decisions = agent_wiring.user_scope_version_decisions(binary_version=__version__)
+        if debug:
+            for decision in decisions:
+                version = decision.version or "-"
+                click.echo(
+                    "[conductor] auto-refresh scan: "
+                    f"{decision.kind} {decision.path} version={version} "
+                    f"stale={decision.stale} reason={decision.reason}",
+                    err=True,
+                )
+        if not any(decision.stale for decision in decisions):
+            return
+        agent_wiring.wire_claude_code(__version__, patch_claude_md=True)
+        click.echo(
+            "[conductor] refreshed user-scope integration files "
+            f"to v{__version__.split('+', 1)[0]}",
+            err=True,
+        )
+    except Exception as e:
+        click.echo(
+            f"[conductor] auto-refresh warning: failed to refresh "
+            f"user-scope integration files: {e}",
+            err=True,
+        )
+
+
 @click.group()
 @click.version_option(__version__, prog_name="conductor")
 @click.pass_context
 def main(ctx: click.Context) -> None:
     """Pick an LLM, give it a job."""
+    _maybe_auto_refresh_user_scope(ctx)
     _maybe_emit_agent_wiring_notice(ctx)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,8 @@ def _fast_cli_network_profile(monkeypatch):
     from conductor import cli
     from conductor.network_profile import NETWORK_PROFILE_FALLBACK_TARGET, NetworkProfile
 
+    monkeypatch.setenv("CONDUCTOR_NO_AUTO_REFRESH", "1")
+
     def _profile(target: str | None, *, warn=None):
         return NetworkProfile(
             rtt_ms=50,

--- a/tests/test_cli_auto_refresh.py
+++ b/tests/test_cli_auto_refresh.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from conductor import agent_wiring as aw
+from conductor import cli as cli_mod
+from conductor.cli import main
+
+
+def _isolate_user_scope(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("CONDUCTOR_HOME", str(tmp_path / ".conductor"))
+    monkeypatch.setenv("CLAUDE_HOME", str(tmp_path / ".claude"))
+    monkeypatch.delenv("CONDUCTOR_NO_AUTO_REFRESH", raising=False)
+
+
+def test_auto_refresh_current_user_scope_is_silent(tmp_path, monkeypatch):
+    _isolate_user_scope(tmp_path, monkeypatch)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+    aw.wire_claude_code("0.9.0", patch_claude_md=True)
+
+    result = CliRunner().invoke(main, ["doctor", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert "refreshed user-scope" not in result.stderr
+
+
+def test_auto_refresh_stale_user_scope_updates_files(tmp_path, monkeypatch):
+    _isolate_user_scope(tmp_path, monkeypatch)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+    aw.wire_claude_code("0.8.0", patch_claude_md=True)
+
+    result = CliRunner().invoke(main, ["doctor", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert "[conductor] refreshed user-scope integration files to v0.9.0" in result.stderr
+    assert aw.is_user_scope_stale(binary_version="0.9.0") is False
+    versions = {
+        artifact.kind: artifact.version
+        for artifact in aw.detect().managed
+        if artifact.kind in {"guidance", "slash-command", "claude-md-import"}
+    }
+    assert versions == {
+        "guidance": "0.9.0",
+        "slash-command": "0.9.0",
+        "claude-md-import": "0.9.0",
+    }
+
+
+def test_auto_refresh_env_opt_out_leaves_stale_files(tmp_path, monkeypatch):
+    _isolate_user_scope(tmp_path, monkeypatch)
+    monkeypatch.setenv("CONDUCTOR_NO_AUTO_REFRESH", "1")
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+    aw.wire_claude_code("0.8.0", patch_claude_md=True)
+
+    result = CliRunner().invoke(main, ["doctor", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert "refreshed user-scope" not in result.stderr
+    assert aw.is_user_scope_stale(binary_version="0.9.0") is True
+
+
+def test_auto_refresh_skips_read_only_commands(monkeypatch):
+    monkeypatch.delenv("CONDUCTOR_NO_AUTO_REFRESH", raising=False)
+
+    def fail_scan(*, binary_version: str):
+        raise AssertionError(f"unexpected auto-refresh scan for {binary_version}")
+
+    monkeypatch.setattr(aw, "user_scope_version_decisions", fail_scan)
+
+    for args in (["list"], ["--help"], ["--version"]):
+        result = CliRunner().invoke(main, args)
+        assert result.exit_code == 0, result.output
+
+
+def test_auto_refresh_failure_logs_and_continues(tmp_path, monkeypatch):
+    _isolate_user_scope(tmp_path, monkeypatch)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+    aw.wire_claude_code("0.8.0", patch_claude_md=True)
+
+    def fail_wire(version: str, *, patch_claude_md: bool):
+        raise PermissionError("permission denied")
+
+    monkeypatch.setattr(aw, "wire_claude_code", fail_wire)
+
+    result = CliRunner().invoke(main, ["doctor", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert "auto-refresh warning: failed to refresh user-scope integration files" in result.stderr
+    assert "permission denied" in result.stderr


### PR DESCRIPTION
Closes #271.

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
