### PR TITLE
fix: let review gates own timeout budgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Shipped:
 - `conductor refresh-on-commit` — hook-mode counterpart to `update`, installed by `conductor init` for pre-commit refresh of stale embedded repo integrations.
 - Credentials resolver (`conductor.credentials`): env var first, then `key_command`, then macOS Keychain under service `conductor`.
 - Offline-mode fallback: on a real connectivity failure (DNS, TCP reset, unreachable host) during `--auto` routing, Conductor prompts once to switch to the local `ollama` provider and remembers that choice for a short window. `conductor call --offline --brief "..."` is the non-interactive form — useful on a plane, in CI, or any time you want to force local. Clear the sticky flag with `--no-offline`. Ollama requests use `CONDUCTOR_OLLAMA_MODEL` when set; when no explicit `--model` is passed and the requested local model is missing, Conductor queries `/api/tags` and retries once with a non-embedding installed chat model.
-- Review-gate routing: `--auto` routes tagged `code-review` derive bounded provider budgets from prompt size and fallback count, so consumers do not need to guess raw timeout flags for normal review delegation. OpenRouter empty responses are retried against the remaining model stack before surfacing a provider error.
+- Review-gate routing: `--auto` routes tagged `code-review` derive bounded provider budgets from prompt size and fallback count, so consumers do not need to guess raw timeout flags for normal review delegation. For these review-gate routes, Conductor owns provider timeout/stall budgets even when a caller accidentally forwards timeout flags. OpenRouter empty responses are retried against the remaining model stack before surfacing a provider error.
 
 Deferred (see `autumn-garage/.cortex/plans/conductor-bootstrap.md`):
 

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -423,30 +423,32 @@ def _apply_review_gate_auto_budget(
     candidate_count: int,
     silent: bool,
 ) -> tuple[int | None, int | None]:
-    derived_timeout = False
-    derived_stall = False
-    if timeout_is_default:
-        timeout_sec = _review_gate_timeout_sec(estimated_input_tokens)
-        derived_timeout = True
-    if max_stall_is_default and timeout_sec is not None:
-        max_stall_sec = _review_gate_stall_sec(
-            timeout_sec,
-            candidate_count=candidate_count,
-        )
-        derived_stall = True
-    else:
-        max_stall_sec = _cap_default_auto_fallback_stall(
-            timeout_sec=timeout_sec,
-            max_stall_sec=max_stall_sec,
-            max_stall_is_default=max_stall_is_default,
-            candidate_count=candidate_count,
-        )
-    if not silent and (derived_timeout or derived_stall):
+    budget_timeout_sec = _review_gate_timeout_sec(estimated_input_tokens)
+    budget_stall_sec = _review_gate_stall_sec(
+        budget_timeout_sec,
+        candidate_count=candidate_count,
+    )
+    caller_timeout_sec = None if timeout_is_default else timeout_sec
+    caller_stall_sec = None if max_stall_is_default else max_stall_sec
+    timeout_sec = budget_timeout_sec
+    max_stall_sec = budget_stall_sec
+    if not silent:
         stall_label = "disabled" if max_stall_sec is None else f"{max_stall_sec}s"
+        ignored_parts: list[str] = []
+        if caller_timeout_sec is not None and caller_timeout_sec != timeout_sec:
+            ignored_parts.append(f"timeout={caller_timeout_sec}s")
+        if caller_stall_sec is not None and caller_stall_sec != max_stall_sec:
+            ignored_parts.append(f"max-stall={caller_stall_sec}s")
+        ignored = (
+            " ignored caller " + " ".join(ignored_parts)
+            if ignored_parts
+            else ""
+        )
         click.echo(
             "[conductor] review gate budget: "
             f"timeout={timeout_sec}s stall={stall_label} "
-            f"candidates={candidate_count} est_input={estimated_input_tokens:,} tokens",
+            f"candidates={candidate_count} est_input={estimated_input_tokens:,} tokens"
+            f"{ignored}",
             err=True,
         )
     return timeout_sec, max_stall_sec
@@ -3685,7 +3687,8 @@ def main(ctx: click.Context) -> None:
     type=int,
     help=(
         "Wall-clock timeout in seconds for review/exec provider calls. "
-        "Unbounded by default. Council uses --council-timeout for its total cap."
+        "Unbounded by default. Review-tagged auto routes derive their own "
+        "provider budget. Council uses --council-timeout for its total cap."
     ),
 )
 @click.option(
@@ -3693,7 +3696,10 @@ def main(ctx: click.Context) -> None:
     "max_stall_sec",
     default=DEFAULT_EXEC_MAX_STALL_SEC,
     type=int,
-    help="Kill streaming exec/review providers after this many silent seconds. Set 0 to disable.",
+    help=(
+        "Kill streaming exec/review providers after this many silent seconds. "
+        "Review-tagged auto routes derive their own stall budget. Set 0 to disable."
+    ),
 )
 @click.option(
     "--council-timeout",
@@ -4244,7 +4250,10 @@ def ask(
     "timeout_sec",
     default=None,
     type=int,
-    help="Wall-clock timeout in seconds. Unbounded by default.",
+    help=(
+        "Wall-clock timeout in seconds. Unbounded by default. Review-tagged "
+        "auto routes derive their own provider budget."
+    ),
 )
 @click.option(
     "--max-stall-seconds",
@@ -4253,7 +4262,8 @@ def ask(
     type=int,
     help=(
         "Kill streaming CLI-backed calls after this many silent seconds. "
-        "Default: 360, scaled up on slow networks. Set 0 to disable."
+        "Default: 360, scaled up on slow networks. Review-tagged auto routes "
+        "derive their own stall budget. Set 0 to disable."
     ),
 )
 @click.option(
@@ -4669,7 +4679,10 @@ def call(
     "timeout_sec",
     default=None,
     type=int,
-    help=("Wall-clock timeout in seconds for the native review command. Unbounded by default."),
+    help=(
+        "Wall-clock timeout in seconds for the native review command. "
+        "Review auto-routing derives its own provider budget."
+    ),
 )
 @click.option(
     "--max-stall-seconds",
@@ -4678,7 +4691,7 @@ def call(
     type=int,
     help=(
         "Kill streaming review providers if they produce no output for this "
-        "many seconds. Set 0 to disable."
+        "many seconds. Review auto-routing derives its own stall budget."
     ),
 )
 @click.option(
@@ -6124,7 +6137,8 @@ def _run_exec_phase_dispatch(
     type=int,
     help=(
         "Wall-clock timeout in seconds. Unbounded by default. Set explicitly "
-        "(e.g. --timeout 600) for CI or unattended runs that need a fixed bound."
+        "(e.g. --timeout 600) for non-review CI or unattended runs that need "
+        "a fixed bound; review-tagged auto routes derive their own provider budget."
     ),
 )
 @click.option(
@@ -6136,7 +6150,8 @@ def _run_exec_phase_dispatch(
         "Kill the underlying provider if it produces no output for this many "
         "seconds. Default: 360, just past codex's 5-minute internal websocket "
         "idle (openai/codex#17003) so codex gets one retry attempt before "
-        "conductor kills it. Set 0 to disable."
+        "conductor kills it. Review-tagged auto routes derive their own stall "
+        "budget. Set 0 to disable."
     ),
 )
 @click.option(

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -2367,6 +2367,45 @@ def test_exec_auto_code_review_derives_budget_without_timeout(mocker):
     assert "review gate budget: timeout=300s stall=75s" in result.stderr
 
 
+def test_exec_auto_code_review_ignores_caller_timeout_budget(mocker):
+    _stub_all_configured(mocker, {"claude", "codex"})
+    mocker.patch(
+        "conductor.cli.get_network_profile",
+        return_value=NetworkProfile(None, "https://api.openai.com", 1_000),
+    )
+    exec_mock = mocker.patch.object(
+        ClaudeProvider,
+        "exec",
+        return_value=_fake_response("claude"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--auto",
+            "--prefer",
+            "best",
+            "--tags",
+            "code-review",
+            "--timeout",
+            "10",
+            "--max-stall-seconds",
+            "999",
+            "--tools",
+            "Read",
+            "--task",
+            "Review the diff.",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert exec_mock.call_args.kwargs["timeout_sec"] == 300
+    assert exec_mock.call_args.kwargs["max_stall_sec"] == 75
+    assert "review gate budget: timeout=300s stall=75s" in result.stderr
+    assert "ignored caller timeout=10s max-stall=999s" in result.stderr
+
+
 def test_exec_cli_max_stall_seconds_zero_disables_watchdog(mocker):
     _stub_all_configured(mocker, {"codex"})
     exec_mock = mocker.patch.object(CodexProvider, "exec", return_value=_fake_response("codex"))

--- a/tests/test_review_cascade.py
+++ b/tests/test_review_cascade.py
@@ -129,7 +129,7 @@ def test_review_chain_walks_past_codex_to_next_code_review_provider(mocker) -> N
     assert "claude (stall), codex (stall), openrouter (success)" in result.stderr
 
 
-def test_review_fallback_call_propagates_timeout_flags(mocker) -> None:
+def test_review_fallback_call_uses_conductor_owned_budget(mocker) -> None:
     from conductor.providers.interface import ProviderStalledError
 
     _stub_all_configured(mocker, {"claude", "codex", "openrouter"})
@@ -166,8 +166,10 @@ def test_review_fallback_call_propagates_timeout_flags(mocker) -> None:
     )
 
     assert result.exit_code == 0, result.output
-    assert openrouter_call.call_args.kwargs["timeout_sec"] == 7
-    assert openrouter_call.call_args.kwargs["max_stall_sec"] == 3
+    assert openrouter_call.call_args.kwargs["timeout_sec"] == 300
+    assert openrouter_call.call_args.kwargs["max_stall_sec"] == 75
+    assert "review gate budget: timeout=300s stall=75s" in result.stderr
+    assert "ignored caller timeout=7s max-stall=3s" in result.stderr
 
 
 def test_review_patch_context_git_timeout_surfaces_context_error(


### PR DESCRIPTION
## Summary
- make review-tagged `--auto` routes always use Conductor-derived provider timeout and stall budgets
- emit an explicit diagnostic when caller timeout or stall flags are ignored for a review gate
- update README/help text and regression tests so integrations do not treat timeout guessing as the recovery path

## Root Cause
Conductor 0.10.10 derived review budgets only when callers left timeout/stall flags at their defaults. Wrappers could still accidentally forward customer-guessed values such as `--timeout 300`, causing Conductor to honor stale outer policy instead of owning the review-gate budget.

## Validation
- `uv run pytest tests/test_cli_v02.py::test_exec_auto_code_review_derives_budget_without_timeout tests/test_cli_v02.py::test_exec_auto_code_review_ignores_caller_timeout_budget tests/test_review_cascade.py::test_review_fallback_call_uses_conductor_owned_budget -q`
- `uv run pytest tests/test_cli_v02.py tests/test_review_cascade.py tests/test_consumer_contract.py -q`
- `uv run pytest -q`
- `uv run ruff check .`
- `git diff --check`
- commit hooks
- pre-push hooks
