### PR TITLE
fix: simplify review routing

### DIFF
--- a/.cursor/rules/conductor-delegation.mdc
+++ b/.cursor/rules/conductor-delegation.mdc
@@ -2,7 +2,7 @@
 description: Use when delegating or routing tasks to a different LLM via the conductor CLI — e.g., cheap second opinions, long-context reads, web search, or offline runs.
 globs: ""
 alwaysApply: false
-managed-by: conductor v0.10.12
+managed-by: conductor v0.10.13
 ---
 
 # Conductor delegation
@@ -27,8 +27,8 @@ Use it when:
 - You want a cheap second opinion (`conductor call --with kimi --brief "..."`).
 - You need fresh web information (`conductor call --with gemini --brief "..."`).
 - You want to stay local / offline (`conductor call --with ollama --brief "..."`).
-- You want a native code review:
-  `conductor review --auto --base origin/main --brief-file /tmp/review.md`.
+- You want a code review cascade:
+  `conductor review --base origin/main --brief-file /tmp/review.md`.
 - You're not sure which provider fits — let the router pick:
   `conductor call --auto --tags <tag1>,<tag2> --brief "..."`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ If there are zero blocking issues, the review is just: "LGTM."
 
 @.cortex/protocol.md
 
-<!-- conductor:begin v0.10.12 -->
+<!-- conductor:begin v0.10.13 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
 
-<!-- conductor:begin v0.10.12 -->
+<!-- conductor:begin v0.10.13 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ conductor call --with kimi --model moonshotai/kimi-k2 --brief "..."
 # Get the full response as JSON (for scripting)
 conductor call --with kimi --brief "ping" --json
 
-# Read-only code review uses native review entrypoints when available
-conductor review --auto --base origin/main --brief-file /tmp/review.md
+# Read-only code review uses the semantic review cascade by default
+conductor review --base origin/main --brief-file /tmp/review.md
 
 # Semantic API: say what kind of work this is and let Conductor pick
 conductor ask --kind research --effort medium --brief-file /tmp/brief.md
@@ -108,7 +108,7 @@ Shipped:
 - `conductor call --with <id> --brief "..."` — manual mode for any provider.
 - `conductor call --auto [--tags a,b,c] --brief "..."` — rule-based router picks the best configured provider for the task's tags.
 - `conductor swarm --brief a.md --brief b.md --provider codex --max-parallel 2 --json` — first-class multi-task coding supervisor with isolated worktrees and structured per-task results.
-- `conductor review --auto --base <ref> --brief-file <path>` — code review routed only to native review providers (`codex review`, Claude `/review`, Gemini `/code-review` extension).
+- `conductor review --base <ref> --brief-file <path>` — code review uses the same semantic review cascade as `ask --kind review`: Codex native review, then Claude native review, then an OpenRouter hosted review prompt. Use `--with <provider>` to hard-pin one provider.
 - `conductor list [--json]` — shows every provider with ready/not-ready status, default model, and capability tags.
 - `conductor smoke <id>` / `conductor smoke --all [--json]` — proves a provider's auth + endpoint work (cheapest round-trip that exercises the full path).
 - `conductor doctor [--json]` — diagnostic report: which providers are configured, which env vars are set, what's in the macOS Keychain.

--- a/docs/consumers.md
+++ b/docs/consumers.md
@@ -30,8 +30,8 @@ conductor call --with <provider> [options]
 # Force the local provider
 conductor call --offline [options]
 
-# Native code-review mode
-conductor review --auto --base <branch-or-ref> [options]
+# Code-review mode; auto-routed by default when --with is absent
+conductor review --base <branch-or-ref> [options]
 conductor review --with <provider> --base <branch-or-ref> [options]
 
 # Agentic code/edit mode
@@ -41,9 +41,9 @@ conductor exec --with <provider> --permission-profile <read-only|patch|full> [op
 
 Use `conductor ask` when the caller knows the semantic kind but does not want to reason about providers. It applies Conductor's deterministic `kind × effort` matrix, then delegates to `call`, `exec`, `review`, or council fan-out internally. Provider/model/tag/tool overrides intentionally stay on the lower-level `call`, `exec`, and `review` commands.
 
-Usually, exactly one of `--auto` or `--with` is required for `call`, `exec`, and `review`. `--auto` runs the router using `--tags`, `--prefer`, and `--exclude` to pick a configured provider; `--with` bypasses the router for direct provider use. `--offline` is the exception: it may be used without `--auto` or `--with`, sets the sticky offline flag, and rewrites the call to `--with ollama`. Passing `--offline --with <non-ollama>` is an error. `--no-offline` clears the sticky flag, then normal `--auto` / `--with` rules apply.
+Usually, exactly one of `--auto` or `--with` is required for `call` and `exec`. `review` is auto-routed by default when `--with` is absent; `--auto` remains accepted for compatibility. `--auto` runs the router using `--tags`, `--prefer`, and `--exclude` to pick a configured provider; `--with` bypasses the router for direct provider use. `--offline` is the exception for `call` and `exec`: it may be used without `--auto` or `--with`, sets the sticky offline flag, and rewrites the call to `--with ollama`. Passing `--offline --with <non-ollama>` is an error. `--no-offline` clears the sticky flag, then normal `--auto` / `--with` rules apply.
 
-Use `conductor review` for code review. It only routes to providers with native review entrypoints: Codex `codex review`, Claude Code `/review`, and Gemini CLI `/code-review` when the Code Review extension is installed. Use `conductor exec` for engineering or auto-fix tasks that may edit files.
+Use `conductor review` for code review. Its auto route uses the same semantic review cascade as `conductor ask --kind review`: Codex `codex review`, Claude Code `/review`, then an OpenRouter hosted review prompt. Use `--with codex` / `--with claude` for a native-review hard pin, or `--with openrouter` for a hosted-review hard pin. Use `conductor exec` for engineering or auto-fix tasks that may edit files.
 
 ## Semantic matrix
 
@@ -57,7 +57,7 @@ Use `conductor review` for code review. It only routes to providers with native 
 | `code` | `minimal`, `low` | `call` | `openrouter` auto with coding/cheap bias → `ollama` |
 | `code` | `medium` | `call` | `openrouter` auto with coding/thinking bias → `ollama` |
 | `code` | `high`, `max` | `exec` | `codex` -> `claude` -> `openrouter` -> `ollama`, with `Read,Grep,Glob,Edit,Write,Bash`; exec runs unsandboxed, and callers can opt into tool permission profiles |
-| `review` | all levels | `review` | `codex` → `claude` → `gemini`, native review only |
+| `review` | all levels | `review` | `codex` -> `claude` -> `openrouter` hosted review prompt |
 | `council` | `minimal`, `low` | `council` | OpenRouter fan-out: `~google/gemini-flash-latest`, `~openai/gpt-mini-latest`; synthesize with the same stack |
 | `council` | `medium` | `council` | OpenRouter fan-out: `~google/gemini-pro-latest`, `~moonshotai/kimi-latest`, `deepseek/deepseek-v4-pro`; synthesize with `~google/gemini-pro-latest` → `~openai/gpt-latest` |
 | `council` | `high`, `max` | `council` | OpenRouter fan-out: `~google/gemini-pro-latest`, `~anthropic/claude-sonnet-latest`, `~openai/gpt-latest`, `deepseek/deepseek-v4-pro`, `qwen/qwen3.6-max-preview`; synthesize with `~openai/gpt-latest` → `~anthropic/claude-sonnet-latest` |
@@ -237,10 +237,10 @@ Consumers should handle `0` as success and treat every non-zero code as failure.
 
 ### Touchstone — code review
 
-Merge and pre-push review-only gates call Conductor's native review intent:
+Merge and pre-push review-only gates call Conductor's review intent:
 
 ```bash
-conductor review --auto --tags code-review --effort medium \
+conductor review --effort medium \
   --base origin/main --brief-file /tmp/review-prompt.txt \
   --json --silent-route
 ```
@@ -280,7 +280,7 @@ conductor ask --kind council --effort medium --brief-file /tmp/brief.md \
   --council-max-cost-usd 0.10 --json
 ```
 
-For merge review, Touchstone should continue to use `conductor review` or `conductor ask --kind review`; both must trigger native review mode, not generic code chat.
+For merge review, Touchstone should continue to use `conductor review` or `conductor ask --kind review`; both must trigger the review cascade, not generic code chat.
 
 ## Versioning policy
 

--- a/src/conductor/_agent_templates.py
+++ b/src/conductor/_agent_templates.py
@@ -84,9 +84,9 @@ Manual provider calls are the escape hatch, not the default:
 
     conductor call --with <provider> --brief "..."
 
-Read-only code review using native provider review mode:
+Read-only code review using Conductor's review cascade:
 
-    conductor review --auto --base origin/main \\
+    conductor review --base origin/main \\
         --brief-file /tmp/review-brief.md
 
 Pipe content in as the brief:
@@ -597,8 +597,8 @@ Use it when:
 - You want a cheap second opinion (`conductor call --with kimi --brief "..."`).
 - You need fresh web information (`conductor call --with gemini --brief "..."`).
 - You want to stay local / offline (`conductor call --with ollama --brief "..."`).
-- You want a native code review:
-  `conductor review --auto --base origin/main --brief-file /tmp/review.md`.
+- You want a code review cascade:
+  `conductor review --base origin/main --brief-file /tmp/review.md`.
 - You're not sure which provider fits — let the router pick:
   `conductor call --auto --tags <tag1>,<tag2> --brief "..."`.
 
@@ -653,9 +653,9 @@ When invoked:
    - `offline` — user explicitly asked for local-only
    Pick 1–3 tags; do NOT invent new ones.
 3. If the task is a code review and you are not using `ask`, use
-   native review mode:
+   Conductor's review cascade:
 
-       conductor review --auto --tags code-review,<tag> --base <base-ref> \\
+       conductor review --tags code-review,<tag> --base <base-ref> \\
            --brief-file /tmp/conductor-review-brief.md --json
 
    Use this for PR/merge review. Do not use it for auto-fix work; fixes

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -1184,6 +1184,31 @@ def _semantic_priority(plan: SemanticPlan) -> tuple[str, ...]:
     return tuple(candidate.provider for candidate in plan.candidates)
 
 
+def _apply_semantic_priority_to_decision(
+    decision: RouteDecision,
+    plan: SemanticPlan,
+) -> RouteDecision:
+    """Make the semantic candidate order the dispatch order after router filters."""
+    priority = {provider: idx for idx, provider in enumerate(_semantic_priority(plan))}
+    ranked = tuple(
+        sorted(decision.ranked, key=lambda candidate: priority.get(candidate.name, len(priority)))
+    )
+    if not ranked:
+        return decision
+    winner = ranked[0]
+    return replace(
+        decision,
+        provider=winner.name,
+        thinking_budget=winner.estimated_thinking_tokens,
+        tier=winner.tier,
+        matched_tags=winner.matched_tags,
+        ranked=ranked,
+        estimated_input_tokens=winner.estimated_input_tokens,
+        estimated_output_tokens=winner.estimated_output_tokens,
+        estimated_thinking_tokens=winner.estimated_thinking_tokens,
+    )
+
+
 def _requires_strong_code_provider(plan: SemanticPlan) -> bool:
     return plan.kind == "code" and plan.effort_bucket in {"high", "max"}
 
@@ -3976,6 +4001,7 @@ def ask(
                 shadow=True,
                 estimated_input_tokens=review_estimated_input_tokens,
             )
+            decision = _apply_semantic_priority_to_decision(decision, plan)
         except (NoConfiguredProvider, InvalidRouterRequest, MutedProvidersError) as e:
             click.echo(f"conductor: {_native_review_unavailable_message(review_reasons)}", err=True)
             click.echo(f"conductor: {e}", err=True)
@@ -4576,7 +4602,7 @@ def call(
         )
         max_stall_sec = _normalize_max_stall_sec(max_stall_sec)
         try:
-            if isinstance(provider, OpenRouterProvider):
+            if provider_id == "openrouter" and isinstance(provider, OpenRouterProvider):
                 response = provider.call(
                     body,
                     model=model,
@@ -4663,7 +4689,10 @@ def call(
     "--with",
     "provider_id",
     default=None,
-    help="Native review provider identifier (codex, claude, gemini).",
+    help=(
+        "Review provider identifier. Native review providers use their review "
+        "entrypoint; openrouter uses a hosted review prompt."
+    ),
 )
 @click.option(
     "--profile",
@@ -4849,10 +4878,11 @@ def review(
     )
     exclude = _resolve_layered_value(exclude, env_key="CONDUCTOR_EXCLUDE")
 
+    implicit_auto = provider_id is None
+    auto_route = auto or implicit_auto
+
     if auto and provider_id:
         raise click.UsageError("--with and --auto are mutually exclusive.")
-    if not auto and not provider_id:
-        raise click.UsageError("pass --with <id> or --auto.")
     if provider_id and exclude and provider_id in _parse_csv(exclude):
         raise click.UsageError(
             f"--with {provider_id} and --exclude {exclude} contradict each other."
@@ -4881,21 +4911,27 @@ def review(
     )
     dispatch_started_at = time.monotonic()
     max_fallbacks = _validate_max_fallbacks(max_fallbacks)
-    prefer_value = _validate_prefer(prefer) if prefer is not None else "best"
+    prefer_value = _validate_prefer(prefer) if prefer is not None else None
 
     decision: RouteDecision | None = None
-    if auto:
+    if auto_route:
+        plan = plan_for("review", effort_value)
+        user_tags = tuple(_parse_csv(tags))
+        plan = _with_user_semantic_tags(plan, user_tags)
         user_exclude = frozenset(_parse_csv(exclude))
         review_exclude, review_reasons = _review_exclude_set(user_exclude)
+        exclude_set = _semantic_candidate_exclude_set(plan, review_exclude)
         try:
             _provider, decision = pick(
-                _review_tags(tags),
-                prefer=prefer_value,
+                list(plan.tags),
+                prefer=prefer_value or plan.prefer,
                 effort=effort_value,
-                exclude=review_exclude,
+                exclude=exclude_set,
+                priority=_semantic_priority(plan),
                 shadow=True,
                 estimated_input_tokens=estimated_input_tokens,
             )
+            decision = _apply_semantic_priority_to_decision(decision, plan)
         except (NoConfiguredProvider, InvalidRouterRequest, MutedProvidersError) as e:
             click.echo(f"conductor: {_native_review_unavailable_message(review_reasons)}", err=True)
             click.echo(f"conductor: {e}", err=True)
@@ -4933,6 +4969,11 @@ def review(
                 title=title,
                 silent=silent_route or as_json,
                 max_fallbacks=max_fallbacks,
+                models_by_provider={
+                    candidate.provider: candidate.models
+                    for candidate in plan.candidates
+                    if candidate.models
+                },
             )
         except ProviderConfigError as e:
             _record_failed_delegation(
@@ -4964,14 +5005,7 @@ def review(
             provider = get_provider(provider_id)
         except KeyError as e:
             raise click.UsageError(str(e)) from e
-        review_provider = _review_provider_or_none(provider)
-        if review_provider is None:
-            raise click.UsageError(f"provider {provider_id!r} does not expose native code review.")
         print_caller_banner(provider_id, silent=silent_route or as_json)
-        ok, reason = review_provider.review_configured()
-        if not ok:
-            click.echo(f"conductor: {reason or 'native review is not configured'}", err=True)
-            sys.exit(2)
         timeout_sec, max_stall_sec = _scale_dispatch_defaults(
             provider_id=provider_id,
             timeout_sec=timeout_sec,
@@ -4981,17 +5015,65 @@ def review(
         )
         max_stall_sec = _normalize_max_stall_sec(max_stall_sec)
         try:
-            response = review_provider.review(
-                body,
-                effort=effort_value,
-                cwd=cwd,
-                timeout_sec=timeout_sec,
-                max_stall_sec=max_stall_sec,
-                base=base,
-                commit=commit,
-                uncommitted=uncommitted,
-                title=title,
-            )
+            if provider_id == "openrouter" and isinstance(provider, OpenRouterProvider):
+                plan = _with_user_semantic_tags(
+                    plan_for("review", effort_value),
+                    tuple(_parse_csv(tags)),
+                )
+                models_by_provider = {
+                    candidate.provider: candidate.models
+                    for candidate in plan.candidates
+                    if candidate.models
+                }
+                response = provider.call(
+                    build_review_task_prompt(
+                        body,
+                        base=base,
+                        commit=commit,
+                        uncommitted=uncommitted,
+                        title=title,
+                        cwd=cwd,
+                        include_patch=True,
+                    ),
+                    models=models_by_provider.get(provider_id),
+                    effort=effort_value,
+                    task_tags=list(plan.tags),
+                    prefer=prefer_value or plan.prefer,
+                    log_selection=not (silent_route or as_json),
+                    timeout_sec=timeout_sec,
+                    max_stall_sec=max_stall_sec,
+                )
+                validated_text = validate_requested_review_sentinel(
+                    provider_name=response.provider,
+                    prompt=body,
+                    text=response.text,
+                )
+                if validated_text != response.text:
+                    response = replace(response, text=validated_text)
+            else:
+                review_provider = _review_provider_or_none(provider)
+                if review_provider is None:
+                    raise click.UsageError(
+                        f"provider {provider_id!r} does not expose native code review."
+                    )
+                ok, reason = review_provider.review_configured()
+                if not ok:
+                    click.echo(
+                        f"conductor: {reason or 'native review is not configured'}",
+                        err=True,
+                    )
+                    sys.exit(2)
+                response = review_provider.review(
+                    body,
+                    effort=effort_value,
+                    cwd=cwd,
+                    timeout_sec=timeout_sec,
+                    max_stall_sec=max_stall_sec,
+                    base=base,
+                    commit=commit,
+                    uncommitted=uncommitted,
+                    title=title,
+                )
         except ProviderConfigError as e:
             _record_failed_delegation(
                 "review",
@@ -5014,8 +5096,19 @@ def review(
             )
             click.echo(f"conductor: {e}", err=True)
             sys.exit(1)
+        except ReviewContextError as e:
+            _record_failed_delegation(
+                "review",
+                provider_id=provider_id,
+                model=None,
+                effort=effort_value,
+                started_at=dispatch_started_at,
+                error=e,
+            )
+            click.echo(f"conductor: {e}", err=True)
+            sys.exit(1)
 
-    if auto and not as_json:
+    if auto_route and not as_json:
         _emit_usage_log(response, silent=silent_route)
     _record_response_delegation(
         "review",

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -1190,11 +1190,20 @@ def test_ask_council_rejects_offline():
 # ---------------------------------------------------------------------------
 
 
-def test_review_auto_routes_by_router_tag_order(mocker):
+def test_review_auto_uses_semantic_priority_over_router_scoring(
+    mocker, monkeypatch, tmp_path
+):
+    defaults = tmp_path / "router.toml"
+    defaults.write_text('[tag_defaults]\ncode-review = "claude"\n', encoding="utf-8")
+    monkeypatch.setenv("CONDUCTOR_ROUTER_DEFAULTS_FILE", str(defaults))
+    monkeypatch.setenv(
+        "CONDUCTOR_REPO_ROUTER_DEFAULTS_FILE",
+        str(tmp_path / "missing-repo-router.toml"),
+    )
     _stub_all_configured(mocker, {"codex", "claude"})
     mocker.patch.object(CodexProvider, "review_configured", return_value=(True, None))
     mocker.patch.object(ClaudeProvider, "review_configured", return_value=(True, None))
-    review_mock = mocker.patch.object(
+    codex_review = mocker.patch.object(
         CodexProvider,
         "review",
         return_value=_fake_response("codex", "codex-review"),
@@ -1218,10 +1227,87 @@ def test_review_auto_routes_by_router_tag_order(mocker):
     )
 
     assert result.exit_code == 0, result.output
-    assert claude_review.called
-    assert not review_mock.called
-    assert claude_review.call_args.kwargs["base"] == "origin/main"
-    assert "→ claude" in result.stderr
+    assert codex_review.called
+    assert not claude_review.called
+    assert codex_review.call_args.kwargs["base"] == "origin/main"
+    assert "→ codex" in result.stderr
+
+
+def test_review_without_auto_or_with_uses_semantic_review_route(mocker, tmp_path):
+    brief = tmp_path / "review.md"
+    brief.write_text("Review this merge using the project reviewer guide.", encoding="utf-8")
+    _stub_all_configured(mocker, {"codex", "claude"})
+    mocker.patch.object(CodexProvider, "review_configured", return_value=(True, None))
+    mocker.patch.object(ClaudeProvider, "review_configured", return_value=(True, None))
+    codex_review = mocker.patch.object(
+        CodexProvider,
+        "review",
+        return_value=_fake_response("codex", "codex-review"),
+    )
+    claude_review = mocker.patch.object(
+        ClaudeProvider,
+        "review",
+        return_value=_fake_response("claude", "sonnet"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "review",
+            "--base",
+            "origin/main",
+            "--brief-file",
+            str(brief),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert codex_review.called
+    assert not claude_review.called
+    assert codex_review.call_args.kwargs["base"] == "origin/main"
+    assert "→ codex" in result.stderr
+
+
+def test_review_with_openrouter_uses_hosted_review_prompt(mocker, tmp_path):
+    repo = _make_diff_repo(tmp_path)
+    _stub_all_configured(mocker, {"openrouter"})
+    openrouter_call = mocker.patch.object(
+        OpenRouterProvider,
+        "call",
+        return_value=_fake_response(
+            "openrouter",
+            OPENROUTER_CODING_HIGH[0],
+            text="No blocking issues found.\nCODEX_REVIEW_CLEAN",
+        ),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "review",
+            "--with",
+            "openrouter",
+            "--cwd",
+            str(repo),
+            "--base",
+            "HEAD~1",
+            "--brief",
+            (
+                "Review this merge. The LAST line of your output must be exactly "
+                "CODEX_REVIEW_CLEAN or CODEX_REVIEW_BLOCKED."
+            ),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert openrouter_call.called
+    assert openrouter_call.call_args.kwargs["models"] == OPENROUTER_CODING_HIGH
+    assert openrouter_call.call_args.kwargs["task_tags"] == ["code-review"]
+    assert openrouter_call.call_args.kwargs["prefer"] == "best"
+    prompt = openrouter_call.call_args.args[0]
+    assert "Patch context for generic review fallback" in prompt
+    assert "diff --git a/README.md b/README.md" in prompt
+    assert result.stdout.strip().endswith("CODEX_REVIEW_CLEAN")
 
 
 def test_review_auto_does_not_route_to_generic_code_review_tag_provider(mocker):
@@ -1272,7 +1358,7 @@ def test_review_auto_exhausted_fallback_names_stalled_codex_and_claude(mocker):
 
     assert result.exit_code == 1
     assert "code review failed for all tried providers" in result.stderr
-    assert "claude (timeout), codex (stall)" in result.stderr
+    assert "codex (stall), claude (timeout)" in result.stderr
 
 
 def test_review_auto_output_contract_failure_falls_through_to_next_provider(mocker):
@@ -1280,20 +1366,20 @@ def test_review_auto_output_contract_failure_falls_through_to_next_provider(mock
     mocker.patch.object(CodexProvider, "review_configured", return_value=(True, None))
     mocker.patch.object(ClaudeProvider, "review_configured", return_value=(True, None))
     mocker.patch.object(
-        ClaudeProvider,
-        "review",
-        return_value=_fake_response(
-            "claude",
-            "sonnet",
-            text="The patch looks safe, but I omitted the required marker.",
-        ),
-    )
-    mocker.patch.object(
         CodexProvider,
         "review",
         return_value=_fake_response(
             "codex",
             "codex-review",
+            text="The patch looks safe, but I omitted the required marker.",
+        ),
+    )
+    mocker.patch.object(
+        ClaudeProvider,
+        "review",
+        return_value=_fake_response(
+            "claude",
+            "sonnet",
             text="No blocking issues found.\nCODEX_REVIEW_CLEAN",
         ),
     )
@@ -1314,7 +1400,7 @@ def test_review_auto_output_contract_failure_falls_through_to_next_provider(mock
 
     assert result.exit_code == 0, result.output
     assert result.stdout.strip().endswith("CODEX_REVIEW_CLEAN")
-    assert "claude review failed (output-contract)" in result.stderr
+    assert "codex review failed (output-contract)" in result.stderr
     assert "falling back" in result.stderr
 
 
@@ -1358,6 +1444,7 @@ def test_review_auto_generic_fallback_prompt_includes_diff(mocker, tmp_path):
     )
 
     assert result.exit_code == 0, result.output
+    assert openrouter_call.call_args.kwargs["models"] == OPENROUTER_CODING_HIGH
     prompt = openrouter_call.call_args.args[0]
     assert "Patch context for generic review fallback" in prompt
     assert "diff --git a/README.md b/README.md" in prompt

--- a/tests/test_review_cascade.py
+++ b/tests/test_review_cascade.py
@@ -126,7 +126,7 @@ def test_review_chain_walks_past_codex_to_next_code_review_provider(mocker) -> N
     assert result.stdout == "openrouter reviewed\n"
     assert "claude review failed (stall)" in result.stderr
     assert "codex review failed (stall)" in result.stderr
-    assert "claude (stall), codex (stall), openrouter (success)" in result.stderr
+    assert "codex (stall), claude (stall), openrouter (success)" in result.stderr
 
 
 def test_review_fallback_call_uses_conductor_owned_budget(mocker) -> None:
@@ -224,7 +224,7 @@ def test_review_max_fallbacks_caps_total_attempts(mocker) -> None:
 
     assert result.exit_code == 1
     assert not openrouter_call.called
-    assert "claude (stall), codex (stall)" in result.stderr
+    assert "codex (stall), claude (stall)" in result.stderr
     assert "openrouter" not in result.stderr
 
 
@@ -262,7 +262,7 @@ def test_review_exhausted_error_includes_tried_provider_trail(mocker) -> None:
 
     assert result.exit_code == 1
     assert "code review failed for all tried providers" in result.stderr
-    assert "claude (rate-limit), codex (stall), openrouter (5xx)" in result.stderr
+    assert "codex (stall), claude (rate-limit), openrouter (5xx)" in result.stderr
     assert "ProviderHTTPError: OpenRouter returned HTTP 503" in result.stderr
     assert "Next step:" in result.stderr
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
