### PR TITLE
fix: stabilize review gate routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Shipped:
 - `conductor refresh-on-commit` — hook-mode counterpart to `update`, installed by `conductor init` for pre-commit refresh of stale embedded repo integrations.
 - Credentials resolver (`conductor.credentials`): env var first, then `key_command`, then macOS Keychain under service `conductor`.
 - Offline-mode fallback: on a real connectivity failure (DNS, TCP reset, unreachable host) during `--auto` routing, Conductor prompts once to switch to the local `ollama` provider and remembers that choice for a short window. `conductor call --offline --brief "..."` is the non-interactive form — useful on a plane, in CI, or any time you want to force local. Clear the sticky flag with `--no-offline`. Ollama requests use `CONDUCTOR_OLLAMA_MODEL` when set; when no explicit `--model` is passed and the requested local model is missing, Conductor queries `/api/tags` and retries once with a non-embedding installed chat model.
+- Review-gate routing: `--auto` routes tagged `code-review` derive bounded provider budgets from prompt size and fallback count, so consumers do not need to guess raw timeout flags for normal review delegation. OpenRouter empty responses are retried against the remaining model stack before surfacing a provider error.
 
 Deferred (see `autumn-garage/.cortex/plans/conductor-bootstrap.md`):
 
@@ -162,7 +163,10 @@ Run `conductor update` to refresh stale embedded repo-scope wiring in the
 current repo immediately. Use `conductor update-all` when you intentionally
 need to walk configured consumer repos; `refresh-consumers` still works as a
 deprecated alias for existing scripts. The installed pre-commit hook continues
-to call `conductor refresh-on-commit`.
+to call `conductor refresh-on-commit`. Normal diagnostic and delegation
+commands do not rewrite tracked repo-scope integration files by default. Set
+`CONDUCTOR_AUTO_REFRESH_REPO_SCOPE=1` only if you intentionally want the older
+ambient repo-refresh behavior.
 
 ## How Sentinel and Touchstone use it
 

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -235,6 +235,13 @@ DEFAULT_COUNCIL_TIMEOUT_SEC = 180
 DEFAULT_COUNCIL_MAX_OUTPUT_TOKENS = 6_000
 DEFAULT_COUNCIL_MAX_COST_USD = 0.25
 ESTIMATED_CHARS_PER_TOKEN = 4
+AUTO_FALLBACK_STALL_FRACTION = 4
+AUTO_FALLBACK_MIN_STALL_SEC = 30
+REVIEW_GATE_BASE_TIMEOUT_SEC = 240
+REVIEW_GATE_MIN_TIMEOUT_SEC = 300
+REVIEW_GATE_MAX_TIMEOUT_SEC = 1_200
+REVIEW_GATE_SECONDS_PER_1K_INPUT_TOKENS = 8
+REVIEW_GATE_MAX_STALL_SEC = 180
 
 
 @dataclass(frozen=True)
@@ -355,6 +362,94 @@ def _scale_dispatch_defaults(
         resolved_max_stall = None if scaled_stall is None else math.ceil(scaled_stall)
 
     return resolved_timeout, resolved_max_stall
+
+
+def _cap_default_auto_fallback_stall(
+    *,
+    timeout_sec: int | None,
+    max_stall_sec: int | None,
+    max_stall_is_default: bool,
+    candidate_count: int,
+) -> int | None:
+    """Keep default stall watchdogs short enough for auto fallback.
+
+    Invariant: when the caller supplies a finite command timeout and leaves
+    max-stall at its default, a silent primary provider must not consume the
+    whole invocation budget before the router can try the next candidate.
+    """
+    if (
+        not max_stall_is_default
+        or timeout_sec is None
+        or max_stall_sec is None
+        or candidate_count < 2
+    ):
+        return max_stall_sec
+    cap = max(AUTO_FALLBACK_MIN_STALL_SEC, timeout_sec // AUTO_FALLBACK_STALL_FRACTION)
+    if cap >= timeout_sec:
+        cap = max(1, timeout_sec - 1)
+    return min(max_stall_sec, cap)
+
+
+def _review_gate_timeout_sec(estimated_input_tokens: int) -> int:
+    token_units = math.ceil(max(1, estimated_input_tokens) / 1_000)
+    derived = (
+        REVIEW_GATE_BASE_TIMEOUT_SEC
+        + token_units * REVIEW_GATE_SECONDS_PER_1K_INPUT_TOKENS
+    )
+    return min(
+        REVIEW_GATE_MAX_TIMEOUT_SEC,
+        max(REVIEW_GATE_MIN_TIMEOUT_SEC, derived),
+    )
+
+
+def _review_gate_stall_sec(timeout_sec: int, *, candidate_count: int) -> int:
+    effective_candidates = max(1, candidate_count)
+    cap = max(
+        AUTO_FALLBACK_MIN_STALL_SEC,
+        timeout_sec // max(AUTO_FALLBACK_STALL_FRACTION, effective_candidates + 1),
+    )
+    if cap >= timeout_sec:
+        cap = max(1, timeout_sec - 1)
+    return min(REVIEW_GATE_MAX_STALL_SEC, cap)
+
+
+def _apply_review_gate_auto_budget(
+    *,
+    timeout_sec: int | None,
+    max_stall_sec: int | None,
+    timeout_is_default: bool,
+    max_stall_is_default: bool,
+    estimated_input_tokens: int,
+    candidate_count: int,
+    silent: bool,
+) -> tuple[int | None, int | None]:
+    derived_timeout = False
+    derived_stall = False
+    if timeout_is_default:
+        timeout_sec = _review_gate_timeout_sec(estimated_input_tokens)
+        derived_timeout = True
+    if max_stall_is_default and timeout_sec is not None:
+        max_stall_sec = _review_gate_stall_sec(
+            timeout_sec,
+            candidate_count=candidate_count,
+        )
+        derived_stall = True
+    else:
+        max_stall_sec = _cap_default_auto_fallback_stall(
+            timeout_sec=timeout_sec,
+            max_stall_sec=max_stall_sec,
+            max_stall_is_default=max_stall_is_default,
+            candidate_count=candidate_count,
+        )
+    if not silent and (derived_timeout or derived_stall):
+        stall_label = "disabled" if max_stall_sec is None else f"{max_stall_sec}s"
+        click.echo(
+            "[conductor] review gate budget: "
+            f"timeout={timeout_sec}s stall={stall_label} "
+            f"candidates={candidate_count} est_input={estimated_input_tokens:,} tokens",
+            err=True,
+        )
+    return timeout_sec, max_stall_sec
 
 
 def _read_task(
@@ -904,6 +999,14 @@ _UPSTREAM_DOWN_ERROR_SIGNALS = (
     "api is down",
 )
 
+_EMPTY_RESPONSE_ERROR_SIGNALS = (
+    "empty response",
+    "empty final response",
+    "empty response content",
+    "produced empty stdout",
+    "produced empty final",
+)
+
 
 def _is_retryable(err: Exception) -> tuple[bool, str]:
     """Classify an error as retryable-with-fallback or fatal.
@@ -921,6 +1024,8 @@ def _is_retryable(err: Exception) -> tuple[bool, str]:
     msg = str(err).lower()
     if "429" in msg or any(sig in msg for sig in _RATE_LIMIT_ERROR_SIGNALS):
         return True, "rate-limit"
+    if any(sig in msg for sig in _EMPTY_RESPONSE_ERROR_SIGNALS):
+        return True, "empty-response"
     if any(sig in msg for sig in _NETWORK_ERROR_SIGNALS):
         return True, "network"
     if "timed out" in msg or "timeout" in msg or "stalled" in msg:
@@ -3392,6 +3497,7 @@ AUTO_REFRESH_COMMANDS = frozenset(
         "update-all",
     }
 )
+REPO_SCOPE_AUTO_REFRESH_ENV = "CONDUCTOR_AUTO_REFRESH_REPO_SCOPE"
 AUTO_REFRESH_VIA_PR_ENV = "CONDUCTOR_AUTO_REFRESH_VIA_PR"
 AUTO_REFRESH_VIA_PR_MODES = frozenset({"auto", "always", "never"})
 
@@ -3462,6 +3568,8 @@ def _maybe_auto_refresh(ctx: click.Context) -> None:
             f"user-scope integration files: {e}",
             err=True,
         )
+    if not _env_flag_enabled(REPO_SCOPE_AUTO_REFRESH_ENV):
+        return
     try:
         from conductor import agent_wiring
 
@@ -3819,6 +3927,13 @@ def ask(
     if plan.mode == "review":
         review_exclude, review_reasons = _review_exclude_set(frozenset())
         exclude_set = _semantic_candidate_exclude_set(plan, review_exclude)
+        review_estimated_input_tokens = _estimate_review_input_tokens(
+            body,
+            base=base,
+            commit=commit,
+            uncommitted=uncommitted,
+            cwd=cwd,
+        )
         try:
             _provider, decision = pick(
                 list(plan.tags),
@@ -3827,13 +3942,7 @@ def ask(
                 exclude=exclude_set,
                 priority=_semantic_priority(plan),
                 shadow=True,
-                estimated_input_tokens=_estimate_review_input_tokens(
-                    body,
-                    base=base,
-                    commit=commit,
-                    uncommitted=uncommitted,
-                    cwd=cwd,
-                ),
+                estimated_input_tokens=review_estimated_input_tokens,
             )
         except (NoConfiguredProvider, InvalidRouterRequest, MutedProvidersError) as e:
             click.echo(f"conductor: {_native_review_unavailable_message(review_reasons)}", err=True)
@@ -3847,6 +3956,15 @@ def ask(
             max_stall_sec=max_stall_sec,
             timeout_is_default=timeout_is_default,
             max_stall_is_default=max_stall_is_default,
+        )
+        timeout_sec, max_stall_sec = _apply_review_gate_auto_budget(
+            timeout_sec=timeout_sec,
+            max_stall_sec=max_stall_sec,
+            timeout_is_default=timeout_is_default,
+            max_stall_is_default=max_stall_is_default,
+            estimated_input_tokens=review_estimated_input_tokens,
+            candidate_count=len(decision.ranked),
+            silent=silent_route or as_json,
         )
         max_stall_sec = _normalize_max_stall_sec(max_stall_sec)
         try:
@@ -3931,6 +4049,12 @@ def ask(
         max_stall_sec=max_stall_sec,
         timeout_is_default=timeout_is_default,
         max_stall_is_default=max_stall_is_default,
+    )
+    max_stall_sec = _cap_default_auto_fallback_stall(
+        timeout_sec=timeout_sec,
+        max_stall_sec=max_stall_sec,
+        max_stall_is_default=max_stall_is_default,
+        candidate_count=len(decision.ranked),
     )
     max_stall_sec = _normalize_max_stall_sec(max_stall_sec)
 
@@ -4331,6 +4455,23 @@ def call(
             timeout_is_default=timeout_is_default,
             max_stall_is_default=max_stall_is_default,
         )
+        if NATIVE_REVIEW_TAG in decision.task_tags:
+            timeout_sec, max_stall_sec = _apply_review_gate_auto_budget(
+                timeout_sec=timeout_sec,
+                max_stall_sec=max_stall_sec,
+                timeout_is_default=timeout_is_default,
+                max_stall_is_default=max_stall_is_default,
+                estimated_input_tokens=estimated_input_tokens,
+                candidate_count=len(decision.ranked),
+                silent=silent_route or as_json,
+            )
+        else:
+            max_stall_sec = _cap_default_auto_fallback_stall(
+                timeout_sec=timeout_sec,
+                max_stall_sec=max_stall_sec,
+                max_stall_is_default=max_stall_is_default,
+                candidate_count=len(decision.ranked),
+            )
         max_stall_sec = _normalize_max_stall_sec(max_stall_sec)
 
         try:
@@ -4728,6 +4869,15 @@ def review(
             max_stall_sec=max_stall_sec,
             timeout_is_default=timeout_is_default,
             max_stall_is_default=max_stall_is_default,
+        )
+        timeout_sec, max_stall_sec = _apply_review_gate_auto_budget(
+            timeout_sec=timeout_sec,
+            max_stall_sec=max_stall_sec,
+            timeout_is_default=timeout_is_default,
+            max_stall_is_default=max_stall_is_default,
+            estimated_input_tokens=estimated_input_tokens,
+            candidate_count=min(max_fallbacks, len(decision.ranked)),
+            silent=silent_route or as_json,
         )
         max_stall_sec = _normalize_max_stall_sec(max_stall_sec)
         try:
@@ -5535,6 +5685,32 @@ def _run_exec_phase_dispatch(
             timeout_is_default=timeout_is_default,
             max_stall_is_default=max_stall_is_default,
         )
+        if NATIVE_REVIEW_TAG in decision.task_tags:
+            timeout_sec, max_stall_sec = _apply_review_gate_auto_budget(
+                timeout_sec=timeout_sec,
+                max_stall_sec=max_stall_sec,
+                timeout_is_default=timeout_is_default,
+                max_stall_is_default=max_stall_is_default,
+                estimated_input_tokens=estimated_input_tokens,
+                candidate_count=len(decision.ranked),
+                silent=silent_route or as_json,
+            )
+            session_log.emit(
+                "review_gate_budget",
+                {
+                    "timeout_sec": timeout_sec,
+                    "max_stall_sec": max_stall_sec,
+                    "estimated_input_tokens": estimated_input_tokens,
+                    "candidate_count": len(decision.ranked),
+                },
+            )
+        else:
+            max_stall_sec = _cap_default_auto_fallback_stall(
+                timeout_sec=timeout_sec,
+                max_stall_sec=max_stall_sec,
+                max_stall_is_default=max_stall_is_default,
+                candidate_count=len(decision.ranked),
+            )
         max_stall_sec = _normalize_max_stall_sec(max_stall_sec)
         if preflight:
             # `provider` may arrive as a Provider object (real `pick()` return)

--- a/src/conductor/providers/openrouter.py
+++ b/src/conductor/providers/openrouter.py
@@ -190,7 +190,7 @@ class OpenRouterProvider:
             return False, f"OpenRouter returned HTTP {resp.status_code}: {resp.text[:200]}"
         return True, None
 
-    def _post_chat(self, payload: dict, *, timeout_sec: int | None = None) -> dict:
+    def _post_chat(self, payload: dict, *, timeout_sec: float | None = None) -> dict:
         try:
             timeout = self._timeout_sec if timeout_sec is None else timeout_sec
             with provider_http_client(timeout=timeout) as client:
@@ -321,16 +321,40 @@ class OpenRouterProvider:
         if max_tokens is not None:
             payload["max_tokens"] = max(1, max_tokens)
 
+        attempts: list[dict[str, object]] = []
         start = time.monotonic()
-        body = self._post_chat(payload, timeout_sec=timeout_sec)
+        while True:
+            body = self._post_chat(
+                payload,
+                timeout_sec=_remaining_timeout_sec(
+                    start,
+                    timeout_sec=timeout_sec,
+                    provider_name=self.name,
+                ),
+            )
+            text = _call_response_text(body)
+            if text.strip():
+                break
+            retry_payload = _retry_payload_after_empty_response(
+                payload,
+                body,
+                attempts=attempts,
+            )
+            if retry_payload is None:
+                raise ProviderHTTPError("OpenRouter produced empty response content")
+            attempts.append(
+                {
+                    "reason": "empty-response",
+                    "model": _response_model(body, fallback=selected_model),
+                }
+            )
+            if log_selection:
+                _log_empty_response_retry(
+                    failed_model=_response_model(body, fallback=selected_model),
+                    retry_payload=retry_payload,
+                )
+            payload = retry_payload
         duration_ms = int((time.monotonic() - start) * 1000)
-
-        try:
-            text = body["choices"][0]["message"]["content"]
-        except (KeyError, IndexError, TypeError) as e:
-            raise ProviderHTTPError(
-                f"OpenRouter response missing choices[0].message.content: {body!r:.500}"
-            ) from e
 
         usage = body.get("usage") or {}
         cost_usd = _usage_cost_usd(usage)
@@ -352,7 +376,7 @@ class OpenRouterProvider:
                 "thinking_budget": thinking_budget,
             },
             cost_usd=cost_usd,
-            raw=body,
+            raw={**body, "empty_response_retries": attempts} if attempts else body,
         )
 
     def exec(
@@ -392,6 +416,8 @@ class OpenRouterProvider:
                 prefer=prefer,
                 exclude=exclude,
                 log_selection=log_selection,
+                timeout_sec=timeout_sec,
+                max_stall_sec=max_stall_sec,
             )
 
         unknown = tools - self.supported_tools
@@ -440,6 +466,7 @@ class OpenRouterProvider:
         validation_failures: list[dict[str, object]] = []
         recent_tool_calls: list[dict[str, object]] = []
         missing_deliverables: list[MissingDeliverable] = []
+        empty_response_retries: list[dict[str, object]] = []
         completion_stretched = False
         repo_changing_task = _is_repo_changing_tool_task(effective_task_tags, tools)
         git_status_before = _git_clean_status(workdir) if repo_changing_task else None
@@ -455,7 +482,14 @@ class OpenRouterProvider:
                 "tools": tool_specs,
                 "tool_choice": "auto",
             }
-            body = self._post_chat(payload)
+            body = self._post_chat(
+                payload,
+                timeout_sec=_remaining_timeout_sec(
+                    start,
+                    timeout_sec=timeout_sec,
+                    provider_name=self.name,
+                ),
+            )
             final_body = body
             message = _first_message(body)
 
@@ -489,7 +523,31 @@ class OpenRouterProvider:
                 }
             )
 
+            tool_calls = message.get("tool_calls") or []
+            final_text = _message_content_text(message)
             actual_model = body.get("model")
+            if not tool_calls and not final_text.strip():
+                retry_payload = _retry_payload_after_empty_response(
+                    target_payload,
+                    body,
+                    attempts=empty_response_retries,
+                )
+                if retry_payload is not None:
+                    failed_model = _response_model(body, fallback=selected_model)
+                    empty_response_retries.append(
+                        {
+                            "iteration": iteration,
+                            "reason": "empty-response",
+                            "model": failed_model,
+                        }
+                    )
+                    if log_selection:
+                        _log_empty_response_retry(
+                            failed_model=failed_model,
+                            retry_payload=retry_payload,
+                        )
+                    target_payload = retry_payload
+                    continue
             if (
                 isinstance(actual_model, str)
                 and actual_model
@@ -500,9 +558,6 @@ class OpenRouterProvider:
                 reasoning = self._reasoning_payload(effort)
                 if reasoning is not None:
                     target_payload["reasoning"] = reasoning
-
-            tool_calls = message.get("tool_calls") or []
-            final_text = _message_content_text(message)
             if not tool_calls:
                 break
 
@@ -645,6 +700,8 @@ class OpenRouterProvider:
                 provider=self.name,
                 status=execution_status,
             )
+        if not final_text.strip():
+            raise ProviderHTTPError("OpenRouter exec produced empty final response")
 
         return CallResponse(
             text=final_text,
@@ -669,6 +726,7 @@ class OpenRouterProvider:
                 "write_success_count": write_success_count,
                 "tool_error_count": len(tool_errors),
                 "bash_failure_count": len(bash_failures),
+                "empty_response_retries": empty_response_retries,
                 "execution_status": execution_status,
                 "iterations": iterations_log,
             },
@@ -1121,6 +1179,80 @@ def _openrouter_attempted_models(payload: dict) -> list[str]:
 def _looks_like_model_restriction_error(response_text: str) -> bool:
     lowered = response_text.lower()
     return "no models match your request and model restrictions" in lowered
+
+
+def _remaining_timeout_sec(
+    start: float,
+    *,
+    timeout_sec: int | None,
+    provider_name: str,
+) -> float | None:
+    if timeout_sec is None:
+        return None
+    remaining = float(timeout_sec) - (time.monotonic() - start)
+    if remaining <= 0:
+        raise ProviderHTTPError(f"{provider_name} timed out after {timeout_sec:g}s")
+    return remaining
+
+
+def _call_response_text(body: dict) -> str:
+    try:
+        text = body["choices"][0]["message"]["content"]
+    except (KeyError, IndexError, TypeError) as e:
+        raise ProviderHTTPError(
+            f"OpenRouter response missing choices[0].message.content: {body!r:.500}"
+        ) from e
+    if not isinstance(text, str):
+        raise ProviderHTTPError(
+            f"OpenRouter response content was not text: {type(text).__name__}"
+        )
+    return text
+
+
+def _response_model(body: dict, *, fallback: str | None) -> str:
+    model = body.get("model")
+    return model if isinstance(model, str) and model else fallback or "<unknown>"
+
+
+def _retry_payload_after_empty_response(
+    payload: dict,
+    body: dict,
+    *,
+    attempts: list[dict[str, object]],
+) -> dict | None:
+    if len(attempts) >= OPENROUTER_MODELS_ARRAY_MAX:
+        return None
+    raw_models = payload.get("models")
+    if not isinstance(raw_models, list) or not raw_models:
+        return None
+    models = [str(model) for model in raw_models if str(model).strip()]
+    if not models:
+        return None
+
+    failed_model = _response_model(body, fallback=models[0])
+    if failed_model in models:
+        remaining = [model for model in models if model != failed_model]
+    else:
+        remaining = models[1:]
+    if not remaining:
+        return None
+
+    retry_payload = dict(payload)
+    retry_payload["models"] = remaining
+    return retry_payload
+
+
+def _log_empty_response_retry(
+    *,
+    failed_model: str,
+    retry_payload: dict,
+) -> None:
+    target = retry_payload.get("models") or retry_payload.get("model") or "<unknown>"
+    sys.stderr.write(
+        "[conductor] openrouter empty response: "
+        f"model={failed_model}; retrying {target}\n"
+    )
+    sys.stderr.flush()
 
 
 def _first_message(body: dict) -> dict:

--- a/tests/test_cli_auto_refresh.py
+++ b/tests/test_cli_auto_refresh.py
@@ -68,8 +68,27 @@ def test_auto_refresh_stale_user_scope_updates_files(tmp_path, monkeypatch):
     }
 
 
-def test_auto_refresh_stale_repo_scope_updates_files(tmp_path, monkeypatch):
+def test_auto_refresh_stale_repo_scope_does_not_update_by_default(tmp_path, monkeypatch):
     _isolate_user_scope(tmp_path, monkeypatch)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+    aw.wire_agents_md(cwd=repo, version="0.8.0")
+
+    result = CliRunner().invoke(main, ["doctor", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert "refreshed repo-scope" not in result.stderr
+    assert "<!-- conductor:begin v0.8.0 -->" in (
+        repo / "AGENTS.md"
+    ).read_text(encoding="utf-8")
+
+
+def test_auto_refresh_stale_repo_scope_opt_in_updates_files(tmp_path, monkeypatch):
+    _isolate_user_scope(tmp_path, monkeypatch)
+    monkeypatch.setenv("CONDUCTOR_AUTO_REFRESH_REPO_SCOPE", "1")
     repo = tmp_path / "repo"
     repo.mkdir()
     _init_git_repo(repo)
@@ -93,6 +112,7 @@ def test_auto_refresh_stale_repo_scope_on_default_branch_uses_refresh_branch(
     tmp_path, monkeypatch
 ):
     _isolate_user_scope(tmp_path, monkeypatch)
+    monkeypatch.setenv("CONDUCTOR_AUTO_REFRESH_REPO_SCOPE", "1")
     repo = tmp_path / "repo-default-branch"
     repo.mkdir()
     _init_git_repo(repo)
@@ -127,6 +147,7 @@ def test_auto_refresh_default_branch_restores_operator_changes(
     tmp_path, monkeypatch
 ):
     _isolate_user_scope(tmp_path, monkeypatch)
+    monkeypatch.setenv("CONDUCTOR_AUTO_REFRESH_REPO_SCOPE", "1")
     repo = tmp_path / "repo-dirty-default"
     repo.mkdir()
     _init_git_repo(repo)
@@ -159,6 +180,7 @@ def test_auto_refresh_default_branch_restores_operator_changes(
 
 def test_auto_refresh_via_pr_never_keeps_in_place_behavior(tmp_path, monkeypatch):
     _isolate_user_scope(tmp_path, monkeypatch)
+    monkeypatch.setenv("CONDUCTOR_AUTO_REFRESH_REPO_SCOPE", "1")
     monkeypatch.setenv("CONDUCTOR_AUTO_REFRESH_VIA_PR", "never")
     repo = tmp_path / "repo-never"
     repo.mkdir()
@@ -198,6 +220,7 @@ def test_auto_refresh_clean_repo_scope_is_silent(tmp_path, monkeypatch):
 
 def test_auto_refresh_repo_scope_skips_import_mode_claude_md(tmp_path, monkeypatch):
     _isolate_user_scope(tmp_path, monkeypatch)
+    monkeypatch.setenv("CONDUCTOR_AUTO_REFRESH_REPO_SCOPE", "1")
     repo = tmp_path / "repo"
     repo.mkdir()
     _init_git_repo(repo)

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -2292,6 +2292,81 @@ def test_exec_cli_no_max_stall_seconds_defaults_to_360(mocker):
     assert exec_mock.call_args.kwargs["max_stall_sec"] == 360
 
 
+def test_exec_auto_default_stall_caps_under_timeout_for_fallback(mocker):
+    from conductor.providers.interface import ProviderStalledError
+
+    _stub_all_configured(mocker, {"claude", "codex"})
+    mocker.patch(
+        "conductor.cli.get_network_profile",
+        return_value=NetworkProfile(None, "https://api.openai.com", 1_000),
+    )
+    claude_exec = mocker.patch.object(
+        ClaudeProvider,
+        "exec",
+        side_effect=ProviderStalledError("claude CLI stalled"),
+    )
+    codex_exec = mocker.patch.object(
+        CodexProvider,
+        "exec",
+        return_value=_fake_response("codex"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--auto",
+            "--prefer",
+            "best",
+            "--timeout",
+            "300",
+            "--tools",
+            "Read",
+            "--task",
+            "Review the diff.",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert claude_exec.call_args.kwargs["max_stall_sec"] == 75
+    assert codex_exec.call_args.kwargs["max_stall_sec"] == 75
+    assert "claude failed (timeout)" in result.stderr
+
+
+def test_exec_auto_code_review_derives_budget_without_timeout(mocker):
+    _stub_all_configured(mocker, {"claude", "codex"})
+    mocker.patch(
+        "conductor.cli.get_network_profile",
+        return_value=NetworkProfile(None, "https://api.openai.com", 1_000),
+    )
+    exec_mock = mocker.patch.object(
+        ClaudeProvider,
+        "exec",
+        return_value=_fake_response("claude"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--auto",
+            "--prefer",
+            "best",
+            "--tags",
+            "code-review",
+            "--tools",
+            "Read",
+            "--task",
+            "Review the diff.",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert exec_mock.call_args.kwargs["timeout_sec"] == 300
+    assert exec_mock.call_args.kwargs["max_stall_sec"] == 75
+    assert "review gate budget: timeout=300s stall=75s" in result.stderr
+
+
 def test_exec_cli_max_stall_seconds_zero_disables_watchdog(mocker):
     _stub_all_configured(mocker, {"codex"})
     exec_mock = mocker.patch.object(CodexProvider, "exec", return_value=_fake_response("codex"))

--- a/tests/test_openrouter.py
+++ b/tests/test_openrouter.py
@@ -119,6 +119,55 @@ def test_call_returns_normalized_response(configured):
     assert response.raw == body
 
 
+def test_call_empty_response_raises_provider_error(configured):
+    body = {
+        "model": OPENROUTER_DEFAULT_MODEL,
+        "choices": [{"message": {"content": ""}}],
+        "usage": {},
+    }
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.post("/chat/completions").mock(
+            return_value=httpx.Response(200, json=body)
+        )
+        with pytest.raises(ProviderHTTPError, match="empty response content"):
+            OpenRouterProvider().call("Review this.", model=OPENROUTER_DEFAULT_MODEL)
+
+
+def test_call_empty_response_retries_remaining_models(configured):
+    requests: list[dict] = []
+    responses = [
+        {
+            "model": "model-a",
+            "choices": [{"message": {"content": ""}}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 0},
+        },
+        {
+            "model": "model-b",
+            "choices": [{"message": {"content": "usable"}}],
+            "usage": {"prompt_tokens": 11, "completion_tokens": 2},
+        },
+    ]
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content))
+        return httpx.Response(200, json=responses[len(requests) - 1])
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.post("/chat/completions").mock(side_effect=_record)
+        response = OpenRouterProvider().call(
+            "Review this.",
+            models=("model-a", "model-b"),
+            log_selection=False,
+        )
+
+    assert response.text == "usable"
+    assert requests[0]["models"] == ["model-a", "model-b"]
+    assert requests[1]["models"] == ["model-b"]
+    assert response.raw["empty_response_retries"] == [
+        {"reason": "empty-response", "model": "model-a"}
+    ]
+
+
 def test_call_raises_config_error_when_unconfigured(no_key):
     with pytest.raises(ProviderConfigError):
         OpenRouterProvider().call("hello")
@@ -521,6 +570,153 @@ def test_exec_with_tools_runs_openai_tool_loop(configured, tmp_path):
         "name": "Read",
         "content": "tool loop works",
     }
+
+
+def test_exec_without_tools_passes_timeout_to_call(configured, mocker):
+    provider = OpenRouterProvider()
+    call = mocker.patch.object(
+        provider,
+        "call",
+        return_value=CallResponse(
+            text="ok",
+            provider="openrouter",
+            model=OPENROUTER_DEFAULT_MODEL,
+            duration_ms=1,
+            usage={},
+            raw={},
+        ),
+    )
+
+    response = provider.exec(
+        "Summarize this.",
+        model=OPENROUTER_DEFAULT_MODEL,
+        timeout_sec=7,
+        max_stall_sec=3,
+    )
+
+    assert response.text == "ok"
+    assert call.call_args.kwargs["timeout_sec"] == 7
+    assert call.call_args.kwargs["max_stall_sec"] == 3
+
+
+def test_exec_with_tools_passes_remaining_timeout(configured, tmp_path, mocker):
+    provider = OpenRouterProvider()
+    observed_timeouts: list[float | None] = []
+
+    def _post_chat(payload: dict, *, timeout_sec: float | None = None) -> dict:
+        observed_timeouts.append(timeout_sec)
+        return {
+            "model": "openai/gpt-5.5",
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "done",
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+        }
+
+    mocker.patch.object(provider, "_post_chat", side_effect=_post_chat)
+
+    response = provider.exec(
+        "Read and summarize.",
+        model="openai/gpt-5.5",
+        tools=frozenset({"Read"}),
+        cwd=str(tmp_path),
+        timeout_sec=60,
+    )
+
+    assert response.text == "done"
+    assert len(observed_timeouts) == 1
+    assert observed_timeouts[0] is not None
+    assert 0 < observed_timeouts[0] <= 60
+
+
+def test_exec_with_tools_empty_final_response_raises(configured, tmp_path):
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.post("/chat/completions").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "model": "openai/gpt-5.5",
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": "",
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {"prompt_tokens": 10, "completion_tokens": 0},
+                },
+            )
+        )
+        with pytest.raises(ProviderHTTPError, match="empty final response"):
+            OpenRouterProvider().exec(
+                "Review this.",
+                model="openai/gpt-5.5",
+                tools=frozenset({"Read"}),
+                cwd=str(tmp_path),
+            )
+
+
+def test_exec_with_tools_empty_final_response_retries_remaining_models(
+    configured, tmp_path
+):
+    requests: list[dict] = []
+    responses = [
+        {
+            "model": "model-a",
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "",
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 0},
+        },
+        {
+            "model": "model-b",
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "final verdict",
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 3},
+        },
+    ]
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content))
+        return httpx.Response(200, json=responses[len(requests) - 1])
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.post("/chat/completions").mock(side_effect=_record)
+        response = OpenRouterProvider().exec(
+            "Review this.",
+            models=("model-a", "model-b"),
+            tools=frozenset({"Read"}),
+            cwd=str(tmp_path),
+            log_selection=False,
+        )
+
+    assert response.text == "final verdict"
+    assert requests[0]["models"] == ["model-a", "model-b"]
+    assert requests[1]["models"] == ["model-b"]
+    assert response.usage["empty_response_retries"] == [
+        {"iteration": 1, "reason": "empty-response", "model": "model-a"}
+    ]
 
 
 def test_exec_with_tools_uses_curated_coding_stack_by_default(configured, tmp_path):


### PR DESCRIPTION
## Summary

Stabilizes Conductor review-gate delegation so consumers such as Touchstone do not need to guess raw timeout flags and do not receive blank provider output as success.

Closes #308.

## Root Cause

Conductor treated review timeouts as caller-owned provider knobs rather than a review-gate policy. That let one silent provider consume an outer gate timeout before fallback. OpenRouter empty responses were also normalized as successful blank `CallResponse.text`, which pushed malformed-sentinel handling into consumers. Separately, ambient repo-scope auto-refresh could dirty tracked integration files during normal diagnostic/delegation commands.

## Changes

- Derive bounded review-gate budgets for `--auto` routes tagged `code-review` from prompt size and fallback count.
- Keep general long-running `exec` behavior unchanged unless the route is explicitly review-tagged or the caller passes an override.
- Classify empty provider output as retryable `empty-response`.
- Retry OpenRouter empty responses against the remaining model stack before surfacing a provider error.
- Share one remaining timeout budget across OpenRouter retries.
- Make repo-scope auto-refresh opt-in with `CONDUCTOR_AUTO_REFRESH_REPO_SCOPE=1` while preserving explicit `conductor update` / `update-all` flows.
- Add regression coverage for review budgets, OpenRouter empty-response retry/failure, and non-mutating repo-scope defaults.

## Validation

- `uv run pytest -q` -> `1091 passed, 16 skipped`
- `uv run ruff check src/conductor/cli.py src/conductor/providers/openrouter.py tests/test_cli_auto_refresh.py tests/test_cli_v02.py tests/test_openrouter.py README.md`
- `git diff --check`
- local pre-commit and pre-push hooks passed