### PR TITLE
[codex] adopt shared update command surface

### DIFF
--- a/.cursor/rules/conductor-delegation.mdc
+++ b/.cursor/rules/conductor-delegation.mdc
@@ -2,7 +2,7 @@
 description: Use when delegating or routing tasks to a different LLM via the conductor CLI — e.g., cheap second opinions, long-context reads, web search, or offline runs.
 globs: ""
 alwaysApply: false
-managed-by: conductor v0.10.7
+managed-by: conductor v0.10.8
 ---
 
 # Conductor delegation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ If there are zero blocking issues, the review is just: "LGTM."
 
 @.cortex/protocol.md
 
-<!-- conductor:begin v0.10.7 -->
+<!-- conductor:begin v0.10.8 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
 
-<!-- conductor:begin v0.10.7 -->
+<!-- conductor:begin v0.10.8 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ Shipped:
 - `conductor smoke <id>` / `conductor smoke --all [--json]` — proves a provider's auth + endpoint work (cheapest round-trip that exercises the full path).
 - `conductor doctor [--json]` — diagnostic report: which providers are configured, which env vars are set, what's in the macOS Keychain.
 - `conductor init [-y]` — interactive first-run wizard (TTY-detected, `--yes` for non-TTY). For providers needing credentials (`openrouter`, plus OpenRouter-backed `kimi` / `deepseek-*`), prompts, recommends macOS Keychain or Linux `secret-tool` when available, keeps 1Password available via `op read`, runs a setup verification smoke test, and prints the manual env-var fallback when no encrypted store is available.
+- `conductor update [--dry-run] [--check]` — refreshes stale embedded Conductor repo integrations in the current repo and stages the refreshed paths. `--check` exits non-zero when an update is needed.
+- `conductor update-all [--paths ...] [--config-file ...] [--branch ...] [--no-auto-stash]` — batch-refreshes configured consumer repos on review branches. `conductor refresh-consumers` remains as a deprecated compatibility alias and prints a one-line warning.
+- `conductor refresh-on-commit` — hook-mode counterpart to `update`, installed by `conductor init` for pre-commit refresh of stale embedded repo integrations.
 - Credentials resolver (`conductor.credentials`): env var first, then `key_command`, then macOS Keychain under service `conductor`.
 - Offline-mode fallback: on a real connectivity failure (DNS, TCP reset, unreachable host) during `--auto` routing, Conductor prompts once to switch to the local `ollama` provider and remembers that choice for a short window. `conductor call --offline --brief "..."` is the non-interactive form — useful on a plane, in CI, or any time you want to force local. Clear the sticky flag with `--no-offline`. Ollama requests use `CONDUCTOR_OLLAMA_MODEL` when set; when no explicit `--model` is passed and the requested local model is missing, Conductor queries `/api/tags` and retries once with a non-embedding installed chat model.
 
@@ -155,6 +158,11 @@ exactly those files and strips the sentinel blocks, preserving user content.
 
 Diagnose wiring state anytime with `conductor doctor` (JSON shape:
 `--json`).
+Run `conductor update` to refresh stale embedded repo-scope wiring in the
+current repo immediately. Use `conductor update-all` when you intentionally
+need to walk configured consumer repos; `refresh-consumers` still works as a
+deprecated alias for existing scripts. The installed pre-commit hook continues
+to call `conductor refresh-on-commit`.
 
 ## How Sentinel and Touchstone use it
 

--- a/docs/consumers.md
+++ b/docs/consumers.md
@@ -301,6 +301,8 @@ Consumers pin a major version in their own dependency declarations (brew formula
 
 - `conductor list` — runtime provider readiness (READY column, missing-config diagnostics).
 - `conductor doctor` — environment checks, missing tools, configuration gaps.
+- `conductor update` — current-repo refresh for stale embedded Conductor wiring.
+- `conductor update-all` — batch refresh for configured consumer repos.
 - `conductor smoke` — minimal end-to-end test against each configured provider.
 - Routing decisions logged to stderr (suppress with `--silent-route` for clean piping).
 

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -1,4 +1,4 @@
-"""Conductor CLI — call, exec, list, smoke, doctor, init, route, config.
+"""Conductor CLI — call, exec, list, smoke, doctor, init, update, route, config.
 
 v0.2 surface (call/exec):
   conductor call --with <id> [--effort max] --brief "..."
@@ -10,6 +10,8 @@ v0.1 surface (unchanged):
   conductor smoke [<id>] [--all] [--json]
   conductor doctor [--json]
   conductor init [--yes]
+  conductor update [--dry-run] [--check]
+  conductor update-all [--paths PATHS] [--config-file FILE]
 
 v0.2 additions:
   conductor route --tags a,b [--prefer best] [--tools X,Y] [--dry-run]
@@ -225,7 +227,7 @@ CONDUCTOR_REFRESH_HOOK_BLOCK = """- repo: local
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from conductor.agent_wiring import AgentArtifact
+    from conductor.agent_wiring import AgentArtifact, RepoScopeVersionDecision
 
 DEFAULT_REVIEW_MAX_FALLBACKS = 3
 DEFAULT_COUNCIL_ROUNDS = 1
@@ -3387,6 +3389,7 @@ AUTO_REFRESH_COMMANDS = frozenset(
         "init",
         "refresh-consumers",
         "route",
+        "update-all",
     }
 )
 AUTO_REFRESH_VIA_PR_ENV = "CONDUCTOR_AUTO_REFRESH_VIA_PR"
@@ -7845,8 +7848,8 @@ def doctor(as_json: bool) -> None:
         click.echo("    brew upgrade conductor       # CLAUDE.md @-import self-heals on upgrade")
         click.echo("    conductor init               # installs refresh hook by default")
         click.echo("  Immediate manual fallback:")
-        click.echo("    conductor init -y --remaining")
-        click.echo("    conductor refresh-consumers  # force-refresh configured consumer repos")
+        click.echo("    conductor update             # refresh this repo's embedded integrations")
+        click.echo("    conductor update-all         # force-refresh configured consumer repos")
         click.echo("  Prefer the auto paths unless an immediate cross-repo refresh is needed.")
 
     git_state = payload["git_state"]
@@ -8157,6 +8160,111 @@ def refresh_on_commit() -> None:
     sys.exit(_run_refresh_on_commit())
 
 
+@main.command("update")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Show stale repo integrations without writing files.",
+)
+@click.option(
+    "--check",
+    is_flag=True,
+    default=False,
+    help="Exit 1 if repo integrations are stale; do not write files.",
+)
+def update(dry_run: bool, check: bool) -> None:
+    """Refresh stale embedded Conductor repo integrations in this repo."""
+    sys.exit(_run_update_current_repo(dry_run=dry_run, check=check))
+
+
+def _run_update_current_repo(*, dry_run: bool, check: bool) -> int:
+    cwd = Path.cwd()
+    repo_check = _run_repo_command(cwd, ["git", "rev-parse", "--is-inside-work-tree"])
+    if repo_check.returncode != 0:
+        detail = (repo_check.stderr or repo_check.stdout or "").strip()
+        suffix = f": {detail}" if detail else ""
+        raise click.ClickException(f"not a git repository{suffix}")
+
+    stale = _stale_repo_integration_decisions(cwd)
+    if not stale:
+        click.echo("Conductor repo integrations are current.")
+        return 0
+
+    if dry_run or check:
+        heading = (
+            "Conductor repo integrations are stale:"
+            if check
+            else "Would refresh Conductor repo integrations:"
+        )
+        click.echo(heading)
+        _echo_repo_update_plan(stale, cwd=cwd)
+        if check:
+            click.echo("Run `conductor update` to refresh them.")
+            return 1
+        return 0
+
+    try:
+        touched = _refresh_stale_repo_integrations(cwd)
+    except OSError as e:
+        raise click.ClickException(f"refresh failed: {e}") from e
+    except Exception as e:
+        raise click.ClickException(f"internal refresh error: {e}") from e
+
+    if not touched:
+        click.echo("Conductor repo integrations are current.")
+        return 0
+
+    add = _run_repo_command(
+        cwd,
+        ["git", "add", "--", *[_repo_relative_path(path, cwd=cwd) for path in touched]],
+    )
+    if add.returncode != 0:
+        raise click.ClickException(_command_failure_detail(add, "git add"))
+
+    click.echo("Refreshed Conductor repo integrations:")
+    for path in touched:
+        click.echo(f"  {_repo_relative_path(path, cwd=cwd)}")
+    click.echo("Staged refreshed paths.")
+    return 0
+
+
+def _stale_repo_integration_decisions(cwd: Path) -> tuple[RepoScopeVersionDecision, ...]:
+    from conductor import agent_wiring
+
+    return tuple(
+        decision
+        for decision in agent_wiring.repo_scope_version_decisions(
+            cwd,
+            binary_version=__version__,
+        )
+        if decision.stale
+    )
+
+
+def _echo_repo_update_plan(
+    decisions: tuple[RepoScopeVersionDecision, ...],
+    *,
+    cwd: Path,
+) -> None:
+    target_version = __version__.split("+", 1)[0]
+    for decision in decisions:
+        version = decision.version or "unknown"
+        click.echo(
+            f"  {_repo_relative_path(decision.path, cwd=cwd)} "
+            f"(v{version} -> v{target_version})"
+        )
+
+
+def _repo_relative_path(path: Path, *, cwd: Path) -> str:
+    root = cwd.resolve()
+    candidate = path if path.is_absolute() else root / path
+    try:
+        return str(candidate.resolve().relative_to(root))
+    except ValueError:
+        return str(path)
+
+
 def _run_refresh_on_commit() -> int:
     cwd = Path.cwd()
     repo_check = _run_repo_command(cwd, ["git", "rev-parse", "--is-inside-work-tree"])
@@ -8264,8 +8372,13 @@ def _read_path_bytes(path: Path) -> bytes | None:
 
 
 # --------------------------------------------------------------------------- #
-# refresh-consumers — refresh explicit downstream repo wiring
+# update-all / refresh-consumers — refresh explicit downstream repo wiring
 # --------------------------------------------------------------------------- #
+
+
+_REFRESH_CONSUMERS_DEPRECATION = (
+    "[conductor] `refresh-consumers` is deprecated; use `conductor update-all`."
+)
 
 
 @dataclass(frozen=True)
@@ -8281,51 +8394,52 @@ class _ConsumerRefreshResult:
     stash_status: str = "none"
 
 
-@main.command("refresh-consumers")
-@click.option(
-    "--paths",
-    default=None,
-    help="Comma-separated consumer repo paths to refresh. Defaults to empty.",
-)
-@click.option(
-    "--config-file",
-    type=click.Path(path_type=Path, dir_okay=False, exists=True),
-    default=None,
-    help=(
-        'TOML file with operator-owned consumer paths, for example `paths = ["~/repos/Sentinel"]`.'
-    ),
-)
-@click.option(
-    "--branch",
-    "branch_name",
-    default=None,
-    help="Branch name to create or reuse in each repo.",
-)
-@click.option(
-    "--no-auto-stash",
-    "no_auto_stash",
-    is_flag=True,
-    default=False,
-    help=(
-        "Skip repos with uncommitted changes instead of auto-stashing them. "
-        "Default: auto-stash uncommitted changes, refresh, then pop the stash back."
-    ),
-)
-def refresh_consumers(
+def _consumer_refresh_options(function):
+    function = click.option(
+        "--no-auto-stash",
+        "no_auto_stash",
+        is_flag=True,
+        default=False,
+        help=(
+            "Skip repos with uncommitted changes instead of auto-stashing them. "
+            "Default: auto-stash uncommitted changes, refresh, then pop the stash back."
+        ),
+    )(function)
+    function = click.option(
+        "--branch",
+        "branch_name",
+        default=None,
+        help="Branch name to create or reuse in each repo.",
+    )(function)
+    function = click.option(
+        "--config-file",
+        type=click.Path(path_type=Path, dir_okay=False, exists=True),
+        default=None,
+        help=(
+            "TOML file with operator-owned consumer paths, for example "
+            '`paths = ["~/repos/Sentinel"]`.'
+        ),
+    )(function)
+    function = click.option(
+        "--paths",
+        default=None,
+        help="Comma-separated consumer repo paths to refresh. Defaults to empty.",
+    )(function)
+    return function
+
+
+@main.command("update-all")
+@_consumer_refresh_options
+def update_all(
     paths: str | None,
     config_file: Path | None,
     branch_name: str | None,
     no_auto_stash: bool,
 ) -> None:
-    """Refresh Conductor integration blocks in explicitly configured repos.
+    """Refresh Conductor integration blocks in configured consumer repos.
 
-    Manual force-refresh backstop. After `brew upgrade conductor`, drift should
-    self-heal via the CLAUDE.md @-import path and, for embed-only files
-    (Cursor .mdc, AGENTS.md, GEMINI.md), the pre-commit refresh hook installed
-    by default by `conductor init`.
-
-    Use `refresh-consumers` only when you need an immediate cross-repo refresh
-    without waiting for the next commit in each repo.
+    Canonical batch operator. Walks explicit consumer paths and refreshes each
+    repo on a review branch so operators can inspect the integration updates.
 
     Repos with uncommitted changes are auto-stashed by default: stash → refresh
     → pop. If the pop conflicts (rare; happens when operator changes overlap
@@ -8333,6 +8447,44 @@ def refresh_consumers(
     `stash@{0}` for manual resolution. Pass `--no-auto-stash` to revert to the
     older skip-on-dirty behavior.
     """
+    _run_update_all(
+        paths=paths,
+        config_file=config_file,
+        branch_name=branch_name,
+        no_auto_stash=no_auto_stash,
+    )
+
+
+@main.command("refresh-consumers")
+@_consumer_refresh_options
+def refresh_consumers(
+    paths: str | None,
+    config_file: Path | None,
+    branch_name: str | None,
+    no_auto_stash: bool,
+) -> None:
+    """Deprecated alias for `conductor update-all`.
+
+    The alias remains for compatibility while scripts migrate to the shared
+    Autumn Garage `update-all` verb.
+    """
+    click.echo(_REFRESH_CONSUMERS_DEPRECATION, err=True)
+    _run_update_all(
+        paths=paths,
+        config_file=config_file,
+        branch_name=branch_name,
+        no_auto_stash=no_auto_stash,
+    )
+
+
+def _run_update_all(
+    *,
+    paths: str | None,
+    config_file: Path | None,
+    branch_name: str | None,
+    no_auto_stash: bool,
+) -> None:
+    """Refresh Conductor integration blocks in explicitly configured repos."""
     try:
         consumer_paths = _resolve_consumer_repo_paths(paths, config_file)
     except ValueError as e:

--- a/tests/test_cli_phase5.py
+++ b/tests/test_cli_phase5.py
@@ -770,12 +770,12 @@ def test_doctor_warns_before_next_steps_when_one_integration_file_is_behind(
     assert "    brew upgrade conductor" in result.output
     assert "    conductor init               # installs refresh hook by default" in result.output
     assert "  Immediate manual fallback:" in result.output
-    assert "    conductor init -y --remaining" in result.output
-    assert "    conductor refresh-consumers" in result.output
+    assert "    conductor update" in result.output
+    assert "    conductor update-all" in result.output
     assert (
         result.output.index("Auto refresh paths:")
         < result.output.index("Immediate manual fallback:")
-        < result.output.index("conductor refresh-consumers")
+        < result.output.index("conductor update")
     )
     assert (
         result.output.index("Repo integration files behind binary")
@@ -966,23 +966,45 @@ def test_doctor_json_includes_agent_integration(mocker, monkeypatch, tmp_path):
     assert ai["managed_files"] == []
 
 
-def test_refresh_consumers_defaults_to_empty():
-    result = CliRunner().invoke(main, ["refresh-consumers"])
+def test_doctor_exits_nonzero_on_malformed_muted_provider_state():
+    from conductor.agent_wiring import conductor_home
+
+    muted_file = conductor_home() / "muted-providers.toml"
+    muted_file.parent.mkdir(parents=True, exist_ok=True)
+    muted_file.write_text("muted = [", encoding="utf-8")
+
+    result = CliRunner().invoke(main, ["doctor"])
+
+    assert result.exit_code != 0
+    assert "not valid TOML" in result.output
+
+
+def test_update_all_defaults_to_empty():
+    result = CliRunner().invoke(main, ["update-all"])
     assert result.exit_code == 0, result.output
     assert "No consumer repos configured." in result.output
 
 
-def test_refresh_consumers_help_positions_command_as_manual_backstop():
-    result = CliRunner().invoke(main, ["refresh-consumers", "--help"])
+def test_update_all_help_positions_command_as_batch_operator():
+    result = CliRunner().invoke(main, ["update-all", "--help"])
     assert result.exit_code == 0, result.output
     assert "Refresh Conductor integration blocks" in result.output
-    assert "Manual force-refresh backstop" in result.output
-    assert "CLAUDE.md @-import" in result.output
-    assert "conductor init`" in result.output
-    assert "Use `refresh-consumers` only" in result.output
+    assert "Canonical batch operator" in result.output
+    assert "--paths" in result.output
+    assert "--config-file" in result.output
+    assert "--branch" in result.output
+    assert "--no-auto-stash" in result.output
 
 
-def test_refresh_consumers_commits_updated_repo_integration(mocker, tmp_path):
+def test_refresh_consumers_alias_warns_and_still_works():
+    result = CliRunner().invoke(main, ["refresh-consumers"])
+    assert result.exit_code == 0, result.output
+    assert "`refresh-consumers` is deprecated" in result.stderr
+    assert "use `conductor update-all`" in result.stderr
+    assert "No consumer repos configured." in result.output
+
+
+def test_update_all_commits_updated_repo_integration(mocker, tmp_path):
     _stub_all_unconfigured(mocker)
     version = cli_mod.__version__.split("+", 1)[0]
 
@@ -1001,7 +1023,7 @@ def test_refresh_consumers_commits_updated_repo_integration(mocker, tmp_path):
     result = CliRunner().invoke(
         main,
         [
-            "refresh-consumers",
+            "update-all",
             "--paths",
             str(consumer),
             "--branch",

--- a/tests/test_refresh_on_commit.py
+++ b/tests/test_refresh_on_commit.py
@@ -98,6 +98,70 @@ def test_refresh_on_commit_mixed_embedded_and_import_refreshes_only_embedded(
     assert _staged_paths(repo) == ["AGENTS.md"]
 
 
+def test_update_refreshes_stale_embedded_file_and_stages(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+    agent_wiring.wire_agents_md(cwd=repo, version="0.8.9")
+
+    result = CliRunner().invoke(main, ["update"])
+
+    assert result.exit_code == 0, result.output
+    assert "Refreshed Conductor repo integrations:" in result.output
+    assert "AGENTS.md" in result.output
+    assert "<!-- conductor:begin v0.9.0 -->" in (
+        repo / "AGENTS.md"
+    ).read_text(encoding="utf-8")
+    assert _staged_paths(repo) == ["AGENTS.md"]
+
+
+def test_update_dry_run_reports_stale_without_writing(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+    agent_wiring.wire_agents_md(cwd=repo, version="0.8.9")
+
+    result = CliRunner().invoke(main, ["update", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "Would refresh Conductor repo integrations:" in result.output
+    assert "AGENTS.md (v0.8.9 -> v0.9.0)" in result.output
+    assert "<!-- conductor:begin v0.8.9 -->" in (
+        repo / "AGENTS.md"
+    ).read_text(encoding="utf-8")
+    assert _staged_paths(repo) == []
+
+
+def test_update_check_exits_one_for_stale_without_writing(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+    agent_wiring.wire_agents_md(cwd=repo, version="0.8.9")
+
+    result = CliRunner().invoke(main, ["update", "--check"])
+
+    assert result.exit_code == 1, result.output
+    assert "Conductor repo integrations are stale:" in result.output
+    assert "Run `conductor update` to refresh them." in result.output
+    assert "<!-- conductor:begin v0.8.9 -->" in (
+        repo / "AGENTS.md"
+    ).read_text(encoding="utf-8")
+    assert _staged_paths(repo) == []
+
+
+def test_update_check_exits_zero_when_current(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+    agent_wiring.wire_agents_md(cwd=repo, version="0.9.0")
+
+    result = CliRunner().invoke(main, ["update", "--check"])
+
+    assert result.exit_code == 0, result.output
+    assert "Conductor repo integrations are current." in result.output
+    assert _staged_paths(repo) == []
+
+
 def test_init_hooks_creates_pre_commit_config_by_default(tmp_path):
     repo = tmp_path / "repo"
 


### PR DESCRIPTION
## Summary

- Add `conductor update` for current-repo embedded integration refresh with `--dry-run` and `--check`.
- Add canonical `conductor update-all` for configured consumer repo refreshes and keep `refresh-consumers` as a deprecated warning alias.
- Update doctor guidance and docs for the shared Autumn Garage update/update-all/doctor command surface.
- Refresh stale generated repo wiring version stamps to the current binary version.

Fixes #303.

## Root Cause

Conductor exposed repo refresh behavior through hook-oriented and Conductor-specific verbs (`refresh-on-commit`, `refresh-consumers`) but did not provide the shared quartet-level `update` / `update-all` surface from autumn-garage doctrine 0008.

## Validation

- `uv run pytest -q` -> 1082 passed, 16 skipped
- `uv run ruff check src/conductor/cli.py tests/test_refresh_on_commit.py tests/test_cli_phase5.py README.md docs/consumers.md`
- `git diff --check`