### PR TITLE
[codex] Surface provider fallback error detail

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -1009,6 +1009,8 @@ _EMPTY_RESPONSE_ERROR_SIGNALS = (
     "produced empty final",
 )
 
+_FALLBACK_ERROR_DETAIL_MAX_CHARS = 500
+
 
 def _is_retryable(err: Exception) -> tuple[bool, str]:
     """Classify an error as retryable-with-fallback or fatal.
@@ -1039,6 +1041,17 @@ def _is_retryable(err: Exception) -> tuple[bool, str]:
     if isinstance(err, ProviderHTTPError):
         return True, "provider-error"
     return False, "other"
+
+
+def _format_fallback_error_detail(err: Exception) -> str:
+    """Return a compact one-line error detail for fallback diagnostics."""
+    message = " ".join(str(err).strip().split())
+    if not message:
+        message = "(no message)"
+    detail = f"{err.__class__.__name__}: {message}"
+    if len(detail) <= _FALLBACK_ERROR_DETAIL_MAX_CHARS:
+        return detail
+    return detail[: _FALLBACK_ERROR_DETAIL_MAX_CHARS - 3].rstrip() + "..."
 
 
 def _review_failure_mode(err: Exception) -> str:
@@ -2035,6 +2048,7 @@ def _invoke_with_fallback(
                 failure_event: dict[str, object] = {
                     "provider": candidate.name,
                     "category": category,
+                    "error_class": e.__class__.__name__,
                     "error": str(e),
                 }
                 if isinstance(e, ProviderExecutionError):
@@ -2076,6 +2090,7 @@ def _invoke_with_fallback(
                 if not silent:
                     click.echo(
                         f"[conductor] {candidate.name} failed ({category}) · "
+                        f"{_format_fallback_error_detail(e)} · "
                         f"falling through to {next_name} (falling back → {next_name})",
                         err=True,
                     )
@@ -2199,8 +2214,14 @@ def _invoke_review_with_fallback(
             tried.append((candidate.name, "review-context"))
 
         if idx + 1 < len(candidates) and not silent:
+            detail = (
+                _format_fallback_error_detail(last_exc)
+                if last_exc is not None
+                else "unknown error"
+            )
             click.echo(
                 f"[conductor] {candidate.name} review failed ({tried[-1][1]}) · "
+                f"{detail} · "
                 f"falling back → {candidates[idx + 1].name}",
                 err=True,
             )
@@ -2208,12 +2229,14 @@ def _invoke_review_with_fallback(
     assert last_exc is not None
     if tried:
         trail = _format_tried_providers(tried)
+        last_detail = _format_fallback_error_detail(last_exc)
         hint = (
             "increase --max-fallbacks, exclude failing providers, or run "
             "`conductor list` to check configured code-review providers"
         )
         raise ProviderError(
-            f"code review failed for all tried providers: {trail}. Next step: {hint}."
+            f"code review failed for all tried providers: {trail}. "
+            f"Last error: {last_detail}. Next step: {hint}."
         ) from last_exc
     raise last_exc
 

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -3502,6 +3502,7 @@ def test_call_fallback_on_rate_limit(mocker):
 
     assert result.exit_code == 0
     assert "claude failed (rate-limit)" in result.stderr
+    assert "ProviderHTTPError: Anthropic returned 429 rate limit" in result.stderr
 
 
 def test_call_no_fallback_on_auth_error(mocker):

--- a/tests/test_review_cascade.py
+++ b/tests/test_review_cascade.py
@@ -263,6 +263,7 @@ def test_review_exhausted_error_includes_tried_provider_trail(mocker) -> None:
     assert result.exit_code == 1
     assert "code review failed for all tried providers" in result.stderr
     assert "claude (rate-limit), codex (stall), openrouter (5xx)" in result.stderr
+    assert "ProviderHTTPError: OpenRouter returned HTTP 503" in result.stderr
     assert "Next step:" in result.stderr
 
 


### PR DESCRIPTION
## Summary

- Include a compact `ExceptionClass: message` detail in provider fallback diagnostics.
- Add `error_class` to structured provider failure session-log events.
- Preserve the last underlying provider error in exhausted review fallback failures.

## Why

Provider fallthrough currently reports only the broad category, which makes `--auto` failures hard to triage when the next provider also fails. This keeps the existing routing categories stable while exposing enough context to distinguish quota, upstream, provider, and local wrapper failures.

Fixes #302.

## Validation

- `PYTHONPATH=src pytest -q tests/test_cli_v02.py tests/test_review_cascade.py`
- `ruff check src/conductor/cli.py tests/test_cli_v02.py tests/test_review_cascade.py`
- `PYTHONPATH=src python3 -m compileall -q src/conductor/cli.py`
- `git diff --check`
