### PR TITLE
chore: harness branch-naming guidance + stall-counter audit findings

### DIFF
--- a/src/conductor/_agent_templates.py
+++ b/src/conductor/_agent_templates.py
@@ -400,6 +400,15 @@ When briefing codex on a task that ships a PR via `scripts/open-pr.sh
 --auto-merge`, include this guidance in the brief so codex doesn't
 need to discover it empirically:
 
+- **Branch must be `<type>/<slug>` shape.** Most autumn-garage repos
+  enforce a pre-push hook that requires the branch to start with
+  `feat/`, `fix/`, `chore/`, `refactor/`, or `docs/`. Agent worktrees
+  are created on a default branch like `worktree-agent-<id>` which
+  fails this hook. Tell codex to check `git branch --show-current` as
+  its first action, and if the result doesn't match the convention
+  (or is `main` / `master`), immediately `git checkout -b <type>/<slug>`.
+  Skipping this step means every push fails the hook and codex has
+  to recover with a rename + re-push.
 - **PR title equals commit subject.** `open-pr.sh` derives the PR title
   from `git log -1 --format=%s`. If the brief specifies a PR title,
   codex must use THAT EXACT STRING as the commit subject; otherwise

--- a/tests/test_agent_template_drift.py
+++ b/tests/test_agent_template_drift.py
@@ -44,6 +44,8 @@ EXPECTED_TEMPLATE_COVERAGE = {
         "PR title equals commit subject",
         # #268: one closing keyword per issue (don't comma-chain).
         "One closing keyword per issue",
+        # #278: harness-default branch names fail the pre-push naming hook.
+        "Branch must be `<type>/<slug>` shape",
     },
     "ollama-offline": {
         "--offline",


### PR DESCRIPTION
Closes #278.
Closes #279.

#278: agent worktrees are created on `worktree-agent-<id>` branches
that fail the standard `<type>/<slug>` pre-push hook. Codex has been
recovering with a rename + re-push on every dispatch (~10–30s and
2–3 tool calls of overhead per dispatch). Adds explicit guidance to
the codex-coding-agent template so the brief tells codex to check
the current branch and switch to a typed name as its first action,
catching the harness-default name in addition to main/master.

#279: audited claude/gemini/ollama for the same coarse "any output
resets stall counter" anti-pattern that #266 fixed for codex. Findings:

- claude (`src/conductor/providers/claude.py`): passes max_stall_sec
  through to the shared subprocess helper; reset on any byte. No
  structured event stream available — the claude CLI emits
  unstructured "thinking..." text mixed with content. Event
  classification not feasible without restructuring the upstream
  CLI's output. Coarse logic is correct given the shape of the
  available data.
- gemini (`src/conductor/providers/gemini.py`): same pattern as
  claude. Same conclusion.
- ollama (`src/conductor/providers/ollama.py`): explicitly discards
  max_stall_sec (`_ = max_stall_sec`). Ollama uses the HTTP
  transport, not subprocess; stall is governed by HTTP read timeout
  on the streaming response. The coarse-logic anti-pattern doesn't
  apply.

Conclusion: the codex fix in #266/#275 was a special case enabled by
codex's structured JSONL event stream. The other providers' adapters
are doing the right thing for the data they have. No follow-up code
changes; the audit class is closed.

Drift test gains the `Branch must be <type>/<slug> shape` token so
a future template edit that drops the new guidance fails in CI.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
