### PR TITLE
Fix Codex review timeout semantics and release validation

### DIFF
--- a/.cursor/rules/conductor-delegation.mdc
+++ b/.cursor/rules/conductor-delegation.mdc
@@ -2,7 +2,7 @@
 description: Use when delegating or routing tasks to a different LLM via the conductor CLI — e.g., cheap second opinions, long-context reads, web search, or offline runs.
 globs: ""
 alwaysApply: false
-managed-by: conductor v0.10.13
+managed-by: conductor v0.10.14
 ---
 
 # Conductor delegation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,51 @@ permissions:
   contents: read
 
 jobs:
+  source-validation:
+    # Validate the exact release tag before the tap is bumped. A GitHub
+    # Release can still be created manually, but Homebrew promotion waits for
+    # the internal suite to pass on the tag being published.
+    if: github.event_name == 'workflow_dispatch' || !github.event.release.prerelease
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ inputs.tag_name || github.event.release.tag_name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag_name || github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Run pre-commit hygiene
+        env:
+          SKIP: no-commit-to-branch
+        run: |
+          pipx install pre-commit
+          pre-commit run --all-files --hook-stage pre-commit --show-diff-on-failure
+
+      - name: Run touchstone validate
+        run: uv run bash scripts/touchstone-run.sh validate
+
+      - name: Compile source and tests
+        run: uv run python -m compileall -q src tests
+
   bump-tap:
     # On the auto-trigger, skip prereleases (RCs, betas) — they shouldn't
     # land in the tap. Manual dispatch always runs so we can re-bump on
     # demand for any tag.
     if: github.event_name == 'workflow_dispatch' || !github.event.release.prerelease
+    needs: source-validation
     uses: autumngarage/autumn-garage/.github/workflows/homebrew-bump.yml@v1
     with:
       formula-name: conductor

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ If there are zero blocking issues, the review is just: "LGTM."
 
 @.cortex/protocol.md
 
-<!-- conductor:begin v0.10.13 -->
+<!-- conductor:begin v0.10.14 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
 
-<!-- conductor:begin v0.10.13 -->
+<!-- conductor:begin v0.10.14 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -567,12 +567,12 @@ class CodexProvider:
         # the target in the prompt instead of forwarding --base/--commit.
         args.append("-")
 
+        # `codex review` is not a streaming interface: it commonly writes no
+        # stdout until the final review text. Applying max_stall_sec here turns
+        # normal long reviews into false stalls. The streaming `codex exec`
+        # path still enforces the no-output watchdog.
+        _ = max_stall_sec
         timeout = self._timeout_sec if timeout_sec is None else timeout_sec
-        effective_timeout = timeout
-        watchdog_timeout = False
-        if max_stall_sec is not None and (timeout is None or max_stall_sec < timeout):
-            effective_timeout = max_stall_sec
-            watchdog_timeout = True
         start = time.monotonic()
         try:
             result = subprocess.run(
@@ -580,15 +580,11 @@ class CodexProvider:
                 input=review_prompt,
                 capture_output=True,
                 text=True,
-                timeout=effective_timeout,
+                timeout=timeout,
                 cwd=cwd,
             )
         except subprocess.TimeoutExpired as e:
             elapsed = time.monotonic() - start
-            if watchdog_timeout:
-                raise ProviderStalledError(
-                    f"codex review stalled after {max_stall_sec:g}s with no stdout"
-                ) from e
             raise ProviderError(
                 f"codex review timed out after {elapsed:.0f}s"
             ) from e

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -1651,22 +1651,21 @@ def test_codex_review_rejects_missing_requested_sentinel(mocker):
         )
 
 
-def test_codex_review_stall_watchdog_fails_fast(mocker):
+def test_codex_review_uses_wall_clock_timeout_not_stall_watchdog(mocker):
     mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
     captured_timeout: float | None = None
 
     def fake_run(args, **kwargs):
         nonlocal captured_timeout
         captured_timeout = kwargs["timeout"]
-        raise subprocess.TimeoutExpired(cmd=args, timeout=kwargs["timeout"])
+        return _fake_completed(stdout="CODEX_REVIEW_CLEAN\n")
 
     mocker.patch("conductor.providers.codex.subprocess.run", side_effect=fake_run)
 
-    with pytest.raises(ProviderStalledError) as exc:
-        CodexProvider().review("Review this.", timeout_sec=60, max_stall_sec=0.05)
+    response = CodexProvider().review("Review this.", timeout_sec=60, max_stall_sec=0.05)
 
-    assert captured_timeout == 0.05
-    assert "codex review stalled after 0.05s" in str(exc.value)
+    assert captured_timeout == 60
+    assert response.text == "CODEX_REVIEW_CLEAN"
 
 
 def test_codex_call_reads_output_backstop_when_ndjson_loses_agent_message(

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -1445,6 +1445,8 @@ def test_review_auto_generic_fallback_prompt_includes_diff(mocker, tmp_path):
 
     assert result.exit_code == 0, result.output
     assert openrouter_call.call_args.kwargs["models"] == OPENROUTER_CODING_HIGH
+    assert openrouter_call.call_args.kwargs["timeout_sec"] == 300
+    assert openrouter_call.call_args.kwargs["max_stall_sec"] == 75
     prompt = openrouter_call.call_args.args[0]
     assert "Patch context for generic review fallback" in prompt
     assert "diff --git a/README.md b/README.md" in prompt
@@ -1500,6 +1502,8 @@ def test_ask_review_uses_openrouter_code_stack_instead_of_gemini(mocker, tmp_pat
     assert not gemini_review.called
     assert openrouter_call.called
     assert openrouter_call.call_args.kwargs["models"] == OPENROUTER_CODING_HIGH
+    assert openrouter_call.call_args.kwargs["timeout_sec"] == 300
+    assert openrouter_call.call_args.kwargs["max_stall_sec"] == 75
     prompt = openrouter_call.call_args.args[0]
     assert "Patch context for generic review fallback" in prompt
     payload = json.loads(result.stdout)


### PR DESCRIPTION
## Summary
- stop applying `max_stall_sec` as a wall-clock timeout to native `codex review`, which does not stream stdout until the final review text
- strengthen OpenRouter review fallback tests to assert the curated review model stack receives bounded review-gate budgets
- add a release `source-validation` job that runs pre-commit, Touchstone validation, and compileall on the exact release tag before the Homebrew tap bump

## Root cause
Codex was operational, but Conductor treated silence from non-streaming `codex review` as a stall. OpenRouter was operational too; the observed merge attempt happened before PR #328, when review fallback could reach unrestricted `openrouter/auto` instead of the review stack.

## Tests
- `PYTHONPATH=/Users/henry/repos/conductor/src pytest -q tests/test_adapters_subprocess.py::test_codex_review_uses_wall_clock_timeout_not_stall_watchdog tests/test_cli_v02.py::test_review_auto_generic_fallback_prompt_includes_diff tests/test_cli_v02.py::test_ask_review_uses_openrouter_code_stack_instead_of_gemini`
- live branch smoke: `PYTHONPATH=/Users/henry/repos/conductor/src python3 -m conductor.cli review --with codex --timeout 30 --max-stall-seconds 1 ...`
- live branch smoke: `PYTHONPATH=/Users/henry/repos/conductor/src python3 -m conductor.cli review --auto --exclude claude,codex --timeout 60 --max-stall-seconds 20 ...`
- `PYTHONPATH=/Users/henry/repos/conductor/src pytest -q tests/test_adapters_subprocess.py tests/test_cli_v02.py tests/test_review_cascade.py`
- `PYTHONPATH=/Users/henry/repos/conductor/src pytest -q`
- `ruff check src tests`
- `PYTHONPATH=/Users/henry/repos/conductor/src python3 -m compileall -q src tests`
- `uv run bash scripts/touchstone-run.sh validate`