### PR TITLE
Complete remaining issue batch

### DIFF
--- a/.cursor/rules/conductor-delegation.mdc
+++ b/.cursor/rules/conductor-delegation.mdc
@@ -2,7 +2,7 @@
 description: Use when delegating or routing tasks to a different LLM via the conductor CLI — e.g., cheap second opinions, long-context reads, web search, or offline runs.
 globs: ""
 alwaysApply: false
-managed-by: conductor v0.8.2
+managed-by: conductor v0.10.7
 ---
 
 # Conductor delegation
@@ -27,7 +27,7 @@ Use it when:
 - You want a cheap second opinion (`conductor call --with kimi --brief "..."`).
 - You need fresh web information (`conductor call --with gemini --brief "..."`).
 - You want to stay local / offline (`conductor call --with ollama --brief "..."`).
-- You want a true read-only code review:
+- You want a native code review:
   `conductor review --auto --base origin/main --brief-file /tmp/review.md`.
 - You're not sure which provider fits — let the router pick:
   `conductor call --auto --tags <tag1>,<tag2> --brief "..."`.
@@ -42,7 +42,7 @@ fit.
 For longer running tool-using sessions:
 
     conductor exec --with <provider> --tools Read,Edit,Bash \
-        --sandbox workspace-write --brief-file /tmp/conductor-brief.md
+        --brief-file /tmp/conductor-brief.md
 
 Discover configured providers: `conductor list`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ If there are zero blocking issues, the review is just: "LGTM."
 
 @.cortex/protocol.md
 
-<!-- conductor:begin v0.8.7 -->
+<!-- conductor:begin v0.10.7 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,4 +1,5 @@
-<!-- conductor:begin v0.8.7 -->
+
+<!-- conductor:begin v0.10.7 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/README.md
+++ b/README.md
@@ -104,9 +104,10 @@ flags remain supported as compatibility aliases.
 Shipped:
 
 - Built-in providers: `kimi` (OpenRouter-backed HTTP preset), `openrouter`, `deepseek-chat`, `deepseek-reasoner`, `claude`, `codex`, `gemini`, and `ollama`.
-- `conductor ask --kind <research|code|review|council> --effort <level>` — deterministic semantic routing. Research and low/medium code favor OpenRouter auto-routing; high-effort code escalates through Codex, Claude, OpenRouter tool-use exec, then Ollama; review routes to native review; council fans out through OpenRouter and synthesizes the results.
+- `conductor ask --kind <research|code|review|council> --effort <level>` — deterministic semantic routing. Research and low/medium code favor call-mode answer synthesis and cannot write files or open PRs; high-effort code escalates through Codex, Claude, OpenRouter tool-use exec, then Ollama; review routes to native review; council fans out through OpenRouter and synthesizes the results.
 - `conductor call --with <id> --brief "..."` — manual mode for any provider.
 - `conductor call --auto [--tags a,b,c] --brief "..."` — rule-based router picks the best configured provider for the task's tags.
+- `conductor swarm --brief a.md --brief b.md --provider codex --max-parallel 2 --json` — first-class multi-task coding supervisor with isolated worktrees and structured per-task results.
 - `conductor review --auto --base <ref> --brief-file <path>` — code review routed only to native review providers (`codex review`, Claude `/review`, Gemini `/code-review` extension).
 - `conductor list [--json]` — shows every provider with ready/not-ready status, default model, and capability tags.
 - `conductor smoke <id>` / `conductor smoke --all [--json]` — proves a provider's auth + endpoint work (cheapest round-trip that exercises the full path).

--- a/docs/consumers.md
+++ b/docs/consumers.md
@@ -64,6 +64,8 @@ Use `conductor review` for code review. It only routes to providers with native 
 
 `council` is intentionally OpenRouter-only and is not the cheap default delegation path. It runs independent member calls through OpenRouter, then sends those outputs to an OpenRouter synthesis model. Use `research` or `code` for routine single-model delegation; reserve `council` for explicit multi-model judgment.
 
+Rows with mode `call` return text on stdout only. They do not have tool access and cannot write files, create branches, commit, push, or open PRs. Use `code` with `high`/`max` effort or `conductor exec` when the brief requires repository side effects.
+
 Council has conservative default caps: 180 seconds total wall-clock, 6,000 reported output tokens across members plus synthesis, and $0.25 total known OpenRouter cost. Override them with `--council-timeout`, `--council-max-output-tokens`, and `--council-max-cost-usd`. When a cap stops the council before synthesis, the command exits nonzero and emits a partial `CallResponse`; `raw.conductor_council.cap_hit` includes the cap kind, requested/observed limit, elapsed time, completed member count, completed member models, and skipped member models. `--timeout` remains the per-call provider timeout and is bounded by the remaining council wall-clock cap.
 
 `--offline` is rejected for council because it violates the OpenRouter-only invariant.

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -151,6 +151,7 @@ CONDUCTOR_TAGS=""
 CONDUCTOR_EXCLUDE=""
 ROUTING_ENABLED=false
 ROUTING_SMALL_MAX_DIFF_LINES=400
+LARGE_DIFF_REVIEW_BUDGET_SEC=900
 ROUTING_SMALL_REVIEWERS=()   # legacy 1.x shape; retained for back-compat parsing
 ROUTING_LARGE_REVIEWERS=()   # legacy 1.x shape; retained for back-compat parsing
 # 2.0 routing knobs — override CONDUCTOR_* for small vs large diffs.
@@ -1180,6 +1181,45 @@ apply_review_routing() {
   fi
 }
 
+scale_large_diff_review_budget() {
+  local diff_lines="$1"
+
+  case "$ROUTING_SMALL_MAX_DIFF_LINES" in
+    ''|*[!0-9]*) return 0 ;;
+  esac
+  case "$diff_lines" in
+    ''|*[!0-9]*) return 0 ;;
+  esac
+
+  [ "$diff_lines" -gt "$ROUTING_SMALL_MAX_DIFF_LINES" ] 2>/dev/null || return 0
+
+  # Runtime env overrides are deliberate operator choices. Config-file values
+  # are repo defaults, so large diffs may still raise the budget unless the
+  # operator pins a value for this run.
+  if [ -n "${CODEX_REVIEW_TIMEOUT:-}" ] || [ -n "${CODEX_REVIEW_MAX_STALL_SEC:-}" ]; then
+    return 0
+  fi
+
+  case "$REVIEW_MAX_STALL_SEC" in
+    ''|*[!0-9]*) return 0 ;;
+  esac
+  case "$REVIEW_TIMEOUT" in
+    ''|*[!0-9]*) return 0 ;;
+  esac
+
+  if [ "$REVIEW_MAX_STALL_SEC" -le 0 ] || [ "$REVIEW_TIMEOUT" -le 0 ]; then
+    return 0
+  fi
+
+  if [ "$REVIEW_MAX_STALL_SEC" -lt "$LARGE_DIFF_REVIEW_BUDGET_SEC" ] \
+      || [ "$REVIEW_TIMEOUT" -lt "$LARGE_DIFF_REVIEW_BUDGET_SEC" ]; then
+    REVIEW_MAX_STALL_SEC="$LARGE_DIFF_REVIEW_BUDGET_SEC"
+    REVIEW_TIMEOUT="$LARGE_DIFF_REVIEW_BUDGET_SEC"
+    echo "==> Review budget: large diff ($diff_lines > $ROUTING_SMALL_MAX_DIFF_LINES) — timeout/stall scaled to ${LARGE_DIFF_REVIEW_BUDGET_SEC}s"
+    echo "    Override with CODEX_REVIEW_TIMEOUT or CODEX_REVIEW_MAX_STALL_SEC."
+  fi
+}
+
 run_reviewer() {
   "reviewer_${ACTIVE_REVIEWER}_exec" "$1"
 }
@@ -1357,6 +1397,7 @@ fi
 
 ROUTING_DIFF_LINE_COUNT="$(git diff "$MERGE_BASE"..HEAD | wc -l | tr -d ' ')"
 apply_review_routing "$ROUTING_DIFF_LINE_COUNT"
+scale_large_diff_review_budget "$ROUTING_DIFF_LINE_COUNT"
 
 # Resolve which reviewer to use from the cascade.
 if ! resolve_reviewer; then

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -24,8 +24,10 @@ import os
 import re
 import subprocess
 import sys
+import threading
 import time
 import tomllib
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
@@ -37,6 +39,7 @@ from click.core import ParameterSource
 from packaging.version import InvalidVersion
 from packaging.version import parse as parse_version
 
+import conductor.git_state as git_state
 import conductor.providers.openrouter_catalog as openrouter_catalog
 from conductor import __version__, credentials, offline_mode
 from conductor._issue_briefs import (
@@ -169,12 +172,12 @@ EXEC_MAX_ITERATION_MULTIPLIERS = {
     "minimal": 1.0,
     "low": 1.5,
     "medium": 2.0,
-    "high": 3.0,
-    "max": 4.0,
+    "high": 6.0,
+    "max": 8.0,
 }
 EXEC_MAX_ITERATIONS_HELP = (
     "Maximum Conductor-managed tool-use loop iterations. Default scales with "
-    "--effort from base 10: minimal=10, low=15, medium=20, high=30, max=40. "
+    "--effort from base 10: minimal=10, low=15, medium=20, high=60, max=80. "
     "If --effort is unset, preserves the legacy cap of 10."
 )
 EXEC_MAX_ITERATION_PROVIDER_IDS = frozenset({"codex", "openrouter", "ollama"})
@@ -472,6 +475,47 @@ def _warn_if_short_exec_brief(
         "--brief-file with goal, context, scope, constraints, expected output, "
         "and validation. Pass --allow-short-brief to silence this warning.",
         err=True,
+    )
+
+
+def _call_mode_side_effect_reason(body: str) -> str | None:
+    patterns = (
+        (
+            re.compile(
+                r"(?is)\b(write|create|update|edit|modify)\b.{0,80}"
+                r"\b(file|path|\.md|\.py|\.toml|AGENTS\.md|CLAUDE\.md)\b"
+            ),
+            "write local files",
+        ),
+        (
+            re.compile(r"(?is)\bwrite\b.{0,80}\b(to|at)\s+`?[./~\w-]"),
+            "write local files",
+        ),
+        (re.compile(r"(?i)\b(git\s+)?commit\b"), "commit changes"),
+        (re.compile(r"(?i)\b(git\s+)?push\b"), "push a branch"),
+        (
+            re.compile(r"(?i)\b(open|create)\s+(a\s+)?(draft\s+)?(pr|pull request)\b|\bgh\s+pr\b"),
+            "open a pull request",
+        ),
+        (
+            re.compile(r"(?i)\b(create|switch|checkout)\b.{0,40}\bbranch\b|\bgit\s+checkout\b"),
+            "change branches",
+        ),
+    )
+    for pattern, reason in patterns:
+        if pattern.search(body):
+            return reason
+    return None
+
+
+def _reject_call_mode_side_effect_brief(kind: str, body: str) -> None:
+    reason = _call_mode_side_effect_reason(body)
+    if reason is None:
+        return
+    raise click.UsageError(
+        f"`conductor ask --kind {kind}` uses call mode and cannot {reason}. "
+        "Use `conductor ask --kind code --effort high`, `conductor exec`, "
+        "or ask for text output on stdout."
     )
 
 
@@ -3338,6 +3382,8 @@ AUTO_REFRESH_COMMANDS = frozenset(
         "route",
     }
 )
+AUTO_REFRESH_VIA_PR_ENV = "CONDUCTOR_AUTO_REFRESH_VIA_PR"
+AUTO_REFRESH_VIA_PR_MODES = frozenset({"auto", "always", "never"})
 
 
 def _env_flag_enabled(name: str) -> bool:
@@ -3345,6 +3391,29 @@ def _env_flag_enabled(name: str) -> bool:
     if value is None:
         return False
     return value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def _auto_refresh_via_pr_mode() -> tuple[str, str | None]:
+    raw = os.environ.get(AUTO_REFRESH_VIA_PR_ENV, "auto").strip().lower()
+    if raw in AUTO_REFRESH_VIA_PR_MODES:
+        return raw, None
+    return (
+        "auto",
+        f"{AUTO_REFRESH_VIA_PR_ENV}={raw!r} is invalid; expected auto, always, or never",
+    )
+
+
+def _repo_scope_auto_refresh_uses_branch(cwd: Path, mode: str) -> tuple[bool, str | None]:
+    if mode == "never":
+        return False, None
+    if mode == "always":
+        return True, None
+    try:
+        current = git_state.current_branch(cwd=cwd)
+        default = git_state.default_branch(cwd=cwd)
+    except GitStateError as e:
+        return False, f"could not determine default branch; refreshing in place: {e}"
+    return current is not None and current == default, None
 
 
 def _maybe_auto_refresh(ctx: click.Context) -> None:
@@ -3401,6 +3470,40 @@ def _maybe_auto_refresh(ctx: click.Context) -> None:
                     err=True,
                 )
         if not any(repo_decision.stale for repo_decision in repo_decisions):
+            return
+        mode, mode_warning = _auto_refresh_via_pr_mode()
+        if mode_warning:
+            click.echo(f"[conductor] auto-refresh warning: {mode_warning}", err=True)
+        via_branch, branch_warning = _repo_scope_auto_refresh_uses_branch(cwd, mode)
+        if branch_warning:
+            click.echo(f"[conductor] auto-refresh warning: {branch_warning}", err=True)
+        if via_branch:
+            version = __version__.split("+", 1)[0]
+            branch = f"chore/conductor-refresh-v{version}"
+            result = _refresh_current_repo_scope_on_branch(
+                cwd,
+                branch=branch,
+                version=__version__,
+            )
+            if result.status in {"failed", "needs-attention", "skipped"}:
+                click.echo(
+                    "[conductor] auto-refresh warning: "
+                    f"{result.status}: {result.detail}",
+                    err=True,
+                )
+                return
+            if result.status == "committed":
+                click.echo(
+                    "[conductor] auto-refreshed repo-scope integration files "
+                    f"on {branch} ({result.detail})",
+                    err=True,
+                )
+            elif result.status == "unchanged":
+                click.echo(
+                    "[conductor] repo-scope integration refresh branch "
+                    f"{branch} is already current",
+                    err=True,
+                )
             return
         report = agent_wiring.refresh_repo_scope(cwd, version=__version__)
         for path, reason in report.skipped:
@@ -3644,6 +3747,8 @@ def ask(
         cwd=cwd,
         attach=attach,
     )
+    if plan.mode == "call":
+        _reject_call_mode_side_effect_brief(kind, brief_input.body)
     if plan.mode == "exec":
         _warn_if_short_exec_brief(brief_input, allow_short_brief=allow_short_brief)
     if plan.mode not in {"review", "council"}:
@@ -4831,6 +4936,7 @@ def _append_previous_phase_results(body: str, summaries: list[str]) -> str:
 
 SWARM_SUCCESS_STATUSES = frozenset({"shipped", "no-changes"})
 SWARM_BRANCH_PREFIX = "feat/swarm"
+SWARM_WORKTREE_LOCK = threading.Lock()
 
 
 @dataclass
@@ -4872,6 +4978,34 @@ def _sanitize_swarm_stem(path: str) -> str:
 
 def _swarm_branch_for_brief(path: str) -> str:
     return f"{SWARM_BRANCH_PREFIX}/{_sanitize_swarm_stem(path)}"
+
+
+def _swarm_worktree_for_brief(path: str, *, repo_root: Path) -> Path:
+    return (repo_root / ".cache" / "conductor" / "swarm" / _sanitize_swarm_stem(path)).resolve()
+
+
+def _validate_swarm_briefs(briefs: tuple[str, ...], *, repo_root: Path) -> None:
+    seen_branches: dict[str, str] = {}
+    for brief_path in briefs:
+        branch = _swarm_branch_for_brief(brief_path)
+        if branch in seen_branches:
+            raise click.UsageError(
+                f"--brief {brief_path!r} and {seen_branches[branch]!r} both map to "
+                f"{branch!r}; rename one brief so swarm branches are unique."
+            )
+        seen_branches[branch] = brief_path
+
+        brief = Path(brief_path)
+        if not brief.is_absolute():
+            brief = (repo_root / brief).resolve()
+        try:
+            body = brief.read_text(encoding="utf-8").strip()
+        except OSError as e:
+            raise click.UsageError(
+                f"could not read --brief {brief_path!r}: {e.strerror or e}"
+            ) from e
+        if not body:
+            raise click.UsageError(f"brief is empty after stripping whitespace: {brief_path!r}")
 
 
 def _run_swarm_git(
@@ -4918,7 +5052,8 @@ def _swarm_dirty_paths(worktree: Path) -> list[str]:
 
 
 def _remove_swarm_worktree(worktree: Path, *, repo_root: Path) -> None:
-    _run_swarm_git(["worktree", "remove", str(worktree)], cwd=repo_root)
+    with SWARM_WORKTREE_LOCK:
+        _run_swarm_git(["worktree", "remove", str(worktree)], cwd=repo_root)
 
 
 def _extract_pr_url(output: str) -> str | None:
@@ -5023,8 +5158,7 @@ def _run_swarm_task(
     started_at = time.monotonic()
     repo_root = _swarm_repo_root()
     branch = _swarm_branch_for_brief(brief_path)
-    task_id = _sanitize_swarm_stem(brief_path)
-    worktree = (repo_root / ".cache" / "conductor" / "swarm" / task_id).resolve()
+    worktree = _swarm_worktree_for_brief(brief_path, repo_root=repo_root)
     brief = Path(brief_path)
     if not brief.is_absolute():
         brief = (repo_root / brief).resolve()
@@ -5043,10 +5177,11 @@ def _run_swarm_task(
     failure_reason: str | None = None
     try:
         worktree.parent.mkdir(parents=True, exist_ok=True)
-        _run_swarm_git(
-            ["worktree", "add", str(worktree), "-b", branch, base_ref],
-            cwd=repo_root,
-        )
+        with SWARM_WORKTREE_LOCK:
+            _run_swarm_git(
+                ["worktree", "add", str(worktree), "-b", branch, base_ref],
+                cwd=repo_root,
+            )
         created_worktree = True
         if not as_json:
             click.echo(f"[conductor] swarm task started: {brief_path} -> {branch}", err=True)
@@ -5158,6 +5293,25 @@ def _run_swarm_task(
             err=True,
         )
     return result
+
+
+def _failed_swarm_thread_result(brief_path: str, error: BaseException) -> SwarmTaskResult:
+    repo_root = _swarm_repo_root()
+    branch = _swarm_branch_for_brief(brief_path)
+    worktree = _swarm_worktree_for_brief(brief_path, repo_root=repo_root)
+    message = f"internal swarm task error: {error}"
+    click.echo(f"[conductor] swarm task crashed: {brief_path}; {message}", err=True)
+    return SwarmTaskResult(
+        brief=brief_path,
+        branch=branch,
+        worktree=str(worktree),
+        status="failed",
+        commits=0,
+        pr_url=None,
+        merge_sha=None,
+        duration_ms=0,
+        failure_reason=message,
+    )
 
 
 DEFAULT_AUTO_PHASE_ANCHORS: tuple[str, ...] = (
@@ -6247,9 +6401,10 @@ def exec_cmd(
 )
 @click.option(
     "--max-parallel",
-    default=None,
+    default=1,
     type=click.IntRange(min=1),
-    hidden=True,
+    show_default=True,
+    help="Maximum number of swarm tasks to run concurrently.",
 )
 def swarm(
     briefs: tuple[str, ...],
@@ -6261,24 +6416,25 @@ def swarm(
     timeout_sec: int | None,
     as_json: bool,
     keep_worktrees_on_failure: bool,
-    max_parallel: int | None,
+    max_parallel: int,
 ) -> None:
-    """Run independent coding briefs under Conductor's sequential supervisor."""
-    if max_parallel is not None:
-        raise click.UsageError("--max-parallel is a v1 feature; runs sequentially in v0.")
+    """Run independent coding briefs under Conductor's supervisor."""
     if provider_id != "codex":
-        raise click.UsageError("conductor swarm v0 supports --provider codex only.")
+        raise click.UsageError("conductor swarm currently supports --provider codex only.")
 
     results: list[SwarmTaskResult] = []
+    repo_root = _swarm_repo_root()
+    _validate_swarm_briefs(briefs, repo_root=repo_root)
     try:
         base_ref = _run_swarm_git(
             ["rev-parse", "--verify", base_branch],
-            cwd=_swarm_repo_root(),
+            cwd=repo_root,
         ).stdout.strip()
     except RuntimeError as e:
         raise click.UsageError(str(e)) from e
-    for brief_path in briefs:
-        result = _run_swarm_task(
+
+    def run_one(brief_path: str) -> SwarmTaskResult:
+        return _run_swarm_task(
             brief_path=brief_path,
             provider_id=provider_id,
             base_branch=base_branch,
@@ -6290,7 +6446,25 @@ def swarm(
             keep_worktrees_on_failure=keep_worktrees_on_failure,
             as_json=as_json,
         )
-        results.append(result)
+
+    if max_parallel == 1 or len(briefs) == 1:
+        for brief_path in briefs:
+            results.append(run_one(brief_path))
+    else:
+        result_slots: list[SwarmTaskResult | None] = [None] * len(briefs)
+        with ThreadPoolExecutor(max_workers=max_parallel) as executor:
+            futures = {
+                executor.submit(run_one, brief_path): index
+                for index, brief_path in enumerate(briefs)
+            }
+            for future in as_completed(futures):
+                index = futures[future]
+                brief_path = briefs[index]
+                try:
+                    result_slots[index] = future.result()
+                except Exception as e:
+                    result_slots[index] = _failed_swarm_thread_result(brief_path, e)
+        results = [result for result in result_slots if result is not None]
 
     payload = _swarm_summary(results)
     if as_json:
@@ -8089,6 +8263,144 @@ def _consumer_paths_from_config(config_file: Path) -> tuple[str, ...]:
                 f"consumer config `{key}` entries must be strings or tables with `path`"
             )
     return tuple(paths)
+
+
+def _refresh_current_repo_scope_on_branch(
+    path: Path,
+    *,
+    branch: str,
+    version: str,
+) -> _ConsumerRefreshResult:
+    if not path.is_dir():
+        return _ConsumerRefreshResult(path, "failed", "path is not a directory")
+    if _run_repo_command(path, ["git", "rev-parse", "--is-inside-work-tree"]).returncode != 0:
+        return _ConsumerRefreshResult(path, "failed", "path is not a git repository")
+
+    before = _git_status_porcelain(path)
+    if before is None:
+        return _ConsumerRefreshResult(path, "failed", "could not read git status")
+
+    orig_branch_proc = _run_repo_command(path, ["git", "rev-parse", "--abbrev-ref", "HEAD"])
+    orig_branch = orig_branch_proc.stdout.strip() if orig_branch_proc.returncode == 0 else None
+    if not orig_branch:
+        return _ConsumerRefreshResult(path, "failed", "could not read current branch")
+
+    stashed = False
+    if before:
+        stash_msg = f"conductor-refresh-v{version.split('+', 1)[0]} auto-stash"
+        stash = _run_repo_command(path, ["git", "stash", "push", "-u", "-m", stash_msg])
+        if stash.returncode != 0:
+            return _ConsumerRefreshResult(
+                path, "failed", _command_failure_detail(stash, "git stash push")
+            )
+        stashed = True
+
+    def _restore(result: _ConsumerRefreshResult) -> _ConsumerRefreshResult:
+        back = _run_repo_command(path, ["git", "checkout", orig_branch])
+        if back.returncode != 0:
+            detail = (
+                f"refresh ran but could not return to {orig_branch}; "
+                "stash@{0} preserved for manual resolution"
+                if stashed
+                else f"refresh ran but could not return to {orig_branch}; "
+                "manual cleanup required"
+            )
+            return _ConsumerRefreshResult(
+                result.path,
+                "needs-attention",
+                detail,
+                branch=result.branch,
+                commit=result.commit,
+                stash_status="preserved" if stashed else "none",
+            )
+        if not stashed:
+            if result.status == "committed":
+                return replace(result, detail=f"no changes left on {orig_branch}")
+            return result
+        pop = _run_repo_command(path, ["git", "stash", "pop"])
+        if pop.returncode != 0:
+            return _ConsumerRefreshResult(
+                result.path,
+                "needs-attention",
+                f"refresh committed on {result.branch}; auto-stash pop "
+                f"conflicted on {orig_branch}; stash@{{0}} preserved for "
+                "manual resolution",
+                branch=result.branch,
+                commit=result.commit,
+                stash_status="preserved",
+            )
+        detail = (
+            f"operator changes restored on {orig_branch}"
+            if result.status == "committed"
+            else f"{result.detail} (auto-stashed and restored)"
+        )
+        return replace(result, detail=detail, stash_status="popped")
+
+    checkout = _checkout_refresh_branch(path, branch)
+    if checkout is not None:
+        return _restore(_ConsumerRefreshResult(path, "failed", checkout, branch=branch))
+
+    from conductor import agent_wiring
+
+    report = agent_wiring.refresh_repo_scope(path, version=version)
+    if report.skipped and not report.refreshed:
+        skipped = "; ".join(f"{item}: {reason}" for item, reason in report.skipped)
+        return _restore(
+            _ConsumerRefreshResult(
+                path,
+                "needs-attention",
+                f"refresh skipped: {skipped}",
+                branch=branch,
+            )
+        )
+
+    after = _git_status_porcelain(path)
+    if after is None:
+        return _restore(
+            _ConsumerRefreshResult(path, "failed", "could not read git status", branch=branch)
+        )
+    if not after:
+        return _restore(
+            _ConsumerRefreshResult(
+                path,
+                "unchanged",
+                "integration files already current",
+                branch=branch,
+            )
+        )
+
+    add = _run_repo_command(path, ["git", "add", "--all"])
+    if add.returncode != 0:
+        return _restore(
+            _ConsumerRefreshResult(
+                path,
+                "failed",
+                _command_failure_detail(add, "git add --all"),
+                branch=branch,
+            )
+        )
+    message = f"Refresh conductor integrations to v{version.split('+', 1)[0]}"
+    commit = _run_repo_command(path, ["git", "commit", "-m", message])
+    if commit.returncode != 0:
+        return _restore(
+            _ConsumerRefreshResult(
+                path,
+                "failed",
+                _command_failure_detail(commit, "git commit"),
+                branch=branch,
+            )
+        )
+    sha = _run_repo_command(path, ["git", "rev-parse", "--short", "HEAD"])
+    commit_sha = sha.stdout.strip() if sha.returncode == 0 else None
+    return _restore(
+        _ConsumerRefreshResult(
+            path,
+            "committed",
+            f"no changes left on {orig_branch}",
+            branch=branch,
+            commit=commit_sha,
+        )
+    )
 
 
 def _refresh_one_consumer_repo(

--- a/src/conductor/providers/_http_client.py
+++ b/src/conductor/providers/_http_client.py
@@ -1,0 +1,53 @@
+"""Shared HTTP client helpers for provider adapters."""
+
+from __future__ import annotations
+
+import logging
+import ssl
+
+import httpx
+
+from conductor.providers.interface import ProviderHTTPError
+
+_LOG = logging.getLogger(__name__)
+
+
+def provider_http_client(*, timeout: float | int | httpx.Timeout | None) -> httpx.Client:
+    """Create an httpx client, recovering from stale CA bundle paths.
+
+    httpx normally loads certifi's CA bundle while constructing the client. In
+    packaged installs that bundle path can occasionally point at a file that no
+    longer exists after an upgrade. That raises ``FileNotFoundError`` before a
+    request exists, so provider-level ``httpx.HTTPError`` handling never runs.
+    Retrying with an explicit OS-default SSL context preserves verification
+    while avoiding the stale certifi path.
+    """
+    try:
+        return httpx.Client(timeout=timeout)
+    except FileNotFoundError as e:
+        verify_context = _fallback_verify_context(e)
+        try:
+            return httpx.Client(timeout=timeout, verify=verify_context)
+        except FileNotFoundError as fallback_error:
+            raise ProviderHTTPError(_missing_ca_message(fallback_error)) from fallback_error
+
+
+def _fallback_verify_context(error: FileNotFoundError) -> ssl.SSLContext:
+    try:
+        context = ssl.create_default_context(cafile=None, capath=None, cadata=None)
+    except OSError as fallback_error:
+        raise ProviderHTTPError(_missing_ca_message(error)) from fallback_error
+
+    filename = getattr(error, "filename", None)
+    location = f" at {filename}" if filename else ""
+    _LOG.warning(
+        "httpx could not load the configured CA bundle%s; retrying with the OS default trust store",
+        location,
+    )
+    return context
+
+
+def _missing_ca_message(error: FileNotFoundError) -> str:
+    filename = getattr(error, "filename", None)
+    location = f" at {filename}" if filename else ""
+    return f"failed to load TLS CA bundle{location}: {error}"

--- a/src/conductor/providers/openrouter.py
+++ b/src/conductor/providers/openrouter.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
     from conductor.session_log import SessionLog
 
 from . import openrouter_catalog
+from ._http_client import provider_http_client
 
 _LOG = logging.getLogger(__name__)
 
@@ -176,8 +177,10 @@ class OpenRouterProvider:
 
         url = f"{self._base_url}/models"
         try:
-            with httpx.Client(timeout=timeout_sec) as client:
+            with provider_http_client(timeout=timeout_sec) as client:
                 resp = client.get(url, headers=headers)
+        except ProviderHTTPError as e:
+            return False, str(e)
         except httpx.TimeoutException:
             return False, f"`GET {url}` timed out after {timeout_sec:.0f}s"
         except httpx.HTTPError as e:
@@ -190,7 +193,7 @@ class OpenRouterProvider:
     def _post_chat(self, payload: dict, *, timeout_sec: int | None = None) -> dict:
         try:
             timeout = self._timeout_sec if timeout_sec is None else timeout_sec
-            with httpx.Client(timeout=timeout) as client:
+            with provider_http_client(timeout=timeout) as client:
                 resp = client.post(
                     f"{self._base_url}/chat/completions",
                     headers=self._headers(),

--- a/src/conductor/providers/openrouter_catalog.py
+++ b/src/conductor/providers/openrouter_catalog.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
+from conductor.providers._http_client import provider_http_client
 from conductor.providers.interface import ProviderHTTPError
 
 if TYPE_CHECKING:
@@ -202,7 +203,7 @@ def _is_fresh(snapshot: CatalogSnapshot) -> bool:
 
 def _fetch_catalog() -> CatalogSnapshot:
     try:
-        with httpx.Client(timeout=OPENROUTER_CATALOG_TIMEOUT_SEC) as client:
+        with provider_http_client(timeout=OPENROUTER_CATALOG_TIMEOUT_SEC) as client:
             response = client.get(OPENROUTER_MODELS_URL)
     except httpx.HTTPError as e:
         raise ProviderHTTPError(

--- a/tests/test_cli_auto_refresh.py
+++ b/tests/test_cli_auto_refresh.py
@@ -20,6 +20,21 @@ def _init_git_repo(path) -> None:
     subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, check=True)
 
 
+def _git(path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _configure_git_identity(path) -> None:
+    _git(path, "config", "user.email", "conductor-test@example.com")
+    _git(path, "config", "user.name", "Conductor Test")
+
+
 def test_auto_refresh_current_user_scope_is_silent(tmp_path, monkeypatch):
     _isolate_user_scope(tmp_path, monkeypatch)
     monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
@@ -69,6 +84,98 @@ def test_auto_refresh_stale_repo_scope_updates_files(tmp_path, monkeypatch):
         f"[conductor] refreshed repo-scope integration files in {repo} to v0.9.0"
         in result.stderr
     )
+    assert "<!-- conductor:begin v0.9.0 -->" in (
+        repo / "AGENTS.md"
+    ).read_text(encoding="utf-8")
+
+
+def test_auto_refresh_stale_repo_scope_on_default_branch_uses_refresh_branch(
+    tmp_path, monkeypatch
+):
+    _isolate_user_scope(tmp_path, monkeypatch)
+    repo = tmp_path / "repo-default-branch"
+    repo.mkdir()
+    _init_git_repo(repo)
+    _configure_git_identity(repo)
+    aw.wire_agents_md(cwd=repo, version="0.8.0")
+    _git(repo, "add", "AGENTS.md")
+    _git(repo, "commit", "-m", "Initial conductor wiring")
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+
+    result = CliRunner().invoke(main, ["doctor", "--json"])
+
+    assert result.exit_code == 0, result.output
+    branch = "chore/conductor-refresh-v0.9.0"
+    assert (
+        "[conductor] auto-refreshed repo-scope integration files "
+        f"on {branch} (no changes left on main)"
+    ) in result.stderr
+    assert _git(repo, "branch", "--show-current").stdout.strip() == "main"
+    assert _git(repo, "status", "--porcelain").stdout.strip() == ""
+    assert "<!-- conductor:begin v0.8.0 -->" in (
+        repo / "AGENTS.md"
+    ).read_text(encoding="utf-8")
+    assert "<!-- conductor:begin v0.9.0 -->" in _git(
+        repo,
+        "show",
+        f"{branch}:AGENTS.md",
+    ).stdout
+
+
+def test_auto_refresh_default_branch_restores_operator_changes(
+    tmp_path, monkeypatch
+):
+    _isolate_user_scope(tmp_path, monkeypatch)
+    repo = tmp_path / "repo-dirty-default"
+    repo.mkdir()
+    _init_git_repo(repo)
+    _configure_git_identity(repo)
+    aw.wire_agents_md(cwd=repo, version="0.8.0")
+    (repo / "operator.txt").write_text("baseline\n", encoding="utf-8")
+    _git(repo, "add", "AGENTS.md", "operator.txt")
+    _git(repo, "commit", "-m", "Initial state")
+    (repo / "operator.txt").write_text("operator edits\n", encoding="utf-8")
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+
+    result = CliRunner().invoke(main, ["doctor", "--json"])
+
+    assert result.exit_code == 0, result.output
+    branch = "chore/conductor-refresh-v0.9.0"
+    assert (
+        "[conductor] auto-refreshed repo-scope integration files "
+        f"on {branch} (operator changes restored on main)"
+    ) in result.stderr
+    assert _git(repo, "branch", "--show-current").stdout.strip() == "main"
+    assert (repo / "operator.txt").read_text(encoding="utf-8") == "operator edits\n"
+    assert _git(repo, "status", "--porcelain").stdout.strip() == "M operator.txt"
+    assert "<!-- conductor:begin v0.9.0 -->" in _git(
+        repo,
+        "show",
+        f"{branch}:AGENTS.md",
+    ).stdout
+
+
+def test_auto_refresh_via_pr_never_keeps_in_place_behavior(tmp_path, monkeypatch):
+    _isolate_user_scope(tmp_path, monkeypatch)
+    monkeypatch.setenv("CONDUCTOR_AUTO_REFRESH_VIA_PR", "never")
+    repo = tmp_path / "repo-never"
+    repo.mkdir()
+    _init_git_repo(repo)
+    _configure_git_identity(repo)
+    aw.wire_agents_md(cwd=repo, version="0.8.0")
+    _git(repo, "add", "AGENTS.md")
+    _git(repo, "commit", "-m", "Initial conductor wiring")
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+
+    result = CliRunner().invoke(main, ["doctor", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert "[conductor] refreshed repo-scope integration files" in result.stderr
+    assert _git(repo, "branch", "--show-current").stdout.strip() == "main"
+    assert _git(repo, "status", "--porcelain").stdout.strip() == "M AGENTS.md"
     assert "<!-- conductor:begin v0.9.0 -->" in (
         repo / "AGENTS.md"
     ).read_text(encoding="utf-8")

--- a/tests/test_cli_swarm.py
+++ b/tests/test_cli_swarm.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import threading
 from pathlib import Path
 
 from click.testing import CliRunner
@@ -226,14 +227,86 @@ def test_swarm_sanitizes_brief_stem_for_branch(monkeypatch, tmp_path: Path) -> N
     assert payload["tasks"][0]["branch"] == "feat/swarm/feature-big-thing"
 
 
-def test_swarm_max_parallel_is_v1_usage_error(tmp_path: Path) -> None:
+def test_swarm_max_parallel_runs_tasks_concurrently(monkeypatch, tmp_path: Path) -> None:
     repo = _repo(tmp_path)
-    brief = _brief(repo, "foo.md")
+    first = _brief(repo, "foo.md", "first change")
+    second = _brief(repo, "bar.md", "second change")
+    monkeypatch.chdir(repo)
+    started: set[str] = set()
+    started_lock = threading.Lock()
+    both_started = threading.Event()
+
+    def fake_exec(**kwargs):
+        worktree = Path(kwargs["cwd"])
+        body = kwargs["body"]
+        with started_lock:
+            started.add(body)
+            if len(started) == 2:
+                both_started.set()
+        if not both_started.wait(timeout=2):
+            raise cli._ExecPhaseError(
+                exit_code=1,
+                exit_status="parallelism-missing",
+                message="tasks did not overlap",
+            )
+        filename = f"{body.replace(' ', '-')}.txt"
+        _commit_change(worktree, filename, body)
+        return (
+            CallResponse(
+                text="done",
+                provider="codex",
+                model="codex",
+                duration_ms=1,
+            ),
+            None,
+            None,
+        )
+
+    monkeypatch.setattr(cli, "_run_exec_phase_dispatch", fake_exec)
+    monkeypatch.setattr(cli, "_ship_swarm_pr", _fake_ship)
 
     result = CliRunner().invoke(
         main,
-        ["swarm", "--provider", "codex", "--brief", str(brief), "--max-parallel", "2"],
+        [
+            "swarm",
+            "--provider",
+            "codex",
+            "--brief",
+            str(first),
+            "--brief",
+            str(second),
+            "--max-parallel",
+            "2",
+            "--auto-merge",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert [task["status"] for task in payload["tasks"]] == ["shipped", "shipped"]
+    assert started == {"first change", "second change"}
+
+
+def test_swarm_rejects_duplicate_brief_branch_slugs(monkeypatch, tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    first = _brief(repo, "first/foo.md", "first change")
+    second = _brief(repo, "second/foo.md", "second change")
+    monkeypatch.chdir(repo)
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "swarm",
+            "--provider",
+            "codex",
+            "--brief",
+            str(first),
+            "--brief",
+            str(second),
+        ],
     )
 
     assert result.exit_code == 2
-    assert "--max-parallel is a v1 feature; runs sequentially in v0" in result.output
+    assert "both map to 'feat/swarm/foo'" in result.output

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -506,6 +506,37 @@ def test_ask_research_low_lets_openrouter_auto_select(mocker):
     assert payload["semantic"]["candidates"][0]["models"] == []
 
 
+def test_ask_research_rejects_repo_side_effect_brief(mocker):
+    _stub_all_configured(mocker, {"openrouter"})
+    call_mock = mocker.patch.object(
+        OpenRouterProvider,
+        "call",
+        return_value=_fake_response("openrouter", "openrouter/auto"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "ask",
+            "--kind",
+            "research",
+            "--effort",
+            "medium",
+            "--brief",
+            (
+                "Synthesize a doctrine candidate, write it to "
+                ".cortex/doctrine/candidate.md, commit it, push, and open a PR."
+            ),
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert not call_mock.called
+    assert "uses call mode" in result.output
+    assert "cannot write local files" in result.output
+    assert "conductor ask --kind code --effort high" in result.output
+
+
 def test_ask_code_high_routes_to_codex_exec_with_default_tools(mocker):
     _stub_all_configured(mocker, {"codex"})
     exec_mock = mocker.patch.object(CodexProvider, "exec", return_value=_fake_response("codex"))
@@ -2234,8 +2265,8 @@ def test_exec_cli_max_stall_seconds_zero_disables_watchdog(mocker):
         ("minimal", 10),
         ("low", 15),
         ("medium", 20),
-        ("high", 30),
-        ("max", 40),
+        ("high", 60),
+        ("max", 80),
     ],
 )
 def test_exec_max_iterations_default_scales_by_effort(effort, expected):

--- a/tests/test_codex_review_sentinel.py
+++ b/tests/test_codex_review_sentinel.py
@@ -170,6 +170,72 @@ def test_codex_review_wrapper_accepts_footer_after_sentinel(tmp_path: Path) -> N
     assert not any(line.startswith("exec ") for line in conductor_invocations)
 
 
+def test_codex_review_large_diff_scales_default_review_budget(tmp_path: Path) -> None:
+    repo, env = _make_review_repo(tmp_path)
+    large_body = "".join(f"generated line {i}\n" for i in range(450))
+    (repo / "large.txt").write_text(large_body, encoding="utf-8")
+    subprocess.run(["git", "add", "large.txt"], cwd=repo, env=env, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "large diff"], cwd=repo, env=env, check=True)
+
+    fakes = tmp_path / "fakes"
+    fakes.mkdir()
+    conductor_args = tmp_path / "conductor-args.txt"
+    conductor = fakes / "conductor"
+    conductor.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            printf '%s\\n' "$*" >> "${FAKE_CONDUCTOR_ARGS:?}"
+            case "$1" in
+              doctor)
+                printf '{"configured": true}\\n'
+                ;;
+              review|exec)
+                cat >/dev/null
+                printf 'LGTM\\nCODEX_REVIEW_CLEAN\\n'
+                ;;
+              *)
+                exit 1
+                ;;
+            esac
+            """
+        ),
+        encoding="utf-8",
+    )
+    conductor.chmod(0o755)
+
+    script = Path(__file__).resolve().parent.parent / "scripts" / "codex-review.sh"
+    result = subprocess.run(
+        ["bash", str(script)],
+        cwd=repo,
+        env={
+            **env,
+            "PATH": f"{fakes}:{os.environ.get('PATH', '')}",
+            "CODEX_REVIEW_BASE": "HEAD~1",
+            "CODEX_REVIEW_MODE": "review-only",
+            "CODEX_REVIEW_DISABLE_CACHE": "1",
+            "CODEX_REVIEW_TIMEOUT": "",
+            "CODEX_REVIEW_MAX_STALL_SEC": "",
+            "FAKE_CONDUCTOR_ARGS": str(conductor_args),
+            "NO_COLOR": "1",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Review budget: large diff" in result.stdout
+    conductor_invocations = conductor_args.read_text(encoding="utf-8").splitlines()
+    review_invocations = [
+        line for line in conductor_invocations if line.startswith("review --auto")
+    ]
+    assert any(
+        "--timeout 900" in line and "--max-stall-seconds 900" in line
+        for line in review_invocations
+    ), conductor_invocations
+
+
 def test_codex_review_wrapper_blocks_malformed_sentinel_even_fail_open(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_openrouter.py
+++ b/tests/test_openrouter.py
@@ -213,6 +213,41 @@ def test_openrouter_family_health_probe_network_error(
     assert "network error" in reason
 
 
+def test_call_recovers_from_missing_default_ca_bundle(configured, mocker):
+    original_client = httpx.Client
+    client_kwargs: list[dict[str, object]] = []
+
+    def client_factory(*args, **kwargs):
+        client_kwargs.append(dict(kwargs))
+        if len(client_kwargs) == 1:
+            raise FileNotFoundError(
+                2,
+                "No such file or directory",
+                "/missing/certifi/cacert.pem",
+            )
+        return original_client(*args, **kwargs)
+
+    mocker.patch("conductor.providers._http_client.httpx.Client", side_effect=client_factory)
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.post("/chat/completions").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "model": OPENROUTER_DEFAULT_MODEL,
+                    "choices": [{"message": {"content": "ok"}}],
+                    "usage": {},
+                },
+            )
+        )
+        response = OpenRouterProvider().call("hi", model=OPENROUTER_DEFAULT_MODEL)
+
+    assert response.text == "ok"
+    assert len(client_kwargs) == 2
+    assert "verify" not in client_kwargs[0]
+    assert "verify" in client_kwargs[1]
+
+
 def test_call_sends_reasoning_effort_and_openrouter_headers(configured):
     captured: dict[str, object] = {}
 

--- a/tests/test_openrouter_catalog.py
+++ b/tests/test_openrouter_catalog.py
@@ -156,6 +156,34 @@ def test_load_catalog_raises_without_cache_on_network_error(catalog_cache):
             openrouter_catalog.load_catalog_snapshot()
 
 
+def test_load_catalog_recovers_from_missing_default_ca_bundle(
+    catalog_response, catalog_cache, mocker
+):
+    original_client = httpx.Client
+    client_kwargs: list[dict[str, object]] = []
+
+    def client_factory(*args, **kwargs):
+        client_kwargs.append(dict(kwargs))
+        if len(client_kwargs) == 1:
+            raise FileNotFoundError(
+                2,
+                "No such file or directory",
+                "/missing/certifi/cacert.pem",
+            )
+        return original_client(*args, **kwargs)
+
+    mocker.patch("conductor.providers._http_client.httpx.Client", side_effect=client_factory)
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.get("/models").mock(return_value=httpx.Response(200, json=catalog_response))
+        snapshot = openrouter_catalog.load_catalog_snapshot()
+
+    assert snapshot.models[0].id == "anthropic/claude-sonnet-4.6"
+    assert len(client_kwargs) == 2
+    assert "verify" not in client_kwargs[0]
+    assert "verify" in client_kwargs[1]
+
+
 def test_read_cached_catalog_returns_none_when_missing(catalog_cache):
     assert openrouter_catalog.read_cached_catalog() is None
 


### PR DESCRIPTION
## Summary

- Recover OpenRouter calls/catalog fetches from stale CA bundle paths.
- Move default-branch repo-scope auto-refresh onto a refresh branch.
- Increase high/max exec iteration caps and reject call-mode briefs that request repo side effects.
- Scale large-diff review budgets and add `conductor swarm --max-parallel`.

## Validation

- `bash -n scripts/codex-review.sh`
- `uv run ruff check ...`
- focused pytest: `207 passed`
- full suite: `1059 passed, 15 skipped`
- pre-push validation passed