### PR TITLE
fix: bound conductor local orchestration waits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,6 @@ Use `--permission-profile read-only` for inspect-only exec work (`Read,Grep,Glob
 
 Because the child has the same ambient authority as the parent, prompts should still be explicit about ownership: whether the child may edit files, run tests, use network, or perform git operations. For PR workflows in this repo, the parent agent still owns commit, push, and PR creation unless the user explicitly delegates those steps.
 
-<!-- conductor:begin v0.10.1 -->
+<!-- conductor:begin v0.10.7 -->
 @~/.conductor/delegation-guidance.md
 <!-- conductor:end -->

--- a/src/conductor/_issue_briefs.py
+++ b/src/conductor/_issue_briefs.py
@@ -15,6 +15,8 @@ class IssueBriefError(RuntimeError):
 
 _EXPLICIT_ISSUE_RE = re.compile(r"^(?P<repo>[^/\s#]+/[^/\s#]+)#(?P<number>[1-9]\d*)$")
 _ISSUE_NUMBER_RE = re.compile(r"^[1-9]\d*$")
+_GIT_REMOTE_TIMEOUT_SEC = 5.0
+_GH_ISSUE_TIMEOUT_SEC = 30.0
 
 
 def build_issue_brief(
@@ -57,6 +59,7 @@ def _owner_repo_from_origin(*, cwd: str | Path | None) -> str:
             cwd=cwd,
             capture_output=True,
             text=True,
+            timeout=_GIT_REMOTE_TIMEOUT_SEC,
             check=True,
         )
     except subprocess.CalledProcessError as e:
@@ -67,6 +70,11 @@ def _owner_repo_from_origin(*, cwd: str | Path | None) -> str:
         ) from e
     except FileNotFoundError as e:
         raise IssueBriefError("--issue <N> requires git to resolve the current repository.") from e
+    except subprocess.TimeoutExpired as e:
+        raise IssueBriefError(
+            f"--issue <N> timed out after {_GIT_REMOTE_TIMEOUT_SEC:.0f}s while "
+            "resolving the current repository origin."
+        ) from e
 
     origin = result.stdout.strip()
     owner_repo = _parse_github_owner_repo(origin)
@@ -108,10 +116,16 @@ def _fetch_issue(owner_repo: str, number: str, *, cwd: str | Path | None) -> dic
             cwd=cwd,
             capture_output=True,
             text=True,
+            timeout=_GH_ISSUE_TIMEOUT_SEC,
             check=True,
         )
     except FileNotFoundError as e:
         raise IssueBriefError("--issue requires the gh CLI; install via brew install gh.") from e
+    except subprocess.TimeoutExpired as e:
+        raise IssueBriefError(
+            f"timed out after {_GH_ISSUE_TIMEOUT_SEC:.0f}s fetching GitHub issue "
+            f"{owner_repo}#{number}. Run {' '.join(command)} to inspect manually."
+        ) from e
     except subprocess.CalledProcessError as e:
         detail = (e.stderr or e.stdout or str(e)).strip()
         raise IssueBriefError(

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -18,10 +18,12 @@ v0.2 additions:
 
 from __future__ import annotations
 
+import contextlib
 import json
 import math
 import os
 import re
+import signal
 import subprocess
 import sys
 import threading
@@ -59,6 +61,7 @@ from conductor.delegation_ledger import (
 from conductor.git_state import (
     DEFAULT_BRANCH_SCAN_LIMIT,
     DEFAULT_KEEP_WORKTREE_DAYS,
+    GIT_STATE_COMMAND_TIMEOUT_SEC,
     AbandonedWorktree,
     BranchScanLimit,
     GitCleanupPlan,
@@ -2028,6 +2031,8 @@ def _invoke_review_with_fallback(
                     task_tags=list(decision.task_tags),
                     prefer=decision.prefer,
                     log_selection=not silent,
+                    timeout_sec=timeout_sec,
+                    max_stall_sec=max_stall_sec,
                 )
             else:
                 response = provider.call(
@@ -2041,6 +2046,8 @@ def _invoke_review_with_fallback(
                         include_patch=True,
                     ),
                     effort=effort,
+                    timeout_sec=timeout_sec,
+                    max_stall_sec=max_stall_sec,
                 )
             repaired_text = ensure_requested_review_sentinel(
                 provider_name=response.provider,
@@ -4857,6 +4864,9 @@ def _exec_failure_status(error: Exception | str) -> str:
     return _delegation_status_from_error(error)
 
 
+_EXEC_PHASE_GIT_TIMEOUT_SEC = 10.0
+
+
 def _git_phase_head(cwd: str | None) -> str | None:
     worktree = cwd or os.getcwd()
     try:
@@ -4865,9 +4875,10 @@ def _git_phase_head(cwd: str | None) -> str | None:
             cwd=worktree,
             capture_output=True,
             text=True,
+            timeout=_EXEC_PHASE_GIT_TIMEOUT_SEC,
             check=True,
         )
-    except (OSError, subprocess.CalledProcessError) as e:
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
         click.echo(
             f"[conductor] warning: could not capture phase git HEAD in {worktree}: {e}",
             err=True,
@@ -4884,9 +4895,10 @@ def _git_phase_output(cwd: str | None, args: list[str]) -> str | None:
             cwd=worktree,
             capture_output=True,
             text=True,
+            timeout=_EXEC_PHASE_GIT_TIMEOUT_SEC,
             check=True,
         )
-    except (OSError, subprocess.CalledProcessError) as e:
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
         click.echo(
             f"[conductor] warning: git {' '.join(args)} failed in {worktree}: {e}",
             err=True,
@@ -4937,6 +4949,9 @@ def _append_previous_phase_results(body: str, summaries: list[str]) -> str:
 SWARM_SUCCESS_STATUSES = frozenset({"shipped", "no-changes"})
 SWARM_BRANCH_PREFIX = "feat/swarm"
 SWARM_WORKTREE_LOCK = threading.Lock()
+SWARM_GIT_TIMEOUT_SEC = 30.0
+SWARM_GH_TIMEOUT_SEC = 30.0
+SWARM_SHIP_TIMEOUT_SEC = 1800.0
 
 
 @dataclass
@@ -5020,8 +5035,14 @@ def _run_swarm_git(
             cwd=cwd,
             capture_output=True,
             text=True,
+            timeout=SWARM_GIT_TIMEOUT_SEC,
             check=False,
         )
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(
+            f"`git {' '.join(args)}` timed out after {SWARM_GIT_TIMEOUT_SEC:.0f}s "
+            f"in {cwd}"
+        ) from e
     except OSError as e:
         raise RuntimeError(f"`git {' '.join(args)}` failed to start in {cwd}: {e}") from e
     if check and result.returncode != 0:
@@ -5082,8 +5103,16 @@ def _swarm_pr_merge_sha(worktree: Path, pr_url: str | None) -> str | None:
             cwd=worktree,
             capture_output=True,
             text=True,
+            timeout=SWARM_GH_TIMEOUT_SEC,
             check=False,
         )
+    except subprocess.TimeoutExpired as e:
+        click.echo(
+            f"[conductor] warning: gh pr view timed out after {SWARM_GH_TIMEOUT_SEC:.0f}s "
+            f"for {pr_url}: {e}",
+            err=True,
+        )
+        return None
     except OSError as e:
         click.echo(
             f"[conductor] warning: could not inspect PR merge commit for {pr_url}: {e}",
@@ -5111,13 +5140,30 @@ def _ship_swarm_pr(
     args = ["bash", str(script), "--base", base_branch]
     if auto_merge:
         args.append("--auto-merge")
-    result = subprocess.run(
-        args,
-        cwd=worktree,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            args,
+            cwd=worktree,
+            capture_output=True,
+            text=True,
+            timeout=SWARM_SHIP_TIMEOUT_SEC,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as e:
+        output = "\n".join(
+            part
+            for part in (_timeout_output_text(e.stdout), _timeout_output_text(e.stderr))
+            if part
+        ).strip()
+        pr_url = _extract_pr_url(output)
+        status = "review-blocked" if auto_merge and pr_url else "failed"
+        reason = (
+            f"open-pr.sh timed out after {SWARM_SHIP_TIMEOUT_SEC:.0f}s"
+            + (f": {output}" if output else "")
+        )
+        return status, pr_url, reason
+    except OSError as e:
+        return "failed", None, f"open-pr.sh failed to start: {e}"
     output = f"{result.stdout}\n{result.stderr}".strip()
     pr_url = _extract_pr_url(output)
     if result.returncode != 0:
@@ -5126,6 +5172,14 @@ def _ship_swarm_pr(
         return status, pr_url, reason
     merge_sha = _swarm_pr_merge_sha(worktree, pr_url) if auto_merge else None
     return ("shipped" if auto_merge else "pushed-not-merged"), pr_url, merge_sha
+
+
+def _timeout_output_text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
 
 
 def _swarm_summary(results: list[SwarmTaskResult]) -> dict[str, object]:
@@ -6887,6 +6941,72 @@ def list_cmd(as_json: bool) -> None:
 # --------------------------------------------------------------------------- #
 
 
+class _SmokeDeadlineExpiredError(RuntimeError):
+    pass
+
+
+@contextlib.contextmanager
+def _smoke_deadline(timeout_sec: float):
+    if (
+        timeout_sec <= 0
+        or not hasattr(signal, "setitimer")
+        or threading.current_thread() is not threading.main_thread()
+    ):
+        yield
+        return
+
+    previous_handler = signal.getsignal(signal.SIGALRM)
+    previous_timer = signal.getitimer(signal.ITIMER_REAL)
+
+    def raise_timeout(_signum, _frame) -> None:
+        raise _SmokeDeadlineExpiredError
+
+    signal.signal(signal.SIGALRM, raise_timeout)
+    signal.setitimer(signal.ITIMER_REAL, timeout_sec)
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous_handler)
+        if previous_timer[0] > 0:
+            signal.setitimer(signal.ITIMER_REAL, previous_timer[0], previous_timer[1])
+
+
+def _smoke_provider(name: str, *, provider_timeout: float) -> dict[str, object]:
+    provider = get_provider(name)
+    try:
+        with _smoke_deadline(provider_timeout):
+            ok, reason = provider.smoke()
+    except _SmokeDeadlineExpiredError:
+        ok, reason = False, f"smoke timed out after {provider_timeout:g}s"
+    except Exception as exc:  # noqa: BLE001 - smoke reports every provider failure.
+        ok = False
+        reason = f"smoke raised {type(exc).__name__}: {exc}"
+    return {"provider": name, "ok": ok, "reason": reason}
+
+
+def _smoke_configured_result(
+    name: str, *, provider_timeout: float
+) -> tuple[bool, dict[str, object] | None]:
+    provider = get_provider(name)
+    try:
+        with _smoke_deadline(provider_timeout):
+            ok, _reason = provider.configured()
+    except _SmokeDeadlineExpiredError:
+        return False, {
+            "provider": name,
+            "ok": False,
+            "reason": f"configured check timed out after {provider_timeout:g}s",
+        }
+    except Exception as exc:  # noqa: BLE001 - smoke reports every provider failure.
+        return False, {
+            "provider": name,
+            "ok": False,
+            "reason": f"configured check raised {type(exc).__name__}: {exc}",
+        }
+    return ok, None
+
+
 @main.command()
 @click.argument("provider_id", required=False)
 @click.option(
@@ -6903,7 +7023,19 @@ def list_cmd(as_json: bool) -> None:
     default=False,
     help="Emit results as JSON.",
 )
-def smoke(provider_id: str | None, run_all: bool, as_json: bool) -> None:
+@click.option(
+    "--provider-timeout",
+    type=click.FloatRange(min=0.1),
+    default=30.0,
+    show_default=True,
+    help="Maximum seconds to wait for each provider smoke test.",
+)
+def smoke(
+    provider_id: str | None,
+    run_all: bool,
+    as_json: bool,
+    provider_timeout: float,
+) -> None:
     """Prove a provider's auth + endpoint actually work."""
     if provider_id and run_all:
         raise click.UsageError("pass a provider id OR --all, not both.")
@@ -6915,15 +7047,27 @@ def smoke(provider_id: str | None, run_all: bool, as_json: bool) -> None:
             raise click.UsageError(f"unknown provider {provider_id!r}; known: {known_providers()}")
         targets = [provider_id]
     else:
-        targets = [name for name in known_providers() if get_provider(name).configured()[0]]
+        targets = []
+        results = []
+        any_failed = False
+        for name in known_providers():
+            configured, failure = _smoke_configured_result(
+                name,
+                provider_timeout=provider_timeout,
+            )
+            if failure is not None:
+                results.append(failure)
+                any_failed = True
+            elif configured:
+                targets.append(name)
 
-    results = []
-    any_failed = False
+    if provider_id:
+        results = []
+        any_failed = False
     for name in targets:
-        provider = get_provider(name)
-        ok, reason = provider.smoke()
-        results.append({"provider": name, "ok": ok, "reason": reason})
-        if not ok:
+        result = _smoke_provider(name, provider_timeout=provider_timeout)
+        results.append(result)
+        if not result["ok"]:
             any_failed = True
 
     if as_json:
@@ -7347,13 +7491,22 @@ def _echo_branch_scan_cap(
 
 
 def _run_git_cleanup_command(args: list[str], *, cwd: str | Path | None = None) -> tuple[bool, str]:
-    result = subprocess.run(
-        ["git", *args],
-        cwd=cwd,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=GIT_STATE_COMMAND_TIMEOUT_SEC,
+        )
+    except subprocess.TimeoutExpired:
+        return False, (
+            f"`git {' '.join(args)}` timed out after "
+            f"{GIT_STATE_COMMAND_TIMEOUT_SEC:.0f}s"
+        )
+    except OSError as e:
+        return False, f"`git {' '.join(args)}` failed to start: {e}"
     detail = (result.stderr or result.stdout or "").strip()
     return result.returncode == 0, detail
 
@@ -8482,7 +8635,6 @@ def _refresh_one_consumer_repo(
     init_result = _run_repo_command(
         path,
         [sys.executable, "-m", "conductor.cli", "init", "-y", "--remaining"],
-        timeout=None,
     )
     if init_result.returncode != 0:
         detail = _command_failure_detail(init_result, "conductor init -y --remaining")

--- a/src/conductor/credentials.py
+++ b/src/conductor/credentials.py
@@ -43,6 +43,7 @@ CONDUCTOR_SECRET_SERVICE = "conductor"
 CREDENTIALS_FILE_ENV = "CONDUCTOR_CREDENTIALS_FILE"
 DEFAULT_CREDENTIALS_PATH = Path.home() / ".config" / "conductor" / "credentials.toml"
 KEY_COMMAND_TIMEOUT_SEC = 30.0
+CREDENTIAL_HELPER_TIMEOUT_SEC = 15.0
 
 CredentialSource = Literal["env", "key_command", "keychain"]
 
@@ -323,7 +324,7 @@ def _run_key_command(key: str, command: str) -> str | None:
 
 
 # --------------------------------------------------------------------------- #
-# Keychain — macOS Keychain wrappers (unchanged).
+# Keychain — macOS Keychain wrappers.
 # --------------------------------------------------------------------------- #
 
 
@@ -343,21 +344,29 @@ def set_in_keychain(key: str, value: str) -> None:
         raise RuntimeError(
             "`security` command not found (expected at /usr/bin/security on macOS)"
         )
-    result = subprocess.run(
-        [
-            "security",
-            "add-generic-password",
-            "-s",
-            CONDUCTOR_KEYCHAIN_SERVICE,
-            "-a",
-            key,
-            "-w",
-            value,
-            "-U",
-        ],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            [
+                "security",
+                "add-generic-password",
+                "-s",
+                CONDUCTOR_KEYCHAIN_SERVICE,
+                "-a",
+                key,
+                "-w",
+                value,
+                "-U",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=CREDENTIAL_HELPER_TIMEOUT_SEC,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(
+            f"Keychain write timed out after {CREDENTIAL_HELPER_TIMEOUT_SEC:.0f}s"
+        ) from e
+    except OSError as e:
+        raise RuntimeError(f"Keychain write failed to launch: {e}") from e
     if result.returncode != 0:
         raise RuntimeError(
             f"Keychain write failed ({result.returncode}): {result.stderr.strip()}"
@@ -379,21 +388,29 @@ def set_in_libsecret(key: str, value: str) -> None:
         raise RuntimeError(
             "`secret-tool` not found. Install libsecret-tools or use env / 1Password."
         )
-    result = subprocess.run(
-        [
-            "secret-tool",
-            "store",
-            "--label",
-            f"Conductor {key}",
-            "service",
-            CONDUCTOR_SECRET_SERVICE,
-            "account",
-            key,
-        ],
-        input=value,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            [
+                "secret-tool",
+                "store",
+                "--label",
+                f"Conductor {key}",
+                "service",
+                CONDUCTOR_SECRET_SERVICE,
+                "account",
+                key,
+            ],
+            input=value,
+            capture_output=True,
+            text=True,
+            timeout=CREDENTIAL_HELPER_TIMEOUT_SEC,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(
+            f"libsecret write timed out after {CREDENTIAL_HELPER_TIMEOUT_SEC:.0f}s"
+        ) from e
+    except OSError as e:
+        raise RuntimeError(f"libsecret write failed to launch: {e}") from e
     if result.returncode != 0:
         raise RuntimeError(
             f"libsecret write failed ({result.returncode}): {result.stderr.strip()}"
@@ -404,35 +421,61 @@ def delete_from_libsecret(key: str) -> None:
     """Remove a Conductor libsecret entry; silently OK if it doesn't exist."""
     if not libsecret_available():
         return
-    subprocess.run(
-        [
-            "secret-tool",
-            "clear",
-            "service",
-            CONDUCTOR_SECRET_SERVICE,
-            "account",
-            key,
-        ],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        subprocess.run(
+            [
+                "secret-tool",
+                "clear",
+                "service",
+                CONDUCTOR_SECRET_SERVICE,
+                "account",
+                key,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=CREDENTIAL_HELPER_TIMEOUT_SEC,
+        )
+    except subprocess.TimeoutExpired:
+        print(
+            f"conductor: warning: libsecret delete for {key} timed out after "
+            f"{CREDENTIAL_HELPER_TIMEOUT_SEC:.0f}s.",
+            file=sys.stderr,
+        )
+    except OSError as e:
+        print(
+            f"conductor: warning: libsecret delete for {key} failed to launch: {e}",
+            file=sys.stderr,
+        )
 
 
 def delete_from_keychain(key: str) -> None:
     """Remove a Conductor Keychain entry; silently OK if it doesn't exist."""
     if sys.platform != "darwin" or not shutil.which("security"):
         return
-    subprocess.run(
-        [
-            "security",
-            "delete-generic-password",
-            "-s",
-            CONDUCTOR_KEYCHAIN_SERVICE,
-            "-a",
-            key,
-        ],
-        capture_output=True,
-    )
+    try:
+        subprocess.run(
+            [
+                "security",
+                "delete-generic-password",
+                "-s",
+                CONDUCTOR_KEYCHAIN_SERVICE,
+                "-a",
+                key,
+            ],
+            capture_output=True,
+            timeout=CREDENTIAL_HELPER_TIMEOUT_SEC,
+        )
+    except subprocess.TimeoutExpired:
+        print(
+            f"conductor: warning: Keychain delete for {key} timed out after "
+            f"{CREDENTIAL_HELPER_TIMEOUT_SEC:.0f}s.",
+            file=sys.stderr,
+        )
+    except OSError as e:
+        print(
+            f"conductor: warning: Keychain delete for {key} failed to launch: {e}",
+            file=sys.stderr,
+        )
 
 
 def keychain_has(key: str) -> bool:
@@ -443,19 +486,34 @@ def keychain_has(key: str) -> bool:
 def _keychain_find(key: str) -> str | None:
     if not shutil.which("security"):
         return None
-    result = subprocess.run(
-        [
-            "security",
-            "find-generic-password",
-            "-s",
-            CONDUCTOR_KEYCHAIN_SERVICE,
-            "-a",
-            key,
-            "-w",
-        ],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            [
+                "security",
+                "find-generic-password",
+                "-s",
+                CONDUCTOR_KEYCHAIN_SERVICE,
+                "-a",
+                key,
+                "-w",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=CREDENTIAL_HELPER_TIMEOUT_SEC,
+        )
+    except subprocess.TimeoutExpired:
+        print(
+            f"conductor: warning: Keychain lookup for {key} timed out after "
+            f"{CREDENTIAL_HELPER_TIMEOUT_SEC:.0f}s.",
+            file=sys.stderr,
+        )
+        return None
+    except OSError as e:
+        print(
+            f"conductor: warning: Keychain lookup for {key} failed to launch: {e}",
+            file=sys.stderr,
+        )
+        return None
     if result.returncode != 0:
         return None
     value = result.stdout.rstrip("\n")

--- a/src/conductor/git_state.py
+++ b/src/conductor/git_state.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 DEFAULT_BRANCH_SCAN_LIMIT = 50
 DEFAULT_KEEP_WORKTREE_DAYS = 7
+GIT_STATE_COMMAND_TIMEOUT_SEC = 10.0
 
 
 @dataclass(frozen=True)
@@ -97,7 +98,12 @@ def _git(
             check=False,
             capture_output=True,
             text=True,
+            timeout=GIT_STATE_COMMAND_TIMEOUT_SEC,
         )
+    except subprocess.TimeoutExpired as e:
+        raise GitStateError(
+            f"`git {' '.join(args)}` timed out after {GIT_STATE_COMMAND_TIMEOUT_SEC:.0f}s"
+        ) from e
     except OSError as e:
         raise GitStateError(f"`git {' '.join(args)}` failed to start: {e}") from e
     if check and result.returncode != 0:

--- a/src/conductor/providers/_startup_lock.py
+++ b/src/conductor/providers/_startup_lock.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 StartupProcessSnapshot = tuple[int, str]
 SnapshotProvider = Callable[[], StartupProcessSnapshot]
 
-STARTUP_LOCK_TIMEOUT_SEC = 30.0
+STARTUP_LOCK_TIMEOUT_SEC = 5.0
 
 
 @dataclass

--- a/src/conductor/providers/cli_auth.py
+++ b/src/conductor/providers/cli_auth.py
@@ -46,6 +46,7 @@ _AUTH_TEXT_SIGNALS = (
     "login --with-api-key",
 )
 _LOG = logging.getLogger(__name__)
+STARTUP_LOCK_MAX_HOLD_SEC = 2.0
 
 
 @dataclass(frozen=True)
@@ -205,12 +206,12 @@ def run_subprocess_with_live_stderr(
     tracker: AuthPromptTracker,
     popen_factory,
     startup_lock: contextlib.AbstractContextManager | None = None,
+    startup_lock_max_hold_sec: float | None = STARTUP_LOCK_MAX_HOLD_SEC,
     start_new_session: bool = False,
     cleanup_process_group: bool = False,
 ) -> CapturedProcessResult:
     """Run a subprocess while inspecting stderr for auth prompts live."""
 
-    start = time.monotonic()
     lock_context = startup_lock or contextlib.nullcontext()
     with lock_context as startup_lock_handle:
         process: subprocess.Popen[str] | None = None
@@ -224,6 +225,7 @@ def run_subprocess_with_live_stderr(
             env=env,
             start_new_session=start_new_session,
         )
+        start = time.monotonic()
         child_pgid = process.pid if cleanup_process_group else None
 
         parts: dict[str, list[str]] = {"stdout": [], "stderr": []}
@@ -257,6 +259,13 @@ def run_subprocess_with_live_stderr(
         try:
             while True:
                 now = time.monotonic()
+                if (
+                    startup_lock_max_hold_sec is not None
+                    and not saw_output
+                    and now - start >= startup_lock_max_hold_sec
+                ):
+                    release_startup_lock(startup_lock_handle)
+
                 if timeout is not None and now - start > timeout:
                     _terminate_process(process, child_pgid=child_pgid)
                     stdout_thread.join(timeout=1)

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -33,7 +33,7 @@ from conductor.offline_mode import _cache_dir
 from conductor.orphan_detect import find_orphan_codex_processes, format_orphan_hints
 from conductor.providers._startup_lock import codex_startup_lock, release_startup_lock
 from conductor.providers._tool_weights import ToolBudgetCounter
-from conductor.providers.cli_auth import AuthPromptTracker
+from conductor.providers.cli_auth import STARTUP_LOCK_MAX_HOLD_SEC, AuthPromptTracker
 from conductor.providers.interface import (
     CallResponse,
     ProviderConfigError,
@@ -1129,7 +1129,6 @@ class CodexProvider:
         strict_stall: bool,
         max_iterations: int | None,
     ) -> CallResponse:
-        start = time.monotonic()
         startup_lock_context = codex_startup_lock(
             session_log=session_log,
             snapshot_provider=self._codex_startup_lock_snapshot,
@@ -1145,6 +1144,7 @@ class CodexProvider:
                 cwd=cwd,
                 env=os.environ.copy(),
             )
+            start = time.monotonic()
         except BaseException:
             release_startup_lock(startup_lock_handle)
             startup_lock_context.__exit__(*sys.exc_info())
@@ -1221,6 +1221,7 @@ class CodexProvider:
         heartbeat_log_offset = 0
         session_id_emitted = False
         initial_stall_event_seen = False
+        saw_output = False
         stdout_event_buffer = ""
         stderr_failure_tail = ""
         tool_budget = ToolBudgetCounter()
@@ -1228,6 +1229,9 @@ class CodexProvider:
         try:
             while True:
                 now = time.monotonic()
+                if not saw_output and now - start >= STARTUP_LOCK_MAX_HOLD_SEC:
+                    release_startup_lock(startup_lock_handle)
+
                 if process.poll() is not None and stream_q.empty():
                     break
 
@@ -1360,6 +1364,7 @@ class CodexProvider:
                     continue
 
                 release_startup_lock(startup_lock_handle)
+                saw_output = True
                 if stream_name == "stderr":
                     stderr_parts.append(item)
                     last_output = time.monotonic()

--- a/src/conductor/providers/gemini.py
+++ b/src/conductor/providers/gemini.py
@@ -70,6 +70,7 @@ GEMINI_AUTH_ENV_VARS = (
     "GOOGLE_API_KEY",
     "GOOGLE_APPLICATION_CREDENTIALS",
 )
+GEMINI_TRUST_WORKSPACE_ENV = "GEMINI_CLI_TRUST_WORKSPACE"
 # Default OAuth credentials file written by the CLI's first-run browser
 # flow. Override per-instance via the constructor for tests.
 GEMINI_DEFAULT_OAUTH_CREDS_PATH = Path.home() / ".gemini" / "oauth_creds.json"
@@ -546,6 +547,8 @@ class GeminiProvider:
         # Gemini CLI thinking budget support is evolving; pass via env var as
         # a forward-compatible hook. Ignored by versions that don't read it.
         env_overrides: dict[str, str] = {}
+        if approval_mode == "yolo":
+            env_overrides[GEMINI_TRUST_WORKSPACE_ENV] = "true"
         if thinking_budget:
             env_overrides["GEMINI_THINKING_BUDGET"] = str(thinking_budget)
         proc_env = {**os.environ, **env_overrides} if env_overrides else None

--- a/src/conductor/providers/review_contract.py
+++ b/src/conductor/providers/review_contract.py
@@ -15,6 +15,7 @@ _REVIEW_SENTINELS = (
 )
 _SAFE_BLOCKED_SENTINEL = "CODEX_REVIEW_BLOCKED"
 _DEFAULT_PATCH_CONTEXT_MAX_BYTES = 200_000
+_REVIEW_GIT_TIMEOUT_SEC = 30.0
 
 
 class ReviewContextError(RuntimeError):
@@ -131,15 +132,27 @@ def _uncommitted_patch_chunks(*, cwd: Path) -> list[str]:
 
 
 def _run_git(args: list[str], *, cwd: Path) -> str:
-    result = subprocess.run(
-        ["git", *args],
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=_REVIEW_GIT_TIMEOUT_SEC,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise ReviewContextError(
+            f"`git {' '.join(args)}` timed out after {_REVIEW_GIT_TIMEOUT_SEC:.0f}s "
+            "while building review patch context"
+        ) from e
+    except OSError as e:
+        raise ReviewContextError(
+            f"`git {' '.join(args)}` failed to start while building review patch "
+            f"context: {e}"
+        ) from e
     if result.returncode != 0:
         raise ReviewContextError(
             f"could not build review patch context from `git {' '.join(args)}`: "
@@ -149,15 +162,27 @@ def _run_git(args: list[str], *, cwd: Path) -> str:
 
 
 def _run_git_no_index(args: list[str], *, cwd: Path) -> str:
-    result = subprocess.run(
-        ["git", *args],
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=_REVIEW_GIT_TIMEOUT_SEC,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise ReviewContextError(
+            f"`git {' '.join(args)}` timed out after {_REVIEW_GIT_TIMEOUT_SEC:.0f}s "
+            "while building untracked-file review patch"
+        ) from e
+    except OSError as e:
+        raise ReviewContextError(
+            f"`git {' '.join(args)}` failed to start while building untracked-file "
+            f"review patch: {e}"
+        ) from e
     if result.returncode not in {0, 1}:
         raise ReviewContextError(
             f"could not build untracked-file review patch from `git {' '.join(args)}`: "

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -6,6 +6,7 @@ All three call external CLIs. We stub ``subprocess.run`` and
 
 from __future__ import annotations
 
+import errno
 import io
 import json
 import logging
@@ -22,13 +23,18 @@ import pytest
 from click.testing import CliRunner
 
 from conductor.cli import main
+from conductor.providers import _startup_lock
 from conductor.providers.claude import (
     CLAUDE_CALL_FIRST_OUTPUT_TIMEOUT_SEC,
     CLAUDE_EXEC_FIRST_OUTPUT_TIMEOUT_SEC,
     ClaudeProvider,
 )
 from conductor.providers.codex import CODEX_STARTUP_PROBE_CONFIG, CodexProvider
-from conductor.providers.gemini import GEMINI_AUTH_ENV_VARS, GeminiProvider
+from conductor.providers.gemini import (
+    GEMINI_AUTH_ENV_VARS,
+    GEMINI_TRUST_WORKSPACE_ENV,
+    GeminiProvider,
+)
 from conductor.providers.interface import (
     CallResponse,
     ProviderConfigError,
@@ -1979,6 +1985,67 @@ def test_codex_exec_explicit_timeout_is_honored(mocker):
     assert fake.terminated is True
 
 
+def test_codex_exec_releases_startup_lock_when_provider_stays_silent(
+    monkeypatch, mocker, tmp_path
+):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    monkeypatch.setattr("conductor.providers.codex.STARTUP_LOCK_MAX_HOLD_SEC", 0.03)
+
+    lock_state = {"locked": False}
+    lock_guard = threading.Lock()
+
+    def fake_flock(_fd: int, op: int) -> None:
+        with lock_guard:
+            if op & _startup_lock.fcntl.LOCK_UN:
+                lock_state["locked"] = False
+                return
+            if not (op & _startup_lock.fcntl.LOCK_EX):
+                return
+            if lock_state["locked"]:
+                raise OSError(errno.EAGAIN, "locked")
+            lock_state["locked"] = True
+
+    monkeypatch.setattr(_startup_lock.fcntl, "flock", fake_flock)
+
+    popen_times: list[float] = []
+    popen_guard = threading.Lock()
+    first_started = threading.Event()
+    delays = [0.35, 0.0]
+
+    def factory(args, **kwargs):
+        with popen_guard:
+            delay = delays[len(popen_times)]
+            popen_times.append(time.monotonic())
+            if len(popen_times) == 1:
+                first_started.set()
+        fake = _FakePopen(stdout_schedule=[(delay, CODEX_NDJSON)])
+        fake.args = args
+        fake.cwd = kwargs.get("cwd")
+        fake.env = kwargs.get("env")
+        return fake
+
+    mocker.patch("conductor.providers.codex.subprocess.Popen", side_effect=factory)
+
+    def run_one() -> None:
+        CodexProvider().exec("hi", timeout_sec=3, max_stall_sec=None)
+
+    first = threading.Thread(target=run_one)
+    second = threading.Thread(target=run_one)
+
+    first.start()
+    assert first_started.wait(timeout=1)
+    time.sleep(0.08)
+    second.start()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert len(popen_times) == 2
+    assert popen_times[1] - popen_times[0] < 0.25
+
+
 def test_codex_call_keeps_constructor_default_timeout(mocker):
     """Single-turn call() retains the constructor-default HTTP-style timeout
     (180s) — the no-timeout change is scoped to exec(), where long agent
@@ -3016,6 +3083,25 @@ def test_gemini_exec_allows_saved_write_file_response(mocker):
     response = GeminiProvider().exec("write a file", sandbox="workspace-write")
 
     assert "has been saved" in response.text
+
+
+def test_gemini_exec_sets_headless_workspace_trust_env(mocker, monkeypatch):
+    mocker.patch("conductor.providers.gemini.shutil.which", return_value="/usr/bin/gemini")
+    monkeypatch.setenv(GEMINI_TRUST_WORKSPACE_ENV, "false")
+    fake = _FakePopen(stdout_schedule=[(0, GEMINI_JSON)])
+    captured: dict[str, dict[str, str] | None] = {}
+
+    def factory(args, **kwargs):
+        fake.args = args
+        captured["env"] = kwargs.get("env")
+        return fake
+
+    mocker.patch("conductor.providers.gemini.subprocess.Popen", side_effect=factory)
+
+    GeminiProvider().exec("modify this workspace")
+
+    assert captured["env"] is not None
+    assert captured["env"][GEMINI_TRUST_WORKSPACE_ENV] == "true"
 
 
 def test_gemini_review_uses_code_review_extension_command(mocker, monkeypatch):

--- a/tests/test_cli_git_cleanup.py
+++ b/tests/test_cli_git_cleanup.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 import pytest
 from click.testing import CliRunner
 
+from conductor import cli
 from conductor.cli import main
 
 if TYPE_CHECKING:
@@ -166,6 +167,18 @@ def test_git_cleanup_json_shape(repo: Path) -> None:
     assert payload["stale_branches"][0]["name"] == "feat/stale"
     assert payload["abandoned_worktrees"] == []
     assert payload["protected"]
+
+
+def test_git_cleanup_command_timeout_returns_failure(mocker) -> None:
+    mocker.patch(
+        "conductor.cli.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(["git"], 10),
+    )
+
+    ok, detail = cli._run_git_cleanup_command(["branch", "-D", "feat/stale"])
+
+    assert ok is False
+    assert "timed out after 10s" in detail
 
 
 def _stub_all_unconfigured(mocker) -> None:

--- a/tests/test_cli_phase5.py
+++ b/tests/test_cli_phase5.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import time
 
 import pytest
 from click.testing import CliRunner
@@ -288,6 +289,22 @@ def test_smoke_specific_provider_fails_exits_1(mocker):
     assert "bad token" in result.output
 
 
+def test_smoke_specific_provider_timeout_exits_1(mocker):
+    from conductor.providers import KimiProvider
+
+    def slow_smoke(self):
+        time.sleep(1)
+        return True, None
+
+    mocker.patch.object(KimiProvider, "smoke", slow_smoke)
+    result = CliRunner().invoke(
+        main,
+        ["smoke", "kimi", "--provider-timeout", "0.1"],
+    )
+    assert result.exit_code == 1
+    assert "smoke timed out after 0.1s" in result.output
+
+
 def test_smoke_all_only_hits_configured_providers(mocker):
     from conductor.providers import (
         ClaudeProvider,
@@ -308,6 +325,26 @@ def test_smoke_all_only_hits_configured_providers(mocker):
     result = CliRunner().invoke(main, ["smoke", "--all"])
     assert result.exit_code == 0
     assert claude_smoke.called
+
+
+def test_smoke_all_configured_timeout_exits_1(mocker):
+    from conductor.providers import KimiProvider
+
+    _stub_all_unconfigured(mocker)
+
+    def slow_configured(self):
+        time.sleep(1)
+        return True, None
+
+    mocker.patch.object(KimiProvider, "configured", slow_configured)
+
+    result = CliRunner().invoke(
+        main,
+        ["smoke", "--all", "--provider-timeout", "0.1"],
+    )
+
+    assert result.exit_code == 1
+    assert "configured check timed out after 0.1s" in result.output
 
 
 def test_smoke_json_output_shape(mocker):

--- a/tests/test_cli_swarm.py
+++ b/tests/test_cli_swarm.py
@@ -5,6 +5,7 @@ import subprocess
 import threading
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from conductor import cli
@@ -82,6 +83,43 @@ def _fake_ship(worktree: Path, *, base_branch: str, auto_merge: bool):
     if auto_merge:
         return "shipped", "https://github.com/example/repo/pull/123", "abc1234"
     return "pushed-not-merged", "https://github.com/example/repo/pull/123", None
+
+
+def test_run_swarm_git_timeout_surfaces_runtime_error(monkeypatch) -> None:
+    def fake_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(args[0], kwargs["timeout"])
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="timed out after 30s"):
+        cli._run_swarm_git(["status"], cwd=None)
+
+
+def test_ship_swarm_pr_timeout_preserves_detected_pr_url(monkeypatch, tmp_path: Path) -> None:
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    monkeypatch.setattr(cli, "_swarm_repo_root", lambda: tmp_path)
+
+    def fake_run(args, **kwargs):
+        assert kwargs["timeout"] == cli.SWARM_SHIP_TIMEOUT_SEC
+        raise subprocess.TimeoutExpired(
+            args,
+            kwargs["timeout"],
+            output="created https://github.com/example/repo/pull/123",
+        )
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    status, pr_url, reason = cli._ship_swarm_pr(
+        tmp_path,
+        base_branch="main",
+        auto_merge=True,
+    )
+
+    assert status == "review-blocked"
+    assert pr_url == "https://github.com/example/repo/pull/123"
+    assert reason is not None
+    assert "open-pr.sh timed out" in reason
 
 
 def test_swarm_one_brief_succeeds_as_shipped(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -2046,6 +2046,52 @@ def test_exec_issue_missing_gh_errors_clearly(mocker):
     assert "--issue requires the gh CLI; install via brew install gh" in result.output
 
 
+def test_exec_issue_origin_timeout_errors_clearly(mocker):
+    _stub_all_configured(mocker, {"codex"})
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:4] == ["git", "config", "--get", "remote.origin.url"]:
+            raise subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+        raise AssertionError(f"unexpected command: {cmd!r}")
+
+    mocker.patch("conductor._issue_briefs.subprocess.run", side_effect=fake_run)
+
+    result = CliRunner().invoke(
+        main,
+        ["exec", "--with", "codex", "--no-preflight", "--issue", "123"],
+    )
+
+    assert result.exit_code == 2
+    assert "--issue <N> timed out after 5s" in result.output
+
+
+def test_exec_issue_gh_timeout_errors_clearly(mocker):
+    _stub_all_configured(mocker, {"codex"})
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:4] == ["git", "config", "--get", "remote.origin.url"]:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout="git@github.com:autumngarage/conductor.git\n",
+                stderr="",
+            )
+        if cmd[:3] == ["gh", "issue", "view"]:
+            raise subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+        raise AssertionError(f"unexpected command: {cmd!r}")
+
+    mocker.patch("conductor._issue_briefs.subprocess.run", side_effect=fake_run)
+
+    result = CliRunner().invoke(
+        main,
+        ["exec", "--with", "codex", "--no-preflight", "--issue", "123"],
+    )
+
+    assert result.exit_code == 2
+    assert "timed out after 30s fetching GitHub issue" in result.output
+    assert "gh issue view 123 --repo autumngarage/conductor" in result.output
+
+
 def test_exec_issue_not_found_errors_with_recovery_command(mocker):
     _stub_all_configured(mocker, {"codex"})
 

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -50,6 +50,7 @@ def test_set_in_keychain_calls_security(mocker):
     assert args[1] == "add-generic-password"
     assert "-U" in args  # update-if-exists
     assert "-w" in args and args[args.index("-w") + 1] == "secret-value"
+    assert run_mock.call_args.kwargs["timeout"] == credentials.CREDENTIAL_HELPER_TIMEOUT_SEC
 
 
 def test_set_in_keychain_raises_on_non_zero(mocker):
@@ -62,6 +63,18 @@ def test_set_in_keychain_raises_on_non_zero(mocker):
     with pytest.raises(RuntimeError) as exc:
         credentials.set_in_keychain("K", "v")
     assert "denied" in str(exc.value)
+
+
+def test_set_in_keychain_times_out_raises(mocker):
+    mocker.patch.object(credentials.sys, "platform", "darwin")
+    mocker.patch("conductor.credentials.shutil.which", return_value="/usr/bin/security")
+    mocker.patch(
+        "conductor.credentials.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(["security"], 15),
+    )
+
+    with pytest.raises(RuntimeError, match="Keychain write timed out"):
+        credentials.set_in_keychain("K", "v")
 
 
 def test_set_in_keychain_raises_on_non_darwin(mocker):
@@ -89,6 +102,17 @@ def test_keychain_find_returns_none_on_non_zero(mocker):
     assert credentials._keychain_find("missing") is None
 
 
+def test_keychain_find_timeout_warns_and_returns_none(mocker, capsys):
+    mocker.patch("conductor.credentials.shutil.which", return_value="/usr/bin/security")
+    mocker.patch(
+        "conductor.credentials.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(["security"], 15),
+    )
+
+    assert credentials._keychain_find("K") is None
+    assert "Keychain lookup for K timed out" in capsys.readouterr().err
+
+
 def test_keychain_find_returns_none_when_security_absent(mocker):
     mocker.patch("conductor.credentials.shutil.which", return_value=None)
     assert credentials._keychain_find("K") is None
@@ -99,6 +123,44 @@ def test_keychain_has_shortcut(mocker):
     assert credentials.keychain_has("K") is True
     mocker.patch.object(credentials, "_keychain_find", return_value=None)
     assert credentials.keychain_has("K") is False
+
+
+def test_delete_from_keychain_timeout_warns(mocker, capsys):
+    mocker.patch.object(credentials.sys, "platform", "darwin")
+    mocker.patch("conductor.credentials.shutil.which", return_value="/usr/bin/security")
+    mocker.patch(
+        "conductor.credentials.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(["security"], 15),
+    )
+
+    credentials.delete_from_keychain("K")
+
+    assert "Keychain delete for K timed out" in capsys.readouterr().err
+
+
+def test_set_in_libsecret_times_out_raises(mocker):
+    mocker.patch.object(credentials.sys, "platform", "linux")
+    mocker.patch("conductor.credentials.shutil.which", return_value="/usr/bin/secret-tool")
+    mocker.patch(
+        "conductor.credentials.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(["secret-tool"], 15),
+    )
+
+    with pytest.raises(RuntimeError, match="libsecret write timed out"):
+        credentials.set_in_libsecret("K", "v")
+
+
+def test_delete_from_libsecret_timeout_warns(mocker, capsys):
+    mocker.patch.object(credentials.sys, "platform", "linux")
+    mocker.patch("conductor.credentials.shutil.which", return_value="/usr/bin/secret-tool")
+    mocker.patch(
+        "conductor.credentials.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(["secret-tool"], 15),
+    )
+
+    credentials.delete_from_libsecret("K")
+
+    assert "libsecret delete for K timed out" in capsys.readouterr().err
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_git_state.py
+++ b/tests/test_git_state.py
@@ -169,3 +169,14 @@ def test_git_start_failure_is_converted_to_git_state_error(mocker) -> None:
 
     with pytest.raises(GitStateError, match="failed to start"):
         scan_git_state()
+
+
+def test_git_timeout_is_converted_to_git_state_error(mocker) -> None:
+    mocker.patch.object(
+        git_state_mod.subprocess,
+        "run",
+        side_effect=subprocess.TimeoutExpired(["git"], 10),
+    )
+
+    with pytest.raises(GitStateError, match="timed out after 10s"):
+        scan_git_state()

--- a/tests/test_review_cascade.py
+++ b/tests/test_review_cascade.py
@@ -31,6 +31,7 @@ from conductor.providers import (
     KimiProvider,
     OllamaProvider,
     OpenRouterProvider,
+    review_contract,
 )
 from conductor.router import reset_health
 
@@ -126,6 +127,65 @@ def test_review_chain_walks_past_codex_to_next_code_review_provider(mocker) -> N
     assert "claude review failed (stall)" in result.stderr
     assert "codex review failed (stall)" in result.stderr
     assert "claude (stall), codex (stall), openrouter (success)" in result.stderr
+
+
+def test_review_fallback_call_propagates_timeout_flags(mocker) -> None:
+    from conductor.providers.interface import ProviderStalledError
+
+    _stub_all_configured(mocker, {"claude", "codex", "openrouter"})
+    mocker.patch.object(
+        ClaudeProvider,
+        "review",
+        side_effect=ProviderStalledError("claude review stalled"),
+    )
+    mocker.patch.object(
+        CodexProvider,
+        "review",
+        side_effect=ProviderStalledError("codex review stalled"),
+    )
+    openrouter_call = mocker.patch.object(
+        OpenRouterProvider,
+        "call",
+        return_value=_fake_response("openrouter"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "review",
+            "--auto",
+            "--max-fallbacks",
+            "3",
+            "--timeout",
+            "7",
+            "--max-stall-seconds",
+            "3",
+            "--brief",
+            "Review this merge using the project reviewer guide.",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert openrouter_call.call_args.kwargs["timeout_sec"] == 7
+    assert openrouter_call.call_args.kwargs["max_stall_sec"] == 3
+
+
+def test_review_patch_context_git_timeout_surfaces_context_error(
+    mocker, tmp_path: Path
+) -> None:
+    mocker.patch.object(
+        review_contract.subprocess,
+        "run",
+        side_effect=subprocess.TimeoutExpired(["git", "diff"], 30),
+    )
+
+    with pytest.raises(review_contract.ReviewContextError, match="timed out"):
+        review_contract.build_review_patch_context(
+            base="main",
+            commit=None,
+            uncommitted=False,
+            cwd=str(tmp_path),
+        )
 
 
 def test_review_max_fallbacks_caps_total_attempts(mocker) -> None:

--- a/tests/test_startup_lock.py
+++ b/tests/test_startup_lock.py
@@ -139,6 +139,66 @@ def test_live_subprocess_startup_lock_serializes_popen_until_first_output(
     assert popen_times[1] - popen_times[0] >= 0.08
 
 
+def test_live_subprocess_startup_lock_releases_when_provider_stays_silent(
+    monkeypatch, tmp_path
+) -> None:
+    lock_state = {"locked": False}
+    lock_guard = threading.Lock()
+
+    def fake_flock(_fd: int, op: int) -> None:
+        with lock_guard:
+            if op & _startup_lock.fcntl.LOCK_UN:
+                lock_state["locked"] = False
+                return
+            if not (op & _startup_lock.fcntl.LOCK_EX):
+                return
+            if lock_state["locked"]:
+                raise OSError(errno.EAGAIN, "locked")
+            lock_state["locked"] = True
+
+    monkeypatch.setattr(_startup_lock, "_lock_dir", lambda: tmp_path)
+    monkeypatch.setattr(_startup_lock.fcntl, "flock", fake_flock)
+
+    popen_times: list[float] = []
+    popen_guard = threading.Lock()
+    first_started = threading.Event()
+
+    def run_one(stdout_delay: float) -> None:
+        def popen_factory(*_args, **_kwargs):
+            with popen_guard:
+                popen_times.append(time.monotonic())
+                if len(popen_times) == 1:
+                    first_started.set()
+            return _StartupFakePopen(stdout_delay)
+
+        run_subprocess_with_live_stderr(
+            args=["claude"],
+            cwd=None,
+            env=None,
+            timeout=3,
+            provider_name="claude",
+            tracker=AuthPromptTracker("claude"),
+            popen_factory=popen_factory,
+            startup_lock=claude_startup_lock(timeout_sec=1),
+            startup_lock_max_hold_sec=0.03,
+        )
+
+    first = threading.Thread(target=run_one, args=(0.35,))
+    second = threading.Thread(target=run_one, args=(0.0,))
+
+    first.start()
+    assert first_started.wait(timeout=1)
+    time.sleep(0.08)
+    second.start()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert len(popen_times) == 2
+    assert popen_times[1] - popen_times[0] < 0.25
+
+
 def test_startup_lock_timeout_emits_diagnostic_and_proceeds(
     monkeypatch, tmp_path, capsys
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes the conductor timeout/root-cause class where local orchestration could block before provider calls had a chance to complete.

## Root Cause

Several local paths were unbounded or held shared startup locks too long: provider startup locks were held until first output, `smoke --all` could hang inside provider `configured()` / `smoke()`, review fallbacks did not propagate caller deadlines, and several local helper subprocesses had no explicit timeout.

## Changes

- Bound provider startup-lock hold time and start provider wall timers after process launch.
- Add smoke provider deadlines for both configured checks and smoke checks.
- Propagate review fallback timeout/stall flags to call-based providers.
- Add explicit deadlines to credential helpers, issue-brief fetches, review patch git context, git-state scans, swarm helpers, git-cleanup, and phase git summaries.
- Set Gemini headless workspace trust env for yolo exec mode.
- Refresh repo conductor wiring metadata to v0.10.7.

## Validation

- `uv run pytest` -> 1077 passed, 15 skipped
- `uv run ruff check src/conductor tests`
- `uv run mypy .`
- `git diff --check`
- `uv run conductor smoke --all --json --provider-timeout 30`
- `uv run conductor doctor --json`
- `uv run conductor list --json`
- AST audit: all source `subprocess.run(...)` calls have explicit `timeout=`