### PR TITLE
docs: record v0.10.11 release

### DIFF
--- a/.cortex/journal/2026-05-09-release-v0.10.11.md
+++ b/.cortex/journal/2026-05-09-release-v0.10.11.md
@@ -1,0 +1,46 @@
+# Release v0.10.11 - Conductor-owned review budgets
+
+**Date:** 2026-05-09
+**Type:** release
+**Trigger:** T1.10
+**Tag:** v0.10.11
+**Cites:** journal/2026-05-09-pr-315-merged.md
+
+> Conductor v0.10.11 shipped through the GitHub Release and Homebrew tap flow,
+> making review-gate provider budgets Conductor-owned even when integrations
+> accidentally forward timeout flags.
+
+## Artifact
+
+- **Kind:** Homebrew tap and GitHub Release
+- **Location:** `autumngarage/homebrew-conductor` formula and
+  https://github.com/autumngarage/conductor/releases/tag/v0.10.11
+- **Version:** v0.10.11
+- **Tag:** v0.10.11
+- **Release notes:** https://github.com/autumngarage/conductor/releases/tag/v0.10.11
+
+## What shipped
+
+- Review-tagged `--auto` routes now always use Conductor-derived provider
+  timeout and stall budgets from prompt size and fallback breadth.
+- Caller-supplied `--timeout` / `--max-stall-seconds` values are ignored for
+  review-gate provider budgets and reported in the route diagnostic when they
+  differ from the Conductor-owned values.
+- CLI help and README guidance now describe review-gate budgets as
+  Conductor-owned instead of customer-guessed timeout flags.
+- Generated Conductor delegation blocks in this repo were refreshed to
+  v0.10.11 after the release landed.
+
+## Downstream docs this changes
+
+- README.md - review-gate timeout/stall budget ownership.
+- AGENTS.md - generated Conductor delegation block version.
+- GEMINI.md - generated Conductor delegation block version.
+- .cursor/rules/conductor-delegation.mdc - generated Conductor delegation block
+  version.
+- Homebrew tap repo (`autumngarage/homebrew-conductor`) - formula `url` and
+  `sha256`.
+
+## Follow-ups (deferred to future work)
+
+None.

--- a/.cursor/rules/conductor-delegation.mdc
+++ b/.cursor/rules/conductor-delegation.mdc
@@ -2,7 +2,7 @@
 description: Use when delegating or routing tasks to a different LLM via the conductor CLI — e.g., cheap second opinions, long-context reads, web search, or offline runs.
 globs: ""
 alwaysApply: false
-managed-by: conductor v0.10.10
+managed-by: conductor v0.10.11
 ---
 
 # Conductor delegation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ If there are zero blocking issues, the review is just: "LGTM."
 
 @.cortex/protocol.md
 
-<!-- conductor:begin v0.10.10 -->
+<!-- conductor:begin v0.10.11 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
 
-<!-- conductor:begin v0.10.10 -->
+<!-- conductor:begin v0.10.11 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)


### PR DESCRIPTION
## Summary
- record the v0.10.11 release journal entry required by Cortex T1.10
- refresh generated Conductor delegation markers in this repo to v0.10.11

## Validation
- `git diff --cached --check`
- commit hooks
- pre-push hooks
