### PR TITLE
docs: record v0.10.10 release

### DIFF
--- a/.cortex/journal/2026-05-09-release-v0.10.10.md
+++ b/.cortex/journal/2026-05-09-release-v0.10.10.md
@@ -1,0 +1,49 @@
+# Release v0.10.10 - review gate stabilization
+
+**Date:** 2026-05-09
+**Type:** release
+**Trigger:** T1.10
+**Tag:** v0.10.10
+**Cites:** journal/2026-05-09-pr-309-merged.md
+
+> Conductor v0.10.10 shipped through the GitHub Release and Homebrew tap flow,
+> making review-gate stabilization and OpenRouter empty-response handling
+> available via `brew upgrade conductor`.
+
+## Artifact
+
+- **Kind:** Homebrew tap and GitHub Release
+- **Location:** `autumngarage/homebrew-conductor` formula and
+  https://github.com/autumngarage/conductor/releases/tag/v0.10.10
+- **Version:** v0.10.10
+- **Tag:** v0.10.10
+- **Release notes:** https://github.com/autumngarage/conductor/releases/tag/v0.10.10
+
+## What shipped
+
+- Review-tagged `--auto` routes now derive bounded review-gate timeout and
+  stall budgets from prompt size and fallback breadth, so consumers do not have
+  to guess raw timeout values for normal review delegation.
+- OpenRouter empty responses now retry against the remaining model stack before
+  surfacing a provider error, and empty final content no longer becomes a blank
+  success response.
+- Normal Conductor commands no longer refresh tracked repo-scope integration
+  files by default; operators use explicit `conductor update` / `update-all`
+  for those mutations.
+- Generated Conductor delegation blocks in this repo were refreshed to
+  v0.10.10 after the release landed.
+
+## Downstream docs this changes
+
+- README.md - review-gate routing behavior and non-mutating default for
+  repo-scope integration refresh.
+- AGENTS.md - generated Conductor delegation block version.
+- GEMINI.md - generated Conductor delegation block version.
+- .cursor/rules/conductor-delegation.mdc - generated Conductor delegation block
+  version.
+- Homebrew tap repo (`autumngarage/homebrew-conductor`) - formula `url` and
+  `sha256`.
+
+## Follow-ups (deferred to future work)
+
+None.

--- a/.cursor/rules/conductor-delegation.mdc
+++ b/.cursor/rules/conductor-delegation.mdc
@@ -2,7 +2,7 @@
 description: Use when delegating or routing tasks to a different LLM via the conductor CLI — e.g., cheap second opinions, long-context reads, web search, or offline runs.
 globs: ""
 alwaysApply: false
-managed-by: conductor v0.10.9
+managed-by: conductor v0.10.10
 ---
 
 # Conductor delegation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ If there are zero blocking issues, the review is just: "LGTM."
 
 @.cortex/protocol.md
 
-<!-- conductor:begin v0.10.9 -->
+<!-- conductor:begin v0.10.10 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
 
-<!-- conductor:begin v0.10.9 -->
+<!-- conductor:begin v0.10.10 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)


### PR DESCRIPTION
## Summary
- record the v0.10.10 release journal entry required by Cortex T1.10
- refresh generated Conductor delegation markers in this repo to v0.10.10

## Validation
- `git diff --cached --check`
- commit hooks
- pre-push hooks
