### PR TITLE
[codex] record v0.10.9 release

### DIFF
--- a/.cortex/journal/2026-05-09-release-v0.10.9.md
+++ b/.cortex/journal/2026-05-09-release-v0.10.9.md
@@ -1,0 +1,41 @@
+# Release v0.10.9 - shared update command surface
+
+**Date:** 2026-05-09
+**Type:** release
+**Trigger:** T1.10
+**Tag:** v0.10.9
+**Cites:** journal/2026-05-09-pr-305-merged.md
+
+> Conductor v0.10.9 shipped through the GitHub Release and Homebrew tap flow,
+> making the shared `update` / `update-all` command surface available via
+> `brew upgrade conductor`.
+
+## Artifact
+
+- **Kind:** Homebrew tap and GitHub Release
+- **Location:** `autumngarage/homebrew-conductor` formula and
+  https://github.com/autumngarage/conductor/releases/tag/v0.10.9
+- **Version:** v0.10.9
+- **Tag:** v0.10.9
+- **Release notes:** https://github.com/autumngarage/conductor/releases/tag/v0.10.9
+
+## What shipped
+
+- `conductor update` for current-repo embedded integration refresh, including
+  `--dry-run` and `--check`.
+- `conductor update-all` as the canonical batch refresh command for configured
+  consumer repositories.
+- A deprecated `refresh-consumers` compatibility alias that warns and forwards
+  to `update-all`.
+- README and consumer-contract documentation for the shared update surface.
+
+## Downstream docs this changes
+
+- README.md — install / quickstart and command surface.
+- docs/consumers.md — consumer-facing command contract.
+- Homebrew tap repo (`autumngarage/homebrew-conductor`) — formula `url` and
+  `sha256`.
+
+## Follow-ups (deferred to future work)
+
+None.

--- a/.cursor/rules/conductor-delegation.mdc
+++ b/.cursor/rules/conductor-delegation.mdc
@@ -2,7 +2,7 @@
 description: Use when delegating or routing tasks to a different LLM via the conductor CLI — e.g., cheap second opinions, long-context reads, web search, or offline runs.
 globs: ""
 alwaysApply: false
-managed-by: conductor v0.10.8
+managed-by: conductor v0.10.9
 ---
 
 # Conductor delegation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ If there are zero blocking issues, the review is just: "LGTM."
 
 @.cortex/protocol.md
 
-<!-- conductor:begin v0.10.8 -->
+<!-- conductor:begin v0.10.9 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
 
-<!-- conductor:begin v0.10.8 -->
+<!-- conductor:begin v0.10.9 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)


### PR DESCRIPTION
## Summary

- Add the Cortex T1.10 release journal entry for v0.10.9.
- Refresh repo-scope generated Conductor wiring stamps to v0.10.9 after release.

## Validation

- pre-commit hooks passed during commit
- pre-push hooks passed during push