### PR TITLE
feat: --auto-phase chunks single brief on header anchors

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 import math
 import os
+import re
 import subprocess
 import sys
 import time
@@ -233,6 +234,12 @@ class BriefInput:
     body: str
     source: str
     attachments: tuple[Path, ...] = ()
+
+
+@dataclass(frozen=True)
+class BriefPhase:
+    title: str
+    body: str
 
 
 @dataclass(frozen=True)
@@ -4784,6 +4791,60 @@ def _append_previous_phase_results(body: str, summaries: list[str]) -> str:
     return f"{body}\n\n" + "\n\n".join(summaries)
 
 
+DEFAULT_AUTO_PHASE_ANCHORS: tuple[str, ...] = (
+    "## Tests",
+    "## Validation",
+)
+DEFAULT_AUTO_PHASE_REGEX_ANCHORS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^## Phase \d+\s*$"),
+)
+
+
+def _phase_heading_title(line: str) -> str:
+    return line.lstrip("#").strip()
+
+
+def _auto_phase_anchor_matcher(extra_anchors: tuple[str, ...]) -> re.Pattern[str]:
+    literal_anchors = [
+        anchor.strip() for anchor in (*DEFAULT_AUTO_PHASE_ANCHORS, *extra_anchors) if anchor.strip()
+    ]
+    exact_patterns = [rf"^{re.escape(anchor)}\s*$" for anchor in literal_anchors]
+    regex_patterns = [pattern.pattern for pattern in DEFAULT_AUTO_PHASE_REGEX_ANCHORS]
+    return re.compile("|".join([*exact_patterns, *regex_patterns]))
+
+
+def _split_brief_into_auto_phases(
+    body: str,
+    *,
+    extra_anchors: tuple[str, ...] = (),
+) -> list[BriefPhase]:
+    anchor_pattern = _auto_phase_anchor_matcher(extra_anchors)
+    lines = body.splitlines(keepends=True)
+    anchor_indexes = [
+        idx for idx, line in enumerate(lines) if anchor_pattern.match(line.rstrip("\r\n"))
+    ]
+    if not anchor_indexes:
+        return [BriefPhase(title="Brief", body=body)]
+
+    phases: list[BriefPhase] = []
+    first_anchor = anchor_indexes[0]
+    intro = "".join(lines[:first_anchor]).strip()
+    if intro:
+        phases.append(BriefPhase(title="Intro", body=intro))
+
+    for anchor_position, start in enumerate(anchor_indexes):
+        end = (
+            anchor_indexes[anchor_position + 1]
+            if anchor_position + 1 < len(anchor_indexes)
+            else len(lines)
+        )
+        chunk = "".join(lines[start:end]).strip()
+        if chunk:
+            phases.append(BriefPhase(title=_phase_heading_title(lines[start]), body=chunk))
+
+    return phases
+
+
 def _run_exec_phase_dispatch(
     *,
     provider_id: str | None,
@@ -5396,6 +5457,23 @@ def _run_exec_phase_dispatch(
     ),
 )
 @click.option(
+    "--auto-phase",
+    is_flag=True,
+    default=False,
+    help=(
+        "Split one brief into sequential phases on documented anchors "
+        "(e.g. ## Tests, ## Validation, ## Phase 2)."
+    ),
+)
+@click.option(
+    "--phase-anchor",
+    multiple=True,
+    help=(
+        "Additional exact heading anchor for --auto-phase, e.g. "
+        "--phase-anchor '## Custom'. Repeat to add more."
+    ),
+)
+@click.option(
     "--issue",
     default=None,
     help=("Use a GitHub issue as the seed brief. Accepts N for the current repo or owner/repo#N."),
@@ -5500,6 +5578,8 @@ def exec_cmd(
     task_file: str | None,
     brief: str | None,
     brief_file: tuple[str, ...],
+    auto_phase: bool,
+    phase_anchor: tuple[str, ...],
     issue: str | None,
     issue_comment_limit: int,
     attach: tuple[str, ...],
@@ -5558,6 +5638,10 @@ def exec_cmd(
         )
 
     brief_files = tuple(brief_file)
+    if auto_phase and len(brief_files) > 1:
+        raise click.UsageError(
+            "use `--brief-file` repeated OR `--auto-phase` on a single brief, not both."
+        )
     if len(brief_files) > 1 and any(path == "-" for path in brief_files):
         raise click.UsageError("multiple --brief-file phases cannot read from stdin ('-').")
     if len(brief_files) > 1 and any(value is not None for value in (task, task_file, brief)):
@@ -5580,7 +5664,32 @@ def exec_cmd(
             cwd=cwd,
             attach=attach,
         )
-        phase_inputs.append((brief_files[0] if brief_files else brief_input.source, brief_input))
+        if auto_phase:
+            auto_phases = _split_brief_into_auto_phases(
+                brief_input.body,
+                extra_anchors=phase_anchor,
+            )
+            if len(auto_phases) == 1 and auto_phases[0].title == "Brief":
+                click.echo(
+                    "[conductor] --auto-phase: no anchor headers found in brief; "
+                    "running as single phase.",
+                    err=True,
+                )
+                phase_inputs.append(
+                    (brief_files[0] if brief_files else brief_input.source, brief_input)
+                )
+            else:
+                phase_inputs.extend(
+                    (
+                        phase.title,
+                        replace(brief_input, body=phase.body, source=phase.title),
+                    )
+                    for phase in auto_phases
+                )
+        else:
+            phase_inputs.append(
+                (brief_files[0] if brief_files else brief_input.source, brief_input)
+            )
     else:
         for path in brief_files:
             phase_inputs.append(

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -64,6 +64,8 @@ DOCUMENTED_EXEC_FLAGS: frozenset[str] = frozenset(
         "--exclude",
         "--brief",
         "--brief-file",
+        "--auto-phase",
+        "--phase-anchor",
         "--issue",
         "--issue-comment-limit",
         "--task",

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -2550,6 +2550,234 @@ def test_exec_multiple_brief_files_run_sequential_phases_json(mocker, tmp_path):
     assert [phase["brief"] for phase in payload["phases"]] == [str(phase1), str(phase2)]
 
 
+def test_exec_auto_phase_splits_tests_and_validation_anchors(mocker, tmp_path):
+    repo = _make_diff_repo(tmp_path)
+    brief = tmp_path / "combined.md"
+    brief.write_text(
+        "# Brief: implement X\n\n"
+        "Build the production path.\n\n"
+        "## Tests\n\n"
+        "Add regression tests.\n\n"
+        "## Validation\n\n"
+        "Run pytest.\n",
+        encoding="utf-8",
+    )
+    seen_prompts: list[str] = []
+
+    def fake_exec(self, prompt, **kwargs):
+        seen_prompts.append(prompt)
+        return _fake_response("codex", text=f"phase {len(seen_prompts)} done")
+
+    _stub_all_configured(mocker, {"codex"})
+    exec_mock = mocker.patch.object(CodexProvider, "exec", autospec=True, side_effect=fake_exec)
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--with",
+            "codex",
+            "--no-preflight",
+            "--cwd",
+            str(repo),
+            "--brief-file",
+            str(brief),
+            "--auto-phase",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert exec_mock.call_count == 3
+    assert seen_prompts[0] == "# Brief: implement X\n\nBuild the production path."
+    assert seen_prompts[1].startswith("## Tests\n\nAdd regression tests.")
+    assert seen_prompts[2].startswith("## Validation\n\nRun pytest.")
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert [phase["brief"] for phase in payload["phases"]] == [
+        "Intro",
+        "Tests",
+        "Validation",
+    ]
+
+
+def test_exec_auto_phase_no_anchors_falls_back_to_single_phase(mocker, tmp_path):
+    brief = tmp_path / "combined.md"
+    single_phase_body = "# Brief\n\nDo one thing.\n\n## Notes\n\nDo not split here."
+    brief.write_text(f"{single_phase_body}\n", encoding="utf-8")
+    _stub_all_configured(mocker, {"codex"})
+    exec_mock = mocker.patch.object(
+        CodexProvider,
+        "exec",
+        return_value=_fake_response("codex", text="done"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--with",
+            "codex",
+            "--no-preflight",
+            "--brief-file",
+            str(brief),
+            "--auto-phase",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert exec_mock.call_count == 1
+    assert exec_mock.call_args.args[0] == single_phase_body
+    assert "--auto-phase: no anchor headers found" in result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["text"] == "done"
+    assert "phases" not in payload
+
+
+def test_exec_auto_phase_splits_phase_number_anchors(mocker, tmp_path):
+    repo = _make_diff_repo(tmp_path)
+    brief = tmp_path / "combined.md"
+    brief.write_text(
+        "## Phase 1\n\nImplement it.\n\n## Phase 2\n\nTest it.\n",
+        encoding="utf-8",
+    )
+    seen_prompts: list[str] = []
+
+    def fake_exec(self, prompt, **kwargs):
+        seen_prompts.append(prompt)
+        return _fake_response("codex", text=f"phase {len(seen_prompts)} done")
+
+    _stub_all_configured(mocker, {"codex"})
+    mocker.patch.object(CodexProvider, "exec", autospec=True, side_effect=fake_exec)
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--with",
+            "codex",
+            "--no-preflight",
+            "--cwd",
+            str(repo),
+            "--brief-file",
+            str(brief),
+            "--auto-phase",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert seen_prompts[0] == "## Phase 1\n\nImplement it."
+    assert seen_prompts[1].startswith("## Phase 2\n\nTest it.")
+    payload = json.loads(result.stdout)
+    assert [phase["brief"] for phase in payload["phases"]] == ["Phase 1", "Phase 2"]
+
+
+def test_exec_auto_phase_custom_anchor_extends_default_list(mocker, tmp_path):
+    repo = _make_diff_repo(tmp_path)
+    brief = tmp_path / "combined.md"
+    brief.write_text(
+        "# Brief\n\nImplement it.\n\n## Custom\n\nCustom validation.\n",
+        encoding="utf-8",
+    )
+    seen_prompts: list[str] = []
+
+    def fake_exec(self, prompt, **kwargs):
+        seen_prompts.append(prompt)
+        return _fake_response("codex", text=f"phase {len(seen_prompts)} done")
+
+    _stub_all_configured(mocker, {"codex"})
+    mocker.patch.object(CodexProvider, "exec", autospec=True, side_effect=fake_exec)
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--with",
+            "codex",
+            "--no-preflight",
+            "--cwd",
+            str(repo),
+            "--brief-file",
+            str(brief),
+            "--auto-phase",
+            "--phase-anchor",
+            "## Custom",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert seen_prompts[0] == "# Brief\n\nImplement it."
+    assert seen_prompts[1].startswith("## Custom\n\nCustom validation.")
+    payload = json.loads(result.stdout)
+    assert [phase["brief"] for phase in payload["phases"]] == ["Intro", "Custom"]
+
+
+def test_exec_auto_phase_rejects_repeated_brief_files(mocker, tmp_path):
+    phase1 = tmp_path / "phase1.md"
+    phase2 = tmp_path / "phase2.md"
+    phase1.write_text("implement it\n", encoding="utf-8")
+    phase2.write_text("test it\n", encoding="utf-8")
+    _stub_all_configured(mocker, {"codex"})
+    exec_mock = mocker.patch.object(CodexProvider, "exec")
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--with",
+            "codex",
+            "--brief-file",
+            str(phase1),
+            "--brief-file",
+            str(phase2),
+            "--auto-phase",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert not exec_mock.called
+    assert "use `--brief-file` repeated OR `--auto-phase` on a single brief, not both" in (
+        result.output
+    )
+
+
+def test_exec_auto_phase_default_off_preserves_single_phase_behavior(mocker, tmp_path):
+    brief = tmp_path / "combined.md"
+    brief.write_text(
+        "# Brief\n\nImplement it.\n\n## Tests\n\nThese stay in the same phase.\n",
+        encoding="utf-8",
+    )
+    _stub_all_configured(mocker, {"codex"})
+    exec_mock = mocker.patch.object(
+        CodexProvider,
+        "exec",
+        return_value=_fake_response("codex", text="done"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--with",
+            "codex",
+            "--no-preflight",
+            "--brief-file",
+            str(brief),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert exec_mock.call_count == 1
+    assert "## Tests" in exec_mock.call_args.args[0]
+    payload = json.loads(result.stdout)
+    assert payload["text"] == "done"
+    assert "phases" not in payload
+
+
 def test_exec_multiple_brief_files_first_cap_exit_aborts_json(mocker, tmp_path):
     repo = _make_diff_repo(tmp_path)
     phase1 = tmp_path / "phase1.md"


### PR DESCRIPTION
Closes #285.

## Summary

Adds opt-in exec auto-phasing for a single brief by splitting on documented header anchors and feeding the resulting chunks through the existing multi-phase executor.

## Changes

- Added --auto-phase and repeatable --phase-anchor flags to conductor exec.
- Added conservative anchor matching for ## Tests, ## Validation, and ## Phase N, with operator-supplied exact heading extensions.
- Preserved the default single-phase path when --auto-phase is off or no anchors are found.

## Testing

- uv run pytest
- uv run ruff check src/ tests/
- uv run conductor exec --help
- Manual smoke described by tests: a single brief with ## Tests plus --auto-phase is split into sequential phases using the multi-phase orchestration path.

- [x] Tests pass locally
- [x] No new silent failures (no except: pass, no swallowed errors)
- [x] No new code paths that diverge between environments

## Risk

- [x] Low risk — isolated opt-in CLI behavior; existing --brief-file behavior remains default.
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

Clean revert of this commit restores the previous exec CLI behavior.

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
