### PR TITLE
[codex] Handle provider response shape failures

### DIFF
--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -92,13 +92,18 @@ CODEX_STREAM_EXIT_READER_JOIN_SEC = 0.2
 # only in the first case; explicit None means run unbounded.
 _USE_DEFAULT: object = object()
 
-# Map symbolic effort → codex's reasoning-effort value.
-# Codex natively exposes minimal|low|medium|high. The CLI plumbs this via
-# `-c model_reasoning_effort=<value>` as of codex-cli 0.125.0 (the older
-# `--effort` flag was removed in that release). We always emit the new
-# form; users on pre-0.125.0 codex will need to upgrade.
+# Map symbolic effort → codex's reasoning-effort value. The CLI plumbs this
+# via `-c model_reasoning_effort=<value>` as of codex-cli 0.125.0 (the older
+# `--effort` flag was removed in that release). We always emit the new form;
+# users on pre-0.125.0 codex will need to upgrade.
+#
+# Codex CLI's default tool configuration currently rejects
+# `model_reasoning_effort=minimal` because built-in tools such as web_search
+# and image_gen are not allowed at that reasoning tier. Conductor cannot fully
+# control those implicit tools from its narrow Provider contract, so `minimal`
+# dispatches at Codex's lowest compatible tier: `low`.
 _EFFORT_TO_CODEX_FLAG = {
-    "minimal": "minimal",
+    "minimal": "low",
     "low": "low",
     "medium": "medium",
     "high": "high",

--- a/src/conductor/providers/openrouter.py
+++ b/src/conductor/providers/openrouter.py
@@ -341,7 +341,9 @@ class OpenRouterProvider:
                 attempts=attempts,
             )
             if retry_payload is None:
-                raise ProviderHTTPError("OpenRouter produced empty response content")
+                raise ProviderHTTPError(
+                    _empty_call_response_message(body, fallback_model=selected_model)
+                )
             attempts.append(
                 {
                     "reason": "empty-response",
@@ -1197,16 +1199,51 @@ def _remaining_timeout_sec(
 
 def _call_response_text(body: dict) -> str:
     try:
-        text = body["choices"][0]["message"]["content"]
+        message = body["choices"][0]["message"]
     except (KeyError, IndexError, TypeError) as e:
         raise ProviderHTTPError(
             f"OpenRouter response missing choices[0].message.content: {body!r:.500}"
         ) from e
-    if not isinstance(text, str):
+    if not isinstance(message, dict):
         raise ProviderHTTPError(
-            f"OpenRouter response content was not text: {type(text).__name__}"
+            f"OpenRouter response choices[0].message was not an object: {message!r:.500}"
+        )
+    if "content" not in message:
+        raise ProviderHTTPError(
+            f"OpenRouter response missing choices[0].message.content: {body!r:.500}"
+        )
+    text = message["content"]
+    if text is None:
+        return ""
+    if not isinstance(text, str):
+        finish_reason = _first_finish_reason(body)
+        raise ProviderHTTPError(
+            "OpenRouter response content was not text: "
+            f"model={_response_model(body, fallback=None)} "
+            f"content_type={type(text).__name__} "
+            f"finish_reason={finish_reason or '<unknown>'}"
         )
     return text
+
+
+def _empty_call_response_message(body: dict, *, fallback_model: str | None) -> str:
+    message = _first_message(body)
+    content = message.get("content")
+    finish_reason = _first_finish_reason(body)
+    return (
+        "OpenRouter produced empty response content: "
+        f"model={_response_model(body, fallback=fallback_model)} "
+        f"content_type={type(content).__name__} "
+        f"finish_reason={finish_reason or '<unknown>'}"
+    )
+
+
+def _first_finish_reason(body: dict) -> str | None:
+    try:
+        finish_reason = body["choices"][0].get("finish_reason")
+    except (AttributeError, IndexError, KeyError, TypeError):
+        return None
+    return finish_reason if isinstance(finish_reason, str) else None
 
 
 def _response_model(body: dict, *, fallback: str | None) -> str:

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -1711,11 +1711,16 @@ def test_codex_call_reads_output_backstop_when_ndjson_loses_agent_message(
     assert response.raw["output_path"] == str(output_path)
 
 
-def test_codex_call_translates_effort_to_reasoning_effort_config(mocker):
+def test_codex_call_clamps_minimal_effort_to_codex_compatible_low(mocker):
     """Codex CLI 0.125.0 dropped --effort in favor of `-c model_reasoning_effort=`.
     Conductor must emit the new form. Regression test for the silent breakage
     where conductor's call passed `--effort minimal` to a 0.125.0 codex CLI,
-    which exited 2 with `error: unexpected argument '--effort' found`."""
+    which exited 2 with `error: unexpected argument '--effort' found`.
+
+    Codex later rejected `model_reasoning_effort=minimal` when implicit built-in
+    tools were enabled, so Conductor clamps `minimal` to Codex's lowest
+    compatible tier.
+    """
     mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
     captured = mocker.patch(
         "conductor.providers.codex.subprocess.run",
@@ -1728,12 +1733,31 @@ def test_codex_call_translates_effort_to_reasoning_effort_config(mocker):
         "codex CLI >= 0.125.0 removed --effort; conductor must use -c instead. "
         f"args={args!r}"
     )
-    # New form: -c model_reasoning_effort=minimal must be present together.
+    # New form: -c model_reasoning_effort=low must be present together.
     assert "-c" in args, f"missing -c flag, args={args!r}"
     c_idx = args.index("-c")
-    assert args[c_idx + 1] == "model_reasoning_effort=minimal", (
-        f"expected `model_reasoning_effort=minimal`, got {args[c_idx + 1]!r}"
+    assert args[c_idx + 1] == "model_reasoning_effort=low", (
+        f"expected `model_reasoning_effort=low`, got {args[c_idx + 1]!r}"
     )
+
+
+def test_codex_exec_clamps_minimal_effort_to_codex_compatible_low(mocker):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    fake = _FakePopen(
+        stdout_schedule=[(0, line) for line in CODEX_NDJSON.splitlines(keepends=True)]
+    )
+    _patch_codex_popen(mocker, fake)
+
+    CodexProvider().exec("hi", effort="minimal")
+
+    assert fake.args is not None
+    config_values = [
+        fake.args[idx + 1]
+        for idx, value in enumerate(fake.args)
+        if value == "-c"
+    ]
+    assert "model_reasoning_effort=low" in config_values
+    assert "model_reasoning_effort=minimal" not in config_values
 
 
 def test_codex_call_with_resume_uses_resume_subcommand(mocker):

--- a/tests/test_openrouter.py
+++ b/tests/test_openrouter.py
@@ -168,6 +168,63 @@ def test_call_empty_response_retries_remaining_models(configured):
     ]
 
 
+def test_call_none_response_retries_remaining_models(configured):
+    requests: list[dict] = []
+    responses = [
+        {
+            "model": "model-a",
+            "choices": [
+                {"message": {"content": None}, "finish_reason": "stop"}
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 0},
+        },
+        {
+            "model": "model-b",
+            "choices": [{"message": {"content": "usable"}}],
+            "usage": {"prompt_tokens": 11, "completion_tokens": 2},
+        },
+    ]
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content))
+        return httpx.Response(200, json=responses[len(requests) - 1])
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.post("/chat/completions").mock(side_effect=_record)
+        response = OpenRouterProvider().call(
+            "Review this.",
+            models=("model-a", "model-b"),
+            log_selection=False,
+        )
+
+    assert response.text == "usable"
+    assert requests[0]["models"] == ["model-a", "model-b"]
+    assert requests[1]["models"] == ["model-b"]
+    assert response.raw["empty_response_retries"] == [
+        {"reason": "empty-response", "model": "model-a"}
+    ]
+
+
+def test_call_none_response_without_fallback_includes_response_shape(configured):
+    body = {
+        "model": "model-a",
+        "choices": [{"message": {"content": None}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 0},
+    }
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.post("/chat/completions").mock(
+            return_value=httpx.Response(200, json=body)
+        )
+        with pytest.raises(ProviderHTTPError) as exc:
+            OpenRouterProvider().call("Review this.", model="model-a")
+
+    message = str(exc.value)
+    assert "empty response content" in message
+    assert "model=model-a" in message
+    assert "content_type=NoneType" in message
+    assert "finish_reason=stop" in message
+
+
 def test_call_raises_config_error_when_unconfigured(no_key):
     with pytest.raises(ProviderConfigError):
         OpenRouterProvider().call("hello")


### PR DESCRIPTION
## Summary

- Clamp Codex `minimal` effort to `low` for Codex CLI subprocess dispatch so implicit built-in tools do not trigger provider-side 400s.
- Treat OpenRouter `content: null` in call mode as an empty provider response, allowing existing model-stack retry/fallback handling to engage.
- Add response-shape diagnostics for OpenRouter empty responses when no fallback remains.

## Why

Two new provider-shape failures showed up in downstream workflows:

- Codex rejects `model_reasoning_effort=minimal` when implicit built-in tools such as `web_search` and `image_gen` are enabled.
- OpenRouter can return `choices[0].message.content = null`, which Conductor previously surfaced as a non-retryable `NoneType` error with too little context.

This keeps the Provider contract narrow and handles each provider quirk inside the adapter boundary.

Fixes #321.
Fixes #322.

## Validation

- `PYTHONPATH=src pytest -q tests/test_adapters_subprocess.py::test_codex_call_clamps_minimal_effort_to_codex_compatible_low tests/test_adapters_subprocess.py::test_codex_exec_clamps_minimal_effort_to_codex_compatible_low tests/test_openrouter.py::test_call_none_response_retries_remaining_models tests/test_openrouter.py::test_call_none_response_without_fallback_includes_response_shape tests/test_openrouter.py::test_call_empty_response_retries_remaining_models`
- `PYTHONPATH=src pytest -q tests/test_openrouter.py tests/test_adapters_subprocess.py`
- `ruff check src/conductor/providers/codex.py src/conductor/providers/openrouter.py tests/test_adapters_subprocess.py tests/test_openrouter.py`
- `PYTHONPATH=src python3 -m compileall -q src/conductor/providers/codex.py src/conductor/providers/openrouter.py`
- `git diff --check`
