### PR TITLE
feat: refresh-consumers auto-stashes uncommitted changes

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -7456,6 +7456,10 @@ class _ConsumerRefreshResult:
     detail: str
     branch: str | None = None
     commit: str | None = None
+    # "none" — repo was clean, no stash involved.
+    # "popped" — repo was dirty; auto-stashed; pop succeeded (operator's changes restored).
+    # "preserved" — repo was dirty; auto-stashed; pop conflicted; stash@{0} kept for operator.
+    stash_status: str = "none"
 
 
 @main.command("refresh-consumers")
@@ -7478,10 +7482,21 @@ class _ConsumerRefreshResult:
     default=None,
     help="Branch name to create or reuse in each repo.",
 )
+@click.option(
+    "--no-auto-stash",
+    "no_auto_stash",
+    is_flag=True,
+    default=False,
+    help=(
+        "Skip repos with uncommitted changes instead of auto-stashing them. "
+        "Default: auto-stash uncommitted changes, refresh, then pop the stash back."
+    ),
+)
 def refresh_consumers(
     paths: str | None,
     config_file: Path | None,
     branch_name: str | None,
+    no_auto_stash: bool,
 ) -> None:
     """Refresh Conductor integration blocks in explicitly configured repos.
 
@@ -7492,6 +7507,12 @@ def refresh_consumers(
 
     Use `refresh-consumers` only when you need an immediate cross-repo refresh
     without waiting for the next commit in each repo.
+
+    Repos with uncommitted changes are auto-stashed by default: stash → refresh
+    → pop. If the pop conflicts (rare; happens when operator changes overlap
+    conductor-managed sentinel blocks), the stash entry is preserved at
+    `stash@{0}` for manual resolution. Pass `--no-auto-stash` to revert to the
+    older skip-on-dirty behavior.
     """
     try:
         consumer_paths = _resolve_consumer_repo_paths(paths, config_file)
@@ -7503,7 +7524,11 @@ def refresh_consumers(
         return
 
     branch = branch_name or f"chore/conductor-refresh-v{__version__.split('+', 1)[0]}"
-    results = [_refresh_one_consumer_repo(path, branch=branch) for path in consumer_paths]
+    auto_stash = not no_auto_stash
+    results = [
+        _refresh_one_consumer_repo(path, branch=branch, auto_stash=auto_stash)
+        for path in consumer_paths
+    ]
 
     failed = False
     for result in results:
@@ -7512,7 +7537,9 @@ def refresh_consumers(
             click.echo(f"  branch: {result.branch}")
         if result.commit:
             click.echo(f"  commit: {result.commit}")
-        if result.status in {"failed", "skipped"}:
+        if result.stash_status == "preserved":
+            click.echo("  stash: stash@{0} preserved — resolve manually with `git stash pop`")
+        if result.status in {"failed", "skipped", "needs-attention"}:
             failed = True
 
     if failed:
@@ -7572,7 +7599,9 @@ def _consumer_paths_from_config(config_file: Path) -> tuple[str, ...]:
     return tuple(paths)
 
 
-def _refresh_one_consumer_repo(path: Path, *, branch: str) -> _ConsumerRefreshResult:
+def _refresh_one_consumer_repo(
+    path: Path, *, branch: str, auto_stash: bool = True
+) -> _ConsumerRefreshResult:
     if not path.is_dir():
         return _ConsumerRefreshResult(path, "failed", "path is not a directory")
     if _run_repo_command(path, ["git", "rev-parse", "--is-inside-work-tree"]).returncode != 0:
@@ -7580,12 +7609,71 @@ def _refresh_one_consumer_repo(path: Path, *, branch: str) -> _ConsumerRefreshRe
     before = _git_status_porcelain(path)
     if before is None:
         return _ConsumerRefreshResult(path, "failed", "could not read git status")
+
+    # Capture the operator's current branch before we switch to the refresh
+    # branch — we'll return to it before popping the stash so the operator's
+    # in-flight work lands back where they made it.
+    orig_branch_proc = _run_repo_command(path, ["git", "rev-parse", "--abbrev-ref", "HEAD"])
+    orig_branch = orig_branch_proc.stdout.strip() if orig_branch_proc.returncode == 0 else None
+    if not orig_branch:
+        return _ConsumerRefreshResult(path, "failed", "could not read current branch")
+
+    stashed = False
     if before:
-        return _ConsumerRefreshResult(path, "skipped", "repo has pre-existing changes")
+        if not auto_stash:
+            return _ConsumerRefreshResult(path, "skipped", "repo has pre-existing changes")
+        stash_msg = f"conductor-refresh-v{__version__.split('+', 1)[0]} auto-stash"
+        stash = _run_repo_command(path, ["git", "stash", "push", "-u", "-m", stash_msg])
+        if stash.returncode != 0:
+            return _ConsumerRefreshResult(
+                path, "failed", _command_failure_detail(stash, "git stash push")
+            )
+        stashed = True
+
+    def _pop_or_preserve(result: _ConsumerRefreshResult) -> _ConsumerRefreshResult:
+        """If we stashed, return to orig_branch and pop. Augment result with
+        stash_status; on pop conflict, preserve the stash and downgrade
+        status to "needs-attention"."""
+        if not stashed:
+            return result
+        # Best-effort return to the operator's original branch before popping.
+        back = _run_repo_command(path, ["git", "checkout", orig_branch])
+        if back.returncode != 0:
+            return _ConsumerRefreshResult(
+                result.path,
+                "needs-attention",
+                f"refresh ran but could not return to {orig_branch}; "
+                "stash@{0} preserved for manual resolution",
+                branch=result.branch,
+                commit=result.commit,
+                stash_status="preserved",
+            )
+        pop = _run_repo_command(path, ["git", "stash", "pop"])
+        if pop.returncode != 0:
+            return _ConsumerRefreshResult(
+                result.path,
+                "needs-attention",
+                f"refresh committed on {result.branch}; auto-stash pop "
+                f"conflicted on {orig_branch}; stash@{{0}} preserved for "
+                "manual resolution",
+                branch=result.branch,
+                commit=result.commit,
+                stash_status="preserved",
+            )
+        # Pop succeeded — augment detail to record the auto-stash.
+        augmented_detail = f"{result.detail} (auto-stashed and restored)"
+        return _ConsumerRefreshResult(
+            result.path,
+            result.status,
+            augmented_detail,
+            branch=result.branch,
+            commit=result.commit,
+            stash_status="popped",
+        )
 
     checkout = _checkout_refresh_branch(path, branch)
     if checkout is not None:
-        return _ConsumerRefreshResult(path, "failed", checkout)
+        return _pop_or_preserve(_ConsumerRefreshResult(path, "failed", checkout))
 
     init_result = _run_repo_command(
         path,
@@ -7594,44 +7682,56 @@ def _refresh_one_consumer_repo(path: Path, *, branch: str) -> _ConsumerRefreshRe
     )
     if init_result.returncode != 0:
         detail = _command_failure_detail(init_result, "conductor init -y --remaining")
-        return _ConsumerRefreshResult(path, "failed", detail, branch=branch)
+        return _pop_or_preserve(
+            _ConsumerRefreshResult(path, "failed", detail, branch=branch)
+        )
 
     after = _git_status_porcelain(path)
     if after is None:
-        return _ConsumerRefreshResult(path, "failed", "could not read git status", branch=branch)
+        return _pop_or_preserve(
+            _ConsumerRefreshResult(path, "failed", "could not read git status", branch=branch)
+        )
     if not after:
-        return _ConsumerRefreshResult(
-            path,
-            "unchanged",
-            "integration files already current",
-            branch=branch,
+        return _pop_or_preserve(
+            _ConsumerRefreshResult(
+                path,
+                "unchanged",
+                "integration files already current",
+                branch=branch,
+            )
         )
 
     add = _run_repo_command(path, ["git", "add", "--all"])
     if add.returncode != 0:
-        return _ConsumerRefreshResult(
-            path,
-            "failed",
-            _command_failure_detail(add, "git add --all"),
-            branch=branch,
+        return _pop_or_preserve(
+            _ConsumerRefreshResult(
+                path,
+                "failed",
+                _command_failure_detail(add, "git add --all"),
+                branch=branch,
+            )
         )
     message = f"Refresh conductor integrations to v{__version__.split('+', 1)[0]}"
     commit = _run_repo_command(path, ["git", "commit", "-m", message])
     if commit.returncode != 0:
-        return _ConsumerRefreshResult(
-            path,
-            "failed",
-            _command_failure_detail(commit, "git commit"),
-            branch=branch,
+        return _pop_or_preserve(
+            _ConsumerRefreshResult(
+                path,
+                "failed",
+                _command_failure_detail(commit, "git commit"),
+                branch=branch,
+            )
         )
     sha = _run_repo_command(path, ["git", "rev-parse", "--short", "HEAD"])
     commit_sha = sha.stdout.strip() if sha.returncode == 0 else None
-    return _ConsumerRefreshResult(
-        path,
-        "committed",
-        "refresh commit ready for operator review",
-        branch=branch,
-        commit=commit_sha,
+    return _pop_or_preserve(
+        _ConsumerRefreshResult(
+            path,
+            "committed",
+            "refresh commit ready for operator review",
+            branch=branch,
+            commit=commit_sha,
+        )
     )
 
 

--- a/tests/test_cli_phase5.py
+++ b/tests/test_cli_phase5.py
@@ -1014,6 +1014,83 @@ def test_refresh_consumers_default_branch_uses_typed_prefix(mocker, tmp_path):
     assert _git(consumer, "branch", "--show-current").stdout.strip() == expected_branch
 
 
+def test_refresh_consumers_auto_stashes_dirty_repo(mocker, tmp_path):
+    """Dirty repo with operator changes outside the conductor sentinel block
+    should be auto-stashed, refreshed on the refresh branch, and popped back
+    on the original branch (closes #289 piece 3)."""
+    _stub_all_unconfigured(mocker)
+
+    consumer = tmp_path / "consumer-dirty-stash"
+    consumer.mkdir()
+    _git(consumer, "init", "-q", "-b", "main")
+    _git(consumer, "config", "user.email", "conductor-test@example.com")
+    _git(consumer, "config", "user.name", "Conductor Test")
+
+    from conductor import agent_wiring
+
+    agent_wiring.wire_agents_md(cwd=consumer, version="0.8.0")
+    (consumer / "operator-file.txt").write_text("baseline\n", encoding="utf-8")
+    _git(consumer, "add", "AGENTS.md", "operator-file.txt")
+    _git(consumer, "commit", "-m", "Initial state")
+
+    # Operator makes uncommitted changes to a non-conductor file.
+    (consumer / "operator-file.txt").write_text("operator's in-flight work\n", encoding="utf-8")
+
+    result = CliRunner().invoke(
+        main,
+        ["refresh-consumers", "--paths", str(consumer), "--branch", "chore/refresh-test"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "committed" in result.output
+    assert "auto-stashed and restored" in result.output
+    # Operator's in-flight work survived: working tree on original branch with the modification.
+    assert _git(consumer, "branch", "--show-current").stdout.strip() == "main"
+    assert (consumer / "operator-file.txt").read_text(encoding="utf-8") == (
+        "operator's in-flight work\n"
+    )
+    # Refresh commit landed on the refresh branch.
+    log = _git(consumer, "log", "chore/refresh-test", "-1", "--pretty=%s").stdout
+    assert "Refresh conductor integrations" in log
+    # Stash entry was popped (none preserved).
+    stash_list = _git(consumer, "stash", "list").stdout.strip()
+    assert stash_list == "", f"stash should be empty after successful pop; got: {stash_list!r}"
+
+
+def test_refresh_consumers_no_auto_stash_skips_dirty_repo(mocker, tmp_path):
+    """`--no-auto-stash` preserves the older skip-on-dirty behavior so
+    operator scripts that depended on it keep working."""
+    _stub_all_unconfigured(mocker)
+
+    consumer = tmp_path / "consumer-no-stash"
+    consumer.mkdir()
+    _git(consumer, "init", "-q", "-b", "main")
+    _git(consumer, "config", "user.email", "conductor-test@example.com")
+    _git(consumer, "config", "user.name", "Conductor Test")
+
+    from conductor import agent_wiring
+
+    agent_wiring.wire_agents_md(cwd=consumer, version="0.8.0")
+    _git(consumer, "add", "AGENTS.md")
+    _git(consumer, "commit", "-m", "Initial state")
+
+    # Make the repo dirty.
+    (consumer / "operator-file.txt").write_text("dirty\n", encoding="utf-8")
+
+    result = CliRunner().invoke(
+        main,
+        ["refresh-consumers", "--paths", str(consumer), "--no-auto-stash"],
+    )
+
+    # Skip-on-dirty exits 1 (today's behavior with --no-auto-stash opted in).
+    assert result.exit_code == 1, result.output
+    assert "skipped" in result.output
+    assert "pre-existing changes" in result.output
+    # Repo state untouched: still on main, untracked file still present.
+    assert _git(consumer, "branch", "--show-current").stdout.strip() == "main"
+    assert (consumer / "operator-file.txt").read_text(encoding="utf-8") == "dirty\n"
+
+
 def test_refresh_consumers_reads_config_file(mocker, tmp_path):
     _stub_all_unconfigured(mocker)
     consumer = tmp_path / "consumer-from-config"


### PR DESCRIPTION
Closes part of #289 (piece 3).

Replaces the dirty-skip behavior with auto-stash + refresh + restore:

1. If the repo has uncommitted changes, `git stash push -u -m
   "conductor-refresh-vX.Y.Z auto-stash"`.
2. Run the existing refresh logic (checkout refresh branch, conductor
   init -y --remaining, commit).
3. Switch back to the operator's original branch.
4. `git stash pop`. On success, the operator's in-flight work is
   restored; on conflict, the stash entry is preserved at stash@{0}
   and the result downgrades to "needs-attention" with a clear
   instruction.

The operator's in-flight changes survive the refresh: working tree
ends on their original branch with their modifications intact; the
refresh commit lands on the refresh branch.

`--no-auto-stash` flag preserves today's skip-on-dirty behavior for
operator scripts that depend on it.

Surfaced during the v0.10.2 install verification: 3 of 6 wired
consumer repos (vesper, vanguard, outrider) had pre-existing changes
and were skipped, leaving them stale until manual reconciliation.

Tested:
- Dirty repo + refresh → auto-stashed, refreshed on refresh branch,
  popped back on original branch; operator's changes intact; refresh
  commit on refresh branch; stash list empty after pop.
- Dirty repo + --no-auto-stash → today's skip-on-dirty behavior
  (regression-protection).
- All 7 existing refresh-consumers tests still pass (clean repo,
  default branch, help text, etc).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
