### PR TITLE
Treat invalid review sentinels as provider failures

### DIFF
--- a/.cursor/rules/conductor-delegation.mdc
+++ b/.cursor/rules/conductor-delegation.mdc
@@ -2,7 +2,7 @@
 description: Use when delegating or routing tasks to a different LLM via the conductor CLI — e.g., cheap second opinions, long-context reads, web search, or offline runs.
 globs: ""
 alwaysApply: false
-managed-by: conductor v0.10.11
+managed-by: conductor v0.10.12
 ---
 
 # Conductor delegation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ If there are zero blocking issues, the review is just: "LGTM."
 
 @.cortex/protocol.md
 
-<!-- conductor:begin v0.10.11 -->
+<!-- conductor:begin v0.10.12 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
 
-<!-- conductor:begin v0.10.11 -->
+<!-- conductor:begin v0.10.12 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -71,6 +71,7 @@
 #                                       as the stall threshold (the legacy semantics shipped on
 #                                       a wall-clock cap; the new semantics are stall-based).
 #   CODEX_REVIEW_ON_ERROR             — fail-open (default) or fail-closed
+#   CODEX_REVIEW_REQUIRED             — true/1 means infrastructure errors block regardless of on_error
 #   CODEX_REVIEW_DISABLE_CACHE        — set to true/1 to force a fresh review
 #   CODEX_REVIEW_FORCE                — set to true/1 to run even on non-default-branch pushes
 #   CODEX_REVIEW_NO_AUTOFIX           — set to true/1 for review-only mode (backward compat)
@@ -127,6 +128,7 @@ REVIEW_ENABLED="${CODEX_REVIEW_ENABLED:-true}"
 REVIEW_MAX_STALL_SEC="${CODEX_REVIEW_MAX_STALL_SEC:-${CODEX_REVIEW_TIMEOUT:-300}}"
 REVIEW_TIMEOUT="$REVIEW_MAX_STALL_SEC"  # back-compat alias for legacy callers
 ON_ERROR="${CODEX_REVIEW_ON_ERROR:-fail-open}"
+REVIEW_REQUIRED="${CODEX_REVIEW_REQUIRED:-false}"
 UNSAFE_PATHS=""
 REVIEWER_CASCADE=()
 # Legacy local-reviewer env vars — no longer drive behavior in 2.0+, but
@@ -1316,6 +1318,11 @@ run_reviewer_with_timeout() {
 
 handle_error() {
   local reason="$1"
+
+  if is_truthy "$REVIEW_REQUIRED"; then
+    echo "==> ERROR ($reason) — blocking push (required review did not complete; on_error=$ON_ERROR ignored)." >&2
+    exit 1
+  fi
 
   if [ "$ON_ERROR" = "fail-closed" ]; then
     echo "==> ERROR ($reason) — blocking push (on_error=fail-closed)." >&2

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -523,6 +523,7 @@ run_merge_review() {
     CODEX_REVIEW_BRANCH_NAME="$pr_head_branch" \
     CODEX_REVIEW_FORCE=1 \
     CODEX_REVIEW_MODE=review-only \
+    CODEX_REVIEW_REQUIRED=1 \
     bash "$REVIEW_SCRIPT"
 }
 

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -113,9 +113,10 @@ from conductor.providers import (
 )
 from conductor.providers.review_contract import (
     ReviewContextError,
+    ReviewOutputContractError,
     build_review_patch_context,
     build_review_task_prompt,
-    ensure_requested_review_sentinel,
+    validate_requested_review_sentinel,
 )
 from conductor.router import (
     DEFAULT_ESTIMATED_INPUT_TOKENS,
@@ -1021,6 +1022,8 @@ def _is_retryable(err: Exception) -> tuple[bool, str]:
     so the offline-mode prompt can fire on the real thing (DNS/TCP failure)
     rather than on a slow-but-reachable upstream.
     """
+    if isinstance(err, ReviewOutputContractError):
+        return True, "output-contract"
     if isinstance(err, ProviderStalledError):
         return True, "timeout"
     if isinstance(err, ProviderExecutionError):
@@ -2173,13 +2176,13 @@ def _invoke_review_with_fallback(
                     timeout_sec=timeout_sec,
                     max_stall_sec=max_stall_sec,
                 )
-            repaired_text = ensure_requested_review_sentinel(
+            validated_text = validate_requested_review_sentinel(
                 provider_name=response.provider,
                 prompt=task,
                 text=response.text,
             )
-            if repaired_text != response.text:
-                response = replace(response, text=repaired_text)
+            if validated_text != response.text:
+                response = replace(response, text=validated_text)
             mark_outcome(candidate.name, "success")
             tried.append((candidate.name, "success"))
             if not silent and len(tried) > 1:

--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -34,7 +34,7 @@ from conductor.providers.interface import (
     ProviderStartupStalledError,
     resolve_effort_tokens,
 )
-from conductor.providers.review_contract import ensure_requested_review_sentinel
+from conductor.providers.review_contract import validate_requested_review_sentinel
 
 if TYPE_CHECKING:
     from conductor.session_log import SessionLog
@@ -462,7 +462,7 @@ class ClaudeProvider:
             )
 
         usage = data.get("usage") or {}
-        content = ensure_requested_review_sentinel(
+        content = validate_requested_review_sentinel(
             provider_name=self.name,
             prompt=review_prompt,
             text=data.get("result", ""),

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -42,7 +42,7 @@ from conductor.providers.interface import (
     ProviderStalledError,
     resolve_effort_tokens,
 )
-from conductor.providers.review_contract import ensure_requested_review_sentinel
+from conductor.providers.review_contract import validate_requested_review_sentinel
 from conductor.providers.terminal_signals import (
     append_recent_text,
     detect_retriable_provider_failure,
@@ -604,7 +604,7 @@ class CodexProvider:
             raise ProviderHTTPError(
                 f"codex review produced empty stdout: {result.stderr[:500]!r}"
             )
-        content = ensure_requested_review_sentinel(
+        content = validate_requested_review_sentinel(
             provider_name=self.name,
             prompt=review_prompt,
             text=content,

--- a/src/conductor/providers/gemini.py
+++ b/src/conductor/providers/gemini.py
@@ -34,7 +34,7 @@ from conductor.providers.interface import (
     ProviderHTTPError,
     resolve_effort_tokens,
 )
-from conductor.providers.review_contract import ensure_requested_review_sentinel
+from conductor.providers.review_contract import validate_requested_review_sentinel
 
 if TYPE_CHECKING:
     from conductor.session_log import SessionLog
@@ -365,7 +365,7 @@ class GeminiProvider:
         except json.JSONDecodeError:
             if not stdout:
                 raise ProviderHTTPError("gemini review produced empty stdout") from None
-            content = ensure_requested_review_sentinel(
+            content = validate_requested_review_sentinel(
                 provider_name=self.name,
                 prompt=prompt,
                 text=stdout,
@@ -388,7 +388,7 @@ class GeminiProvider:
             )
 
         content = _extract_review_response_text(data.get("response", ""))
-        content = ensure_requested_review_sentinel(
+        content = validate_requested_review_sentinel(
             provider_name=self.name,
             prompt=prompt,
             text=content,

--- a/src/conductor/providers/review_contract.py
+++ b/src/conductor/providers/review_contract.py
@@ -7,6 +7,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from conductor.providers.interface import ProviderError
+
 _REVIEW_SENTINEL_RE = re.compile(r"^\s*(CODEX_REVIEW_(?:CLEAN|FIXED|BLOCKED))\s*$")
 _REVIEW_SENTINELS = (
     "CODEX_REVIEW_CLEAN",
@@ -16,10 +18,33 @@ _REVIEW_SENTINELS = (
 _SAFE_BLOCKED_SENTINEL = "CODEX_REVIEW_BLOCKED"
 _DEFAULT_PATCH_CONTEXT_MAX_BYTES = 200_000
 _REVIEW_GIT_TIMEOUT_SEC = 30.0
+_CONTRACT_ERROR_PREVIEW_CHARS = 240
 
 
 class ReviewContextError(RuntimeError):
     """Raised when generic review fallback cannot build required patch context."""
+
+
+class ReviewOutputContractError(ProviderError):
+    """Raised when a review provider violates the requested verdict contract."""
+
+    def __init__(
+        self,
+        *,
+        provider_name: str,
+        reason: str,
+        output_preview: str,
+    ) -> None:
+        self.provider_name = provider_name
+        self.reason = reason
+        self.output_preview = output_preview
+        preview = f"; output tail: {output_preview!r}" if output_preview else ""
+        super().__init__(
+            f"{provider_name} review output did not match the expected sentinel "
+            f"contract ({reason}); expected exactly one final standalone "
+            "CODEX_REVIEW_CLEAN, CODEX_REVIEW_FIXED, or CODEX_REVIEW_BLOCKED line"
+            f"{preview}"
+        )
 
 
 def build_review_task_prompt(
@@ -213,19 +238,10 @@ def ensure_requested_review_sentinel(
     if not _prompt_requests_review_sentinel(prompt):
         return text
 
-    stripped = text.strip()
-    lines = stripped.splitlines()
-    sentinel_indexes: list[int] = []
-    for idx, line in enumerate(lines):
-        if _REVIEW_SENTINEL_RE.match(line):
-            sentinel_indexes.append(idx)
-
-    if len(sentinel_indexes) == 1 and sentinel_indexes[0] == len(lines) - 1:
+    reason, stripped, lines = _review_sentinel_violation(text)
+    if reason is None:
         return stripped
 
-    reason = "missing"
-    if sentinel_indexes:
-        reason = "misplaced" if len(sentinel_indexes) == 1 else "multiple"
     print(
         f"[conductor] {provider_name} review repaired {reason} "
         f"Touchstone sentinel; appending {_SAFE_BLOCKED_SENTINEL}",
@@ -238,6 +254,54 @@ def ensure_requested_review_sentinel(
     if body:
         return f"{body}\n{_SAFE_BLOCKED_SENTINEL}"
     return _SAFE_BLOCKED_SENTINEL
+
+
+def validate_requested_review_sentinel(
+    *,
+    provider_name: str,
+    prompt: str,
+    text: str,
+) -> str:
+    """Validate the Touchstone sentinel when the caller requested it.
+
+    Invariant: requested review verdicts are accepted only when the provider
+    emits exactly one standalone sentinel and it is the final non-empty line.
+    Violations are provider output failures so the router can try fallback
+    reviewers instead of manufacturing a verdict.
+    """
+    if not _prompt_requests_review_sentinel(prompt):
+        return text
+
+    reason, stripped, _lines = _review_sentinel_violation(text)
+    if reason is not None:
+        raise ReviewOutputContractError(
+            provider_name=provider_name,
+            reason=reason,
+            output_preview=_contract_error_preview(text),
+        )
+    return stripped
+
+
+def _review_sentinel_violation(text: str) -> tuple[str | None, str, list[str]]:
+    stripped = text.strip()
+    lines = stripped.splitlines()
+    sentinel_indexes = [
+        idx for idx, line in enumerate(lines) if _REVIEW_SENTINEL_RE.match(line)
+    ]
+    if len(sentinel_indexes) == 1 and sentinel_indexes[0] == len(lines) - 1:
+        return None, stripped, lines
+    if not sentinel_indexes:
+        return "missing", stripped, lines
+    if len(sentinel_indexes) == 1:
+        return "misplaced", stripped, lines
+    return "multiple", stripped, lines
+
+
+def _contract_error_preview(text: str) -> str:
+    normalized = " ".join(text.strip().split())
+    if len(normalized) <= _CONTRACT_ERROR_PREVIEW_CHARS:
+        return normalized
+    return normalized[-_CONTRACT_ERROR_PREVIEW_CHARS:]
 
 
 def _prompt_requests_review_sentinel(prompt: str) -> bool:

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -43,6 +43,7 @@ from conductor.providers.interface import (
     ProviderStalledError,
     ProviderStartupStalledError,
 )
+from conductor.providers.review_contract import ReviewOutputContractError
 from conductor.session_log import (
     SESSION_DATA_TOKEN_COUNT,
     SESSION_DATA_USAGE,
@@ -400,7 +401,7 @@ def test_claude_review_uses_native_review_slash_command_read_only(mocker):
     assert response.text == "hello from claude"
 
 
-def test_claude_review_repairs_missing_requested_sentinel(mocker, capsys):
+def test_claude_review_rejects_missing_requested_sentinel(mocker):
     mocker.patch("conductor.providers.claude.shutil.which", return_value="/usr/bin/claude")
     fake = _FakePopen(
         stdout_schedule=[
@@ -420,13 +421,8 @@ def test_claude_review_repairs_missing_requested_sentinel(mocker, capsys):
         side_effect=lambda args, **kwargs: fake,
     )
 
-    response = ClaudeProvider().review("End with CODEX_REVIEW_CLEAN or BLOCKED.")
-
-    assert response.text.endswith("\nCODEX_REVIEW_BLOCKED")
-    assert "CODEX_REVIEW_CLEAN" not in response.text
-    assert "[conductor] claude review repaired missing Touchstone sentinel" in (
-        capsys.readouterr().err
-    )
+    with pytest.raises(ReviewOutputContractError, match="claude review output"):
+        ClaudeProvider().review("End with CODEX_REVIEW_CLEAN or BLOCKED.")
 
 
 def test_claude_call_passes_resume_session_id_as_resume_flag(mocker):
@@ -1642,23 +1638,17 @@ def test_codex_review_uses_native_review_command(mocker):
     assert response.text == "LGTM"
 
 
-def test_codex_review_repairs_missing_requested_sentinel(mocker, capsys):
+def test_codex_review_rejects_missing_requested_sentinel(mocker):
     mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
     mocker.patch(
         "conductor.providers.codex.subprocess.run",
         return_value=_fake_completed(stdout="The changes need operator review.\n"),
     )
 
-    response = CodexProvider().review(
-        "Return a final standalone CODEX_REVIEW_CLEAN or CODEX_REVIEW_BLOCKED line.",
-    )
-
-    assert response.text == (
-        "The changes need operator review.\nCODEX_REVIEW_BLOCKED"
-    )
-    assert "[conductor] codex review repaired missing Touchstone sentinel" in (
-        capsys.readouterr().err
-    )
+    with pytest.raises(ReviewOutputContractError, match="codex review output"):
+        CodexProvider().review(
+            "Return a final standalone CODEX_REVIEW_CLEAN or CODEX_REVIEW_BLOCKED line.",
+        )
 
 
 def test_codex_review_stall_watchdog_fails_fast(mocker):
@@ -3161,10 +3151,9 @@ def test_gemini_review_uses_code_review_extension_command(mocker, monkeypatch):
     assert response.text == "hello from gemini"
 
 
-def test_gemini_review_repairs_missing_requested_sentinel(
+def test_gemini_review_rejects_missing_requested_sentinel(
     mocker,
     monkeypatch,
-    capsys,
 ):
     mocker.patch("conductor.providers.gemini.shutil.which", return_value="/usr/bin/gemini")
     _strip_gemini_auth_env(monkeypatch)
@@ -3183,12 +3172,8 @@ def test_gemini_review_repairs_missing_requested_sentinel(
         side_effect=lambda args, **kwargs: fake,
     )
 
-    response = GeminiProvider().review("End with CODEX_REVIEW_CLEAN or BLOCKED.")
-
-    assert response.text == "Plain review without the marker.\nCODEX_REVIEW_BLOCKED"
-    assert "[conductor] gemini review repaired missing Touchstone sentinel" in (
-        capsys.readouterr().err
-    )
+    with pytest.raises(ReviewOutputContractError, match="gemini review output"):
+        GeminiProvider().review("End with CODEX_REVIEW_CLEAN or BLOCKED.")
 
 
 def test_gemini_review_extracts_inner_json_response_and_preserves_sentinel(

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -1275,6 +1275,49 @@ def test_review_auto_exhausted_fallback_names_stalled_codex_and_claude(mocker):
     assert "claude (timeout), codex (stall)" in result.stderr
 
 
+def test_review_auto_output_contract_failure_falls_through_to_next_provider(mocker):
+    _stub_all_configured(mocker, {"codex", "claude"})
+    mocker.patch.object(CodexProvider, "review_configured", return_value=(True, None))
+    mocker.patch.object(ClaudeProvider, "review_configured", return_value=(True, None))
+    mocker.patch.object(
+        ClaudeProvider,
+        "review",
+        return_value=_fake_response(
+            "claude",
+            "sonnet",
+            text="The patch looks safe, but I omitted the required marker.",
+        ),
+    )
+    mocker.patch.object(
+        CodexProvider,
+        "review",
+        return_value=_fake_response(
+            "codex",
+            "codex-review",
+            text="No blocking issues found.\nCODEX_REVIEW_CLEAN",
+        ),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "review",
+            "--auto",
+            "--brief",
+            (
+                "The LAST line of your output must be exactly one of these "
+                "three sentinels: CODEX_REVIEW_CLEAN, CODEX_REVIEW_FIXED, "
+                "or CODEX_REVIEW_BLOCKED."
+            ),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.stdout.strip().endswith("CODEX_REVIEW_CLEAN")
+    assert "claude review failed (output-contract)" in result.stderr
+    assert "falling back" in result.stderr
+
+
 def test_review_auto_generic_fallback_prompt_includes_diff(mocker, tmp_path):
     from conductor.providers.interface import ProviderStalledError
 
@@ -1381,12 +1424,13 @@ def test_ask_review_uses_openrouter_code_stack_instead_of_gemini(mocker, tmp_pat
     assert payload["semantic"]["candidates"][2]["models"] == list(OPENROUTER_CODING_HIGH)
 
 
-def test_review_auto_generic_fallback_repairs_requested_sentinel(mocker, tmp_path):
+def test_review_auto_generic_fallback_rejects_missing_requested_sentinel(
+    mocker, tmp_path
+):
     from conductor.providers.interface import ProviderStalledError
 
-    # Regression for issue #137's weak point: before the CLI-level guard, a
-    # call()-based review fallback returned this prose unchanged and the hook
-    # later failed closed with malformed-sentinel.
+    # Missing review sentinels are provider contract failures. The CLI must not
+    # manufacture a verdict for a generic call()-based review fallback.
     repo = _make_diff_repo(tmp_path)
     _stub_all_configured(mocker, {"codex", "claude", "openrouter"})
     mocker.patch.object(CodexProvider, "review_configured", return_value=(True, None))
@@ -1437,14 +1481,13 @@ def test_review_auto_generic_fallback_repairs_requested_sentinel(mocker, tmp_pat
         ],
     )
 
-    assert result.exit_code == 0, result.output
-    lines = result.stdout.strip().splitlines()
-    assert lines[-1] == "CODEX_REVIEW_BLOCKED"
-    assert sum(1 for line in lines if line.startswith("CODEX_REVIEW_")) == 1
-    assert "review repaired missing Touchstone sentinel" in result.stderr
+    assert result.exit_code == 1
+    assert "code review failed for all tried providers" in result.stderr
+    assert "openrouter (output-contract)" in result.stderr
+    assert "ReviewOutputContractError" in result.stderr
 
 
-def test_review_auto_codex_subprocess_repairs_requested_sentinel(mocker):
+def test_review_auto_codex_subprocess_rejects_missing_requested_sentinel(mocker):
     # Exercises the same conductor review --auto -> codex subprocess path used
     # by scripts/codex-review.sh when codex is the selected native reviewer.
     _stub_all_configured(mocker, {"codex"})
@@ -1477,10 +1520,9 @@ def test_review_auto_codex_subprocess_repairs_requested_sentinel(mocker):
         ],
     )
 
-    assert result.exit_code == 0, result.output
-    lines = result.stdout.strip().splitlines()
-    assert lines[-1] == "CODEX_REVIEW_BLOCKED"
-    assert sum(1 for line in lines if line.startswith("CODEX_REVIEW_")) == 1
+    assert result.exit_code == 1
+    assert "code review failed for all tried providers" in result.stderr
+    assert "codex (output-contract)" in result.stderr
 
 
 def test_review_with_gemini_emits_plain_text_without_json_envelope(mocker):

--- a/tests/test_codex_review_sentinel.py
+++ b/tests/test_codex_review_sentinel.py
@@ -289,6 +289,61 @@ def test_codex_review_wrapper_blocks_malformed_sentinel_even_fail_open(
     assert "regardless of on_error=fail-open" in result.stdout
 
 
+def test_codex_review_wrapper_required_review_blocks_reviewer_error_fail_open(
+    tmp_path: Path,
+) -> None:
+    repo, env = _make_review_repo(tmp_path)
+    fakes = tmp_path / "fakes"
+    fakes.mkdir()
+    conductor = fakes / "conductor"
+    conductor.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            case "$1" in
+              doctor)
+                printf '{"configured": true}\\n'
+                ;;
+              review|exec)
+                cat >/dev/null
+                printf 'provider chain exhausted after rate limits\\n' >&2
+                exit 1
+                ;;
+              *)
+                exit 1
+                ;;
+            esac
+            """
+        ),
+        encoding="utf-8",
+    )
+    conductor.chmod(0o755)
+
+    script = Path(__file__).resolve().parent.parent / "scripts" / "codex-review.sh"
+    result = subprocess.run(
+        ["bash", str(script)],
+        cwd=repo,
+        env={
+            **env,
+            "PATH": f"{fakes}:{os.environ.get('PATH', '')}",
+            "CODEX_REVIEW_BASE": "HEAD~1",
+            "CODEX_REVIEW_MODE": "review-only",
+            "CODEX_REVIEW_REQUIRED": "1",
+            "CODEX_REVIEW_DISABLE_CACHE": "1",
+            "CODEX_REVIEW_TIMEOUT": "5",
+            "NO_COLOR": "1",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "review failed with exit 1" in result.stdout
+    assert "required review did not complete" in result.stderr
+    assert "on_error=fail-open ignored" in result.stderr
+
+
 def test_codex_review_wrapper_falls_back_when_conductor_lacks_review(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_review_contract.py
+++ b/tests/test_review_contract.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import pytest
 
-from conductor.providers.review_contract import ensure_requested_review_sentinel
+from conductor.providers.review_contract import (
+    ReviewOutputContractError,
+    ensure_requested_review_sentinel,
+    validate_requested_review_sentinel,
+)
 
 STRICT_SENTINEL_PROMPT = """
 ## Output contract -- strict
@@ -26,16 +30,38 @@ The LAST line of your output must be exactly one of these three sentinels:
 def test_review_sentinel_contract_accepts_each_final_sentinel(sentinel: str):
     text = f"Review body.\n{sentinel}\n"
 
-    repaired = ensure_requested_review_sentinel(
+    validated = validate_requested_review_sentinel(
         provider_name="codex",
         prompt=STRICT_SENTINEL_PROMPT,
         text=text,
     )
 
-    assert repaired == f"Review body.\n{sentinel}"
+    assert validated == f"Review body.\n{sentinel}"
 
 
-def test_review_sentinel_contract_repairs_prose_without_standalone_sentinel():
+def test_review_sentinel_contract_rejects_prose_without_standalone_sentinel():
+    with pytest.raises(ReviewOutputContractError, match="missing") as exc_info:
+        validate_requested_review_sentinel(
+            provider_name="codex",
+            prompt=STRICT_SENTINEL_PROMPT,
+            text=(
+                "I did not find a blocking issue. The reviewer should emit "
+                "CODEX_REVIEW_CLEAN for that case."
+            ),
+        )
+    assert "output tail:" in str(exc_info.value)
+
+
+def test_review_sentinel_contract_rejects_multiple_sentinels():
+    with pytest.raises(ReviewOutputContractError, match="multiple"):
+        validate_requested_review_sentinel(
+            provider_name="codex",
+            prompt=STRICT_SENTINEL_PROMPT,
+            text="Review body.\nCODEX_REVIEW_CLEAN\nCODEX_REVIEW_BLOCKED\n",
+        )
+
+
+def test_legacy_review_sentinel_repair_helper_fails_closed():
     repaired = ensure_requested_review_sentinel(
         provider_name="codex",
         prompt=STRICT_SENTINEL_PROMPT,


### PR DESCRIPTION
## Summary
- validate requested review sentinels instead of repairing provider output in review-gate paths
- classify sentinel contract violations as fallback-eligible provider failures
- make merge-required reviews block infrastructure failures even when general hook policy is fail-open

Fixes #319.
Refs #318.

## Tests
- `PYTHONPATH=/Users/henry/repos/conductor/src pytest -q`
- `ruff check src tests`
- `PYTHONPATH=/Users/henry/repos/conductor/src python3 -m compileall -q src tests`