### PR TITLE
chore: clarify "actively poll, don't wait passively" in agent template

### DIFF
--- a/src/conductor/_agent_templates.py
+++ b/src/conductor/_agent_templates.py
@@ -383,11 +383,20 @@ When invoked:
    IF THE HARNESS AUTO-BACKGROUNDS YOUR FOREGROUND CALL: some agent
    harnesses silently background long-running Bash calls past an
    internal threshold. Watch for a notification telling you the call
-   was backgrounded. If it happens, do NOT exit. Use the harness's
-   monitor primitive (e.g. `BashOutput` in Claude Code) to poll the
-   background task ID until it reports completion, then read the JSON
-   output. Stay alive for the duration; otherwise your stream
+   was backgrounded. If it happens, do NOT exit and do NOT wait
+   passively for a notification — the harness will not push one when
+   the task finishes. Instead, ACTIVELY POLL: call the harness's
+   read primitive (e.g. `BashOutput` in Claude Code) in a loop,
+   waiting briefly between calls, until the call reports the
+   background task has exited. Then read the JSON output from its
+   final stdout. Stay alive for the duration; otherwise your stream
    watchdog will fire while codex is still producing useful work.
+
+   Concretely in Claude Code: after auto-background, repeatedly call
+   `BashOutput(bash_id=<id>)` (waiting ~30s between calls) until the
+   tool result indicates the task has completed. Reading does not
+   advance the task; it just snapshots current stdout. Polling is the
+   only way to discover completion.
 
 3. Parse the JSON, extract `text`, and return it verbatim prefixed with
    "From Codex:". Note `session_id` in the JSON if present — callers can

--- a/tests/test_agent_template_drift.py
+++ b/tests/test_agent_template_drift.py
@@ -40,6 +40,8 @@ EXPECTED_TEMPLATE_COVERAGE = {
         # #250: handle the case where the harness auto-backgrounds.
         "AUTO-BACKGROUNDS",
         "BashOutput",
+        # #250 follow-up: actively poll, don't wait passively.
+        "ACTIVELY POLL",
         # #270: tie PR title to commit subject under open-pr.sh.
         "PR title equals commit subject",
         # #268: one closing keyword per issue (don't comma-chain).


### PR DESCRIPTION
Closes part of the #250 follow-up gap surfaced during the #287
dispatch on 2026-05-08.

The codex-coding-agent template's harness-auto-background recovery
guidance (added in #258) said "use the harness's monitor primitive
(e.g. `BashOutput`) to poll the background task ID until it reports
completion." Apparently "poll" wasn't unambiguous — the agent that
shipped #287 interpreted "monitor" as "wait passively for a
notification" and stalled with the message "The background bash is
still running. Let me wait for the BashOutput notification."
Codex finished the work and the PR shipped, but the supervising
agent never returned the result; PR was discovered open and merged
manually.

The fix tightens the wording: "ACTIVELY POLL" in caps, an explicit
"do NOT wait passively for a notification — the harness will not
push one when the task finishes," and a concrete how-to ("call
`BashOutput(bash_id=<id>)` repeatedly, ~30s between calls, until
the tool result indicates the task has completed").

Drift test gains the `ACTIVELY POLL` token so a future template
edit that drops this guardrail fails in CI.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
