### PR TITLE
feat: auto-refresh extends to repo-scope; conductor init defaults to --hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,12 +82,3 @@ repos:
         stages: [pre-push]
         always_run: true
         pass_filenames: false
-  - repo: local
-    hooks:
-      - id: conductor-refresh
-        name: Refresh conductor integrations if stale
-        entry: conductor refresh-on-commit
-        language: system
-        pass_filenames: false
-        always_run: true
-        stages: [pre-commit]

--- a/src/conductor/agent_wiring.py
+++ b/src/conductor/agent_wiring.py
@@ -487,7 +487,12 @@ def refresh_repo_scope(cwd: Path, *, version: str) -> RefreshReport:
 
     for decision in repo_scope_version_decisions(root, binary_version=version):
         if not decision.stale:
-            if decision.reason not in {"missing", "not conductor-managed", "current"}:
+            if decision.reason not in {
+                "missing",
+                "not conductor-managed",
+                "current",
+                "import-mode",
+            }:
                 skipped.append((decision.path, decision.reason))
             continue
         try:

--- a/tests/test_cli_auto_refresh.py
+++ b/tests/test_cli_auto_refresh.py
@@ -102,6 +102,8 @@ def test_auto_refresh_repo_scope_skips_import_mode_claude_md(tmp_path, monkeypat
     result = CliRunner().invoke(main, ["doctor", "--json"])
 
     assert result.exit_code == 0, result.output
+    assert "import-mode" not in result.stderr
+    assert "auto-refresh warning: skipped" not in result.stderr
     assert "<!-- conductor:begin v0.9.0 -->" in (
         repo / "AGENTS.md"
     ).read_text(encoding="utf-8")

--- a/tests/test_deepseek_migration.py
+++ b/tests/test_deepseek_migration.py
@@ -19,6 +19,13 @@ from conductor.providers.deepseek import (
 from conductor.providers.openrouter import OpenRouterProvider
 
 
+@pytest.fixture(autouse=True)
+def _isolated_init_cwd(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+
+
 def _model(model_id: str, *, created: int) -> openrouter_catalog.ModelEntry:
     return openrouter_catalog.ModelEntry(
         id=model_id,


### PR DESCRIPTION
Closes part of #289 (pieces 1 + 2).

Extends startup auto-refresh so eligible state-touching commands refresh stale repo-scope conductor-managed files after the existing user-scope pass, while preserving CONDUCTOR_NO_AUTO_REFRESH and CONDUCTOR_DEBUG_AUTO_REFRESH for both layers.

Flips conductor init to install the conductor-refresh pre-commit hook by default and adds --no-hooks as the opt-out.

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
