### PR TITLE
feat: auto-refresh extends to repo-scope; conductor init defaults to --hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,3 +82,12 @@ repos:
         stages: [pre-push]
         always_run: true
         pass_filenames: false
+  - repo: local
+    hooks:
+      - id: conductor-refresh
+        name: Refresh conductor integrations if stale
+        entry: conductor refresh-on-commit
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ hand-authoring any prompts:
   `<!-- conductor:begin -->` markers.
 - Writes a Cursor rule at `.cursor/rules/conductor-delegation.mdc` if
   the directory exists.
+- Installs the `conductor-refresh` pre-commit hook by default so stale
+  embed-only repo instructions refresh on commit; pass `--no-hooks` to skip.
 
 On a TTY you get a prompt per detected file (default yes); in CI use
 `--wire-agents=yes`, `--patch-claude-md=yes`, `--patch-agents-md=yes`,

--- a/src/conductor/agent_wiring.py
+++ b/src/conductor/agent_wiring.py
@@ -89,6 +89,21 @@ class UserScopeVersionDecision:
     reason: str
 
 
+@dataclass(frozen=True)
+class RepoScopeVersionDecision:
+    path: Path
+    kind: str
+    version: str | None
+    stale: bool
+    reason: str
+
+
+@dataclass(frozen=True)
+class RefreshReport:
+    refreshed: tuple[Path, ...]
+    skipped: tuple[tuple[Path, str], ...]
+
+
 def _managed_comment(version: str) -> str:
     version = _canonical_wiring_version(version)
     return (
@@ -308,6 +323,22 @@ def _user_scope_candidate_sentinel_paths() -> dict[Path, str]:
     }
 
 
+def _repo_scope_candidate_artifacts(cwd: Path) -> dict[Path, str]:
+    return {
+        path: kind
+        for path, kind in _candidate_artifacts(cwd=cwd).items()
+        if kind in _REPO_SCOPED_KINDS
+    }
+
+
+def _repo_scope_candidate_sentinel_paths(cwd: Path) -> dict[Path, str]:
+    return {
+        path: kind
+        for path, kind in _candidate_sentinel_paths(cwd=cwd).items()
+        if kind in _REPO_SCOPED_KINDS
+    }
+
+
 # --------------------------------------------------------------------------- #
 # Managed-file helpers — write/read/detect ownership.
 # --------------------------------------------------------------------------- #
@@ -393,6 +424,118 @@ def is_user_scope_stale(*, binary_version: str) -> bool:
     )
 
 
+def repo_scope_version_decisions(
+    cwd: Path,
+    *,
+    binary_version: str,
+) -> tuple[RepoScopeVersionDecision, ...]:
+    """Scan repo-scope managed files for stale conductor version stamps.
+
+    Startup auto-refresh calls this on eligible CLI commands, so the scan is
+    intentionally bounded to the conventional repo-scope files in ``cwd`` and
+    reads only a small prefix from each existing candidate.
+    """
+    root = cwd.resolve()
+    if not _is_inside_git_repo(root):
+        return ()
+
+    decisions: list[RepoScopeVersionDecision] = []
+    for path, kind in _repo_scope_candidate_sentinel_paths(root).items():
+        exists = path.is_file()
+        version, reason = _read_repo_sentinel_version_prefix(path)
+        decisions.append(
+            _repo_scope_decision(
+                path=path,
+                kind=kind,
+                version=version,
+                exists=exists,
+                binary_version=binary_version,
+                reason=reason,
+            )
+        )
+    for path, kind in _repo_scope_candidate_artifacts(root).items():
+        exists = path.is_file()
+        version = _read_managed_version_prefix(path)
+        decisions.append(
+            _repo_scope_decision(
+                path=path,
+                kind=kind,
+                version=version,
+                exists=exists,
+                binary_version=binary_version,
+                reason=None,
+            )
+        )
+    return tuple(decisions)
+
+
+def is_repo_scope_stale(cwd: Path) -> bool:
+    """Return True when any repo-scope conductor-managed file is stale."""
+    from conductor import __version__
+
+    return any(
+        decision.stale
+        for decision in repo_scope_version_decisions(cwd, binary_version=__version__)
+    )
+
+
+def refresh_repo_scope(cwd: Path, *, version: str) -> RefreshReport:
+    """Refresh stale repo-scope conductor-managed files in ``cwd``."""
+    refreshed: list[Path] = []
+    skipped: list[tuple[Path, str]] = []
+    root = cwd.resolve()
+
+    for decision in repo_scope_version_decisions(root, binary_version=version):
+        if not decision.stale:
+            if decision.reason not in {"missing", "not conductor-managed", "current"}:
+                skipped.append((decision.path, decision.reason))
+            continue
+        try:
+            _refresh_repo_scope_path(decision.kind, cwd=root, version=version)
+            refreshed.append(decision.path)
+        except OSError as e:
+            skipped.append((decision.path, f"refresh failed: {e}"))
+        except UserOwnedFileError as e:
+            skipped.append((e.path, "user-owned file; refusing to overwrite"))
+
+    return RefreshReport(refreshed=tuple(refreshed), skipped=tuple(skipped))
+
+
+def _repo_scope_decision(
+    *,
+    path: Path,
+    kind: str,
+    version: str | None,
+    exists: bool,
+    binary_version: str,
+    reason: str | None,
+) -> RepoScopeVersionDecision:
+    if reason is not None:
+        return RepoScopeVersionDecision(path, kind, version, False, reason)
+    if version is None:
+        detail = "missing" if not exists else "not conductor-managed"
+        return RepoScopeVersionDecision(path, kind, None, False, detail)
+    stale = _wiring_version_is_older(version, binary_version=binary_version)
+    detail = "stale" if stale else "current"
+    return RepoScopeVersionDecision(path, kind, version, stale, detail)
+
+
+def _refresh_repo_scope_path(kind: str, *, cwd: Path, version: str) -> None:
+    if kind == "agents-md-import":
+        wire_agents_md(cwd=cwd, version=version)
+        return
+    if kind == "gemini-md-import":
+        wire_gemini_md(cwd=cwd, version=version)
+        return
+    if kind == "claude-md-repo-import":
+        wire_claude_md_repo(cwd=cwd, version=version)
+        return
+    if kind == "cursor-rule":
+        wire_cursor(cwd=cwd, version=version)
+        return
+    raise ValueError(f"unsupported repo integration kind: {kind}")
+
+
 def _user_scope_decision(
     *,
     path: Path,
@@ -442,6 +585,27 @@ def _read_sentinel_version_prefix(path: Path) -> str | None:
     if end == -1:
         return None
     return rest[:end].strip()
+
+
+def _read_repo_sentinel_version_prefix(path: Path) -> tuple[str | None, str | None]:
+    text = _read_prefix(path)
+    if not text:
+        return None, None
+    idx = text.find(SENTINEL_BEGIN_PREFIX)
+    if idx == -1:
+        return None, None
+    marker_end = text.find("-->", idx)
+    if marker_end == -1:
+        return None, "malformed sentinel"
+    body_prefix = text[marker_end + len("-->") :].lstrip()
+    if body_prefix.startswith("@"):
+        return None, "import-mode"
+    version = text[idx + len(SENTINEL_BEGIN_PREFIX) : marker_end].strip()
+    return version or None, None
+
+
+def _is_inside_git_repo(cwd: Path) -> bool:
+    return any((candidate / ".git").exists() for candidate in (cwd, *cwd.parents))
 
 
 def project_root_for_wiring_notice(cwd: Path | None = None) -> Path | None:

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -3347,9 +3347,11 @@ def _env_flag_enabled(name: str) -> bool:
     return value.strip().lower() not in {"", "0", "false", "no", "off"}
 
 
-def _maybe_auto_refresh_user_scope(ctx: click.Context) -> None:
+def _maybe_auto_refresh(ctx: click.Context) -> None:
     command = ctx.invoked_subcommand
     if command not in AUTO_REFRESH_COMMANDS:
+        return
+    if any(arg in {"--help", "-h", "--version"} for arg in sys.argv[1:]):
         return
     if _env_flag_enabled("CONDUCTOR_NO_AUTO_REFRESH"):
         return
@@ -3368,18 +3370,54 @@ def _maybe_auto_refresh_user_scope(ctx: click.Context) -> None:
                     f"stale={decision.stale} reason={decision.reason}",
                     err=True,
                 )
-        if not any(decision.stale for decision in decisions):
-            return
-        agent_wiring.wire_claude_code(__version__, patch_claude_md=True)
-        click.echo(
-            "[conductor] refreshed user-scope integration files "
-            f"to v{__version__.split('+', 1)[0]}",
-            err=True,
-        )
+        if any(decision.stale for decision in decisions):
+            agent_wiring.wire_claude_code(__version__, patch_claude_md=True)
+            click.echo(
+                "[conductor] refreshed user-scope integration files "
+                f"to v{__version__.split('+', 1)[0]}",
+                err=True,
+            )
     except Exception as e:
         click.echo(
             f"[conductor] auto-refresh warning: failed to refresh "
             f"user-scope integration files: {e}",
+            err=True,
+        )
+    try:
+        from conductor import agent_wiring
+
+        cwd = Path.cwd()
+        repo_decisions = agent_wiring.repo_scope_version_decisions(
+            cwd,
+            binary_version=__version__,
+        )
+        if debug:
+            for repo_decision in repo_decisions:
+                version = repo_decision.version or "-"
+                click.echo(
+                    "[conductor] auto-refresh scan: "
+                    f"{repo_decision.kind} {repo_decision.path} version={version} "
+                    f"stale={repo_decision.stale} reason={repo_decision.reason}",
+                    err=True,
+                )
+        if not any(repo_decision.stale for repo_decision in repo_decisions):
+            return
+        report = agent_wiring.refresh_repo_scope(cwd, version=__version__)
+        for path, reason in report.skipped:
+            click.echo(
+                f"[conductor] auto-refresh warning: skipped {path}: {reason}",
+                err=True,
+            )
+        if report.refreshed:
+            click.echo(
+                "[conductor] refreshed repo-scope integration files "
+                f"in {cwd} to v{__version__.split('+', 1)[0]}",
+                err=True,
+            )
+    except Exception as e:
+        click.echo(
+            f"[conductor] auto-refresh warning: failed to refresh "
+            f"repo-scope integration files: {e}",
             err=True,
         )
 
@@ -3389,7 +3427,7 @@ def _maybe_auto_refresh_user_scope(ctx: click.Context) -> None:
 @click.pass_context
 def main(ctx: click.Context) -> None:
     """Pick an LLM, give it a job."""
-    _maybe_auto_refresh_user_scope(ctx)
+    _maybe_auto_refresh(ctx)
     _maybe_emit_agent_wiring_notice(ctx)
 
 
@@ -7019,7 +7057,7 @@ def doctor(as_json: bool) -> None:
             click.echo(f"    {display}{version_note}")
         click.echo("  Auto refresh paths:")
         click.echo("    brew upgrade conductor       # CLAUDE.md @-import self-heals on upgrade")
-        click.echo("    conductor init --hooks       # refresh embed-only files on commit")
+        click.echo("    conductor init               # installs refresh hook by default")
         click.echo("  Immediate manual fallback:")
         click.echo("    conductor init -y --remaining")
         click.echo("    conductor refresh-consumers  # force-refresh configured consumer repos")
@@ -7145,10 +7183,12 @@ def doctor(as_json: bool) -> None:
     "(user-scope + repo-scope sentinel blocks + Cursor rule) and exit.",
 )
 @click.option(
-    "--hooks",
-    is_flag=True,
-    default=False,
-    help="Install the opt-in pre-commit hook that refreshes stale repo integrations.",
+    "--hooks/--no-hooks",
+    default=True,
+    help=(
+        "Install pre-commit refresh hook for embed-only files "
+        "(default: yes; pass --no-hooks to skip)."
+    ),
 )
 def init(
     accept_defaults: bool,
@@ -7165,21 +7205,6 @@ def init(
     hooks: bool,
 ) -> None:
     """Interactively configure Conductor for first use."""
-    if hooks:
-        wiring_flags = (
-            wire_agents,
-            patch_claude_md,
-            patch_agents_md,
-            patch_gemini_md,
-            patch_claude_md_repo,
-            wire_cursor_flag,
-        )
-        if only or remaining or unwire or any(f is not None for f in wiring_flags):
-            raise click.UsageError(
-                "--hooks can't be combined with provider, wiring, or unwire flags."
-            )
-        sys.exit(_run_install_hooks())
-
     if unwire:
         wiring_flags = (
             wire_agents,
@@ -7209,6 +7234,8 @@ def init(
         patch_claude_md_repo=patch_claude_md_repo,
         wire_cursor_flag=wire_cursor_flag,
     )
+    if exit_code == 0 and hooks:
+        exit_code = _run_install_hooks(quiet=quiet)
     sys.exit(exit_code)
 
 
@@ -7233,17 +7260,23 @@ def _run_unwire() -> int:
     return 0
 
 
-def _run_install_hooks() -> int:
+def _run_install_hooks(*, quiet: bool = False) -> int:
     """Install the local pre-commit hook entry for refresh-on-commit."""
     config_path = Path.cwd() / PRE_COMMIT_CONFIG
     try:
         changed = _install_refresh_pre_commit_hook(config_path)
     except OSError as e:
         raise click.ClickException(f"failed to update {config_path}: {e}") from e
+    if quiet:
+        return 0
     if changed:
-        click.echo(f"Installed conductor refresh hook in {config_path}.")
+        click.echo(
+            f"==> Installed conductor-refresh pre-commit hook in {PRE_COMMIT_CONFIG}."
+        )
     else:
-        click.echo(f"Conductor refresh hook already present in {config_path}.")
+        click.echo(
+            f"==> conductor-refresh pre-commit hook already present in {PRE_COMMIT_CONFIG}."
+        )
     return 0
 
 
@@ -7502,8 +7535,8 @@ def refresh_consumers(
 
     Manual force-refresh backstop. After `brew upgrade conductor`, drift should
     self-heal via the CLAUDE.md @-import path and, for embed-only files
-    (Cursor .mdc, AGENTS.md, GEMINI.md), the opt-in pre-commit refresh hook
-    installed by `conductor init --hooks`.
+    (Cursor .mdc, AGENTS.md, GEMINI.md), the pre-commit refresh hook installed
+    by default by `conductor init`.
 
     Use `refresh-consumers` only when you need an immediate cross-repo refresh
     without waiting for the next commit in each repo.

--- a/tests/test_cli_auto_refresh.py
+++ b/tests/test_cli_auto_refresh.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import subprocess
+
 from click.testing import CliRunner
 
 from conductor import agent_wiring as aw
@@ -8,9 +10,14 @@ from conductor.cli import main
 
 
 def _isolate_user_scope(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("CONDUCTOR_HOME", str(tmp_path / ".conductor"))
     monkeypatch.setenv("CLAUDE_HOME", str(tmp_path / ".claude"))
     monkeypatch.delenv("CONDUCTOR_NO_AUTO_REFRESH", raising=False)
+
+
+def _init_git_repo(path) -> None:
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, check=True)
 
 
 def test_auto_refresh_current_user_scope_is_silent(tmp_path, monkeypatch):
@@ -46,17 +53,114 @@ def test_auto_refresh_stale_user_scope_updates_files(tmp_path, monkeypatch):
     }
 
 
+def test_auto_refresh_stale_repo_scope_updates_files(tmp_path, monkeypatch):
+    _isolate_user_scope(tmp_path, monkeypatch)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+    aw.wire_agents_md(cwd=repo, version="0.8.0")
+
+    result = CliRunner().invoke(main, ["doctor", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert (
+        f"[conductor] refreshed repo-scope integration files in {repo} to v0.9.0"
+        in result.stderr
+    )
+    assert "<!-- conductor:begin v0.9.0 -->" in (
+        repo / "AGENTS.md"
+    ).read_text(encoding="utf-8")
+
+
+def test_auto_refresh_clean_repo_scope_is_silent(tmp_path, monkeypatch):
+    _isolate_user_scope(tmp_path, monkeypatch)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+    aw.wire_agents_md(cwd=repo, version="0.9.0")
+
+    result = CliRunner().invoke(main, ["doctor", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert "refreshed repo-scope" not in result.stderr
+
+
+def test_auto_refresh_repo_scope_skips_import_mode_claude_md(tmp_path, monkeypatch):
+    _isolate_user_scope(tmp_path, monkeypatch)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+    aw.wire_agents_md(cwd=repo, version="0.8.0")
+    aw.wire_claude_md_repo(cwd=repo, version="0.8.0")
+
+    result = CliRunner().invoke(main, ["doctor", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert "<!-- conductor:begin v0.9.0 -->" in (
+        repo / "AGENTS.md"
+    ).read_text(encoding="utf-8")
+    claude_text = (repo / "CLAUDE.md").read_text(encoding="utf-8")
+    assert "<!-- conductor:begin v0.8.0 -->" in claude_text
+    assert "@~/.conductor/delegation-guidance.md" in claude_text
+
+
+def test_auto_refresh_repo_scope_non_git_noops(tmp_path, monkeypatch):
+    _isolate_user_scope(tmp_path, monkeypatch)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+    aw.wire_agents_md(cwd=repo, version="0.8.0")
+
+    result = CliRunner().invoke(main, ["doctor", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert "refreshed repo-scope" not in result.stderr
+    assert "<!-- conductor:begin v0.8.0 -->" in (
+        repo / "AGENTS.md"
+    ).read_text(encoding="utf-8")
+
+
+def test_auto_refresh_repo_scope_non_wired_noops(tmp_path, monkeypatch):
+    _isolate_user_scope(tmp_path, monkeypatch)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+
+    result = CliRunner().invoke(main, ["doctor", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert "refreshed repo-scope" not in result.stderr
+
+
 def test_auto_refresh_env_opt_out_leaves_stale_files(tmp_path, monkeypatch):
     _isolate_user_scope(tmp_path, monkeypatch)
     monkeypatch.setenv("CONDUCTOR_NO_AUTO_REFRESH", "1")
     monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
     aw.wire_claude_code("0.8.0", patch_claude_md=True)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    monkeypatch.chdir(repo)
+    aw.wire_agents_md(cwd=repo, version="0.8.0")
 
     result = CliRunner().invoke(main, ["doctor", "--json"])
 
     assert result.exit_code == 0, result.output
     assert "refreshed user-scope" not in result.stderr
+    assert "refreshed repo-scope" not in result.stderr
     assert aw.is_user_scope_stale(binary_version="0.9.0") is True
+    assert "<!-- conductor:begin v0.8.0 -->" in (
+        repo / "AGENTS.md"
+    ).read_text(encoding="utf-8")
 
 
 def test_auto_refresh_skips_read_only_commands(monkeypatch):
@@ -66,8 +170,9 @@ def test_auto_refresh_skips_read_only_commands(monkeypatch):
         raise AssertionError(f"unexpected auto-refresh scan for {binary_version}")
 
     monkeypatch.setattr(aw, "user_scope_version_decisions", fail_scan)
+    monkeypatch.setattr(aw, "repo_scope_version_decisions", fail_scan)
 
-    for args in (["list"], ["--help"], ["--version"]):
+    for args in (["list"], ["--help"], ["--version"], ["init", "--help"]):
         result = CliRunner().invoke(main, args)
         assert result.exit_code == 0, result.output
 

--- a/tests/test_cli_phase5.py
+++ b/tests/test_cli_phase5.py
@@ -731,7 +731,7 @@ def test_doctor_warns_before_next_steps_when_one_integration_file_is_behind(
     assert "    AGENTS.md (v0.8.9)" in result.output
     assert "  Auto refresh paths:" in result.output
     assert "    brew upgrade conductor" in result.output
-    assert "    conductor init --hooks" in result.output
+    assert "    conductor init               # installs refresh hook by default" in result.output
     assert "  Immediate manual fallback:" in result.output
     assert "    conductor init -y --remaining" in result.output
     assert "    conductor refresh-consumers" in result.output
@@ -941,7 +941,7 @@ def test_refresh_consumers_help_positions_command_as_manual_backstop():
     assert "Refresh Conductor integration blocks" in result.output
     assert "Manual force-refresh backstop" in result.output
     assert "CLAUDE.md @-import" in result.output
-    assert "conductor init --hooks" in result.output
+    assert "conductor init`" in result.output
     assert "Use `refresh-consumers` only" in result.output
 
 

--- a/tests/test_consumer_contract.py
+++ b/tests/test_consumer_contract.py
@@ -94,6 +94,7 @@ def _isolated_consumer_contract_env(monkeypatch, tmp_path):
 
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.setenv("CONDUCTOR_NO_AUTO_REFRESH", "1")
     monkeypatch.setenv("CONDUCTOR_HOME", str(tmp_path / "conductor-home"))
     monkeypatch.setenv(
         "CONDUCTOR_PROVIDERS_FILE",

--- a/tests/test_migration_flow.py
+++ b/tests/test_migration_flow.py
@@ -134,11 +134,11 @@ def test_brew_upgrade_then_consumer_commit_refresh(tmp_path, monkeypatch):
     _assert_user_versions("0.10.0")
     _assert_repo_versions(consumer, "0.10.0")
 
-    first_hooks = _invoke(["init", "--hooks"])
-    second_hooks = _invoke(["init", "--hooks"])
+    first_hooks = _invoke(["init", "-y"])
+    second_hooks = _invoke(["init", "-y"])
     pre_commit_config = consumer / ".pre-commit-config.yaml"
     pre_commit_text = pre_commit_config.read_text(encoding="utf-8")
-    assert "Installed conductor refresh hook" in first_hooks.output
+    assert "already present" in first_hooks.output
     assert "already present" in second_hooks.output
     assert pre_commit_text.count("id: conductor-refresh") == 1
     assert pre_commit_text.count("entry: conductor refresh-on-commit") == 1

--- a/tests/test_refresh_on_commit.py
+++ b/tests/test_refresh_on_commit.py
@@ -98,10 +98,10 @@ def test_refresh_on_commit_mixed_embedded_and_import_refreshes_only_embedded(
     assert _staged_paths(repo) == ["AGENTS.md"]
 
 
-def test_init_hooks_creates_pre_commit_config(tmp_path):
+def test_init_hooks_creates_pre_commit_config_by_default(tmp_path):
     repo = tmp_path / "repo"
 
-    result = CliRunner().invoke(main, ["init", "--hooks"])
+    result = CliRunner().invoke(main, ["init", "--yes"])
 
     assert result.exit_code == 0, result.output
     config = repo / ".pre-commit-config.yaml"
@@ -110,6 +110,34 @@ def test_init_hooks_creates_pre_commit_config(tmp_path):
     assert "id: conductor-refresh" in text
     assert "entry: conductor refresh-on-commit" in text
     assert "always_run: true" in text
+    assert "Installed conductor-refresh pre-commit hook" in result.output
+
+
+def test_init_no_hooks_skips_pre_commit_config(tmp_path):
+    repo = tmp_path / "repo"
+
+    result = CliRunner().invoke(main, ["init", "--yes", "--no-hooks"])
+
+    assert result.exit_code == 0, result.output
+    assert not (repo / ".pre-commit-config.yaml").exists()
+
+
+def test_init_accept_defaults_no_hooks_skips_prompts_and_hooks(tmp_path):
+    repo = tmp_path / "repo"
+
+    result = CliRunner().invoke(main, ["init", "-y", "--no-hooks"])
+
+    assert result.exit_code == 0, result.output
+    assert "Proceed?" not in result.output
+    assert not (repo / ".pre-commit-config.yaml").exists()
+
+
+def test_init_help_documents_hooks_default():
+    result = CliRunner().invoke(main, ["init", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "--hooks / --no-hooks" in result.output
+    assert "default: yes; pass --no-hooks to skip" in result.output
 
 
 def test_init_hooks_merges_existing_config_without_duplication(tmp_path):
@@ -125,7 +153,7 @@ def test_init_hooks_merges_existing_config_without_duplication(tmp_path):
         encoding="utf-8",
     )
 
-    result = CliRunner().invoke(main, ["init", "--hooks"])
+    result = CliRunner().invoke(main, ["init", "--yes"])
 
     assert result.exit_code == 0, result.output
     text = config.read_text(encoding="utf-8")
@@ -149,7 +177,7 @@ default_language_version:
         encoding="utf-8",
     )
 
-    result = CliRunner().invoke(main, ["init", "--hooks"])
+    result = CliRunner().invoke(main, ["init", "--yes"])
 
     assert result.exit_code == 0, result.output
     text = config.read_text(encoding="utf-8")
@@ -160,8 +188,8 @@ default_language_version:
 def test_init_hooks_is_idempotent(tmp_path):
     repo = tmp_path / "repo"
 
-    first = CliRunner().invoke(main, ["init", "--hooks"])
-    second = CliRunner().invoke(main, ["init", "--hooks"])
+    first = CliRunner().invoke(main, ["init", "--yes"])
+    second = CliRunner().invoke(main, ["init", "--yes"])
 
     assert first.exit_code == 0, first.output
     assert second.exit_code == 0, second.output


### PR DESCRIPTION
Closes part of #289 (pieces 1 + 2).

## Piece 1: extend in-binary auto-refresh to repo-scope

`_maybe_auto_refresh` (renamed from `_maybe_auto_refresh_user_scope`) now runs both user-scope and repo-scope refresh checks. After the user-scope pass (#280 logic), if cwd is a wired consumer repo with stale embed-only files (AGENTS.md, GEMINI.md, .cursor/rules/conductor-delegation.mdc, or repo-scope CLAUDE.md when in embed mode), conductor refreshes them in-process via the existing wire layer. Files in import mode (post-#246 CLAUDE.md) are skipped — the @-import auto-resolves at read time.

New helpers in `agent_wiring.py`:
- `repo_scope_version_decisions(cwd, *, binary_version)` — per-file staleness predicate.
- `refresh_repo_scope(cwd, *, version)` — atomic per-file refresh, returns `RefreshReport(refreshed, skipped)`.

Same env-var opt-out (`CONDUCTOR_NO_AUTO_REFRESH=1`) and debug (`CONDUCTOR_DEBUG_AUTO_REFRESH=1`) cover both scopes.

Stderr lines on actual refresh:
```
[conductor] refreshed user-scope integration files to v0.10.6
[conductor] refreshed repo-scope integration files in <cwd> to v0.10.6
```

Quiet on no-op.

## Piece 2: flip `conductor init` to default-install the pre-commit hook

`--hooks` becomes `--hooks/--no-hooks` with `default=True`. Operators get the conductor-refresh pre-commit hook installed by default; `--no-hooks` opts out. Removes the \"I forgot the setup step\" friction from the upgrade flow. Doctor's auto-refresh-paths recommendation updates: \"`conductor init               # installs refresh hook by default`\".

Conductor's own `.pre-commit-config.yaml` now ships the conductor-refresh hook (dogfood). This validates that the hook works on conductor's own commits — and surfaces an interesting recursion: every commit in conductor triggers refresh-on-commit, which re-checks conductor's own wired files. Idempotent in the steady state.

## Auto-refresh skip-list refinement

Auto-refresh continues to skip read-only commands (`list`, `--help`, `--version`). New: also skips `<cmd> --help` (e.g. `conductor init --help`) since the operator is asking for documentation, not invoking state.

## Tests

- 1044 passed / 15 skipped on the full suite; ruff and mypy clean.
- `tests/test_cli_auto_refresh.py` covers user-scope + repo-scope refresh paths, env-var opt-out, debug mode, skip-list (incl. `init --help`).
- `tests/test_cli_phase5.py` updated for the new doctor recommendation wording and the `--hooks/--no-hooks` flag default.
- Other touched test files are import / fixture adjustments.

## Emergency-bypass disclosure

`git push --no-verify` was used on the final push because the conductor-refresh pre-commit hook entered a dogfood loop in the worktree (the hook re-modified `.pre-commit-config.yaml` between iterations, leaving an unstaged change that pre-commit's own validation refused to push past). Loop converges in main once the pre-commit-config snapshot is part of the commit (which it now is), so subsequent commits in the conductor repo will not hit this. Disclosed per `principles/git-workflow.md` § Emergency path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)