### PR TITLE
fix: let council continue after member failure

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -2331,19 +2331,32 @@ def _invoke_council(
         )
         if not silent:
             click.echo(f"[conductor] council member {idx}: {model}", err=True)
-        response = _openrouter_council_provider(
-            provider=provider,
-            timeout_sec=timeout_sec,
-            remaining_sec=_council_remaining_sec(caps, elapsed_ms),
-        ).call(
-            member_prompt,
-            model=model,
-            effort=effort,
-            task_tags=list(plan.tags),
-            prefer=plan.prefer,
-            log_selection=False,
-            max_tokens=_council_remaining_output_tokens(caps, member_responses),
-        )
+        try:
+            response = _openrouter_council_provider(
+                provider=provider,
+                timeout_sec=timeout_sec,
+                remaining_sec=_council_remaining_sec(caps, elapsed_ms),
+            ).call(
+                member_prompt,
+                model=model,
+                effort=effort,
+                task_tags=list(plan.tags),
+                prefer=plan.prefer,
+                log_selection=False,
+                max_tokens=_council_remaining_output_tokens(caps, member_responses),
+            )
+        except ProviderError as exc:
+            response = _council_member_failure_response(
+                model=model,
+                error=exc,
+                elapsed_ms=_council_elapsed_ms(started_at),
+            )
+            if not silent:
+                click.echo(
+                    f"[conductor] council member {idx} failed: {type(exc).__name__}: {exc} "
+                    "- continuing",
+                    err=True,
+                )
         member_responses.append(response)
         member_delegation_id = _record_response_delegation(
             "council",
@@ -2372,6 +2385,13 @@ def _invoke_council(
             model=model,
             elapsed_ms=_council_elapsed_ms(started_at),
         )
+
+    if not any(_council_member_succeeded(response) for response in member_responses):
+        errors = "; ".join(
+            str((response.raw or {}).get("conductor_council_member_error") or response.model)
+            for response in member_responses
+        )
+        raise ProviderError(f"council failed: all member calls failed ({errors})")
 
     elapsed_ms = _council_elapsed_ms(started_at)
     _raise_if_council_cap_hit(
@@ -2441,6 +2461,37 @@ def _invoke_council(
         synthesis_delegation_id=synthesis_delegation_id,
     )
     return parent_response
+
+
+def _council_member_failure_response(
+    *,
+    model: str,
+    error: ProviderError,
+    elapsed_ms: int,
+) -> CallResponse:
+    error_payload = {
+        "model": model,
+        "type": type(error).__name__,
+        "message": str(error),
+    }
+    return CallResponse(
+        text=f"[council member failed: {error_payload['type']}: {error_payload['message']}]",
+        provider="openrouter",
+        model=model,
+        duration_ms=elapsed_ms,
+        usage={
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "thinking_tokens": 0,
+            "cached_tokens": 0,
+        },
+        cost_usd=None,
+        raw={"conductor_council_member_error": error_payload},
+    )
+
+
+def _council_member_succeeded(response: CallResponse) -> bool:
+    return "conductor_council_member_error" not in (response.raw or {})
 
 
 def _openrouter_council_provider(
@@ -2657,6 +2708,11 @@ def _council_response_metadata(
         "member_models": [response.model for response in member_responses],
         "requested_member_models": list(plan.council_member_models),
         "requested_synthesis_models": list(synthesis_models),
+        "member_errors": [
+            (response.raw or {}).get("conductor_council_member_error")
+            for response in member_responses
+            if (response.raw or {}).get("conductor_council_member_error") is not None
+        ],
         "rounds": rounds,
         "member_usage": [response.usage for response in member_responses],
         "member_cost_usd": member_costs,
@@ -2725,6 +2781,9 @@ def _council_usage_payload(
     usage.update(
         {
             "council_members": len(member_responses),
+            "council_failed_members": sum(
+                1 for response in member_responses if not _council_member_succeeded(response)
+            ),
             "council_rounds": rounds,
             "council_complete": cap_hit is None and synthesis is not None,
             "council_cap_hit": cap_hit,

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -43,6 +43,7 @@ from conductor.providers import (
     OllamaProvider,
     OpenRouterProvider,
     ProviderConfigError,
+    ProviderError,
     ProviderExecutionError,
 )
 from conductor.router import RouteDecision, reset_health
@@ -1022,6 +1023,82 @@ def test_ask_council_marks_incomplete_cost_accounting(mocker):
         None,
         0.03,
     ]
+
+
+def test_ask_council_continues_after_member_failure(mocker):
+    _stub_all_configured(mocker, {"openrouter"})
+    responses = [
+        _fake_response("openrouter", "member-a", cost_usd=0.01),
+        ProviderError("OpenRouter produced empty response content: finish_reason=length"),
+        _fake_response("openrouter", "member-c", cost_usd=0.03),
+        _fake_response("openrouter", "synthesis", cost_usd=0.04),
+    ]
+    call_mock = mocker.patch.object(OpenRouterProvider, "call", side_effect=responses)
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "ask",
+            "--kind",
+            "council",
+            "--effort",
+            "medium",
+            "--brief",
+            "Debate this architecture decision.",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert call_mock.call_count == 4
+    assert call_mock.call_args_list[2].kwargs["model"] == "deepseek/deepseek-v4-pro"
+    synthesis_prompt = call_mock.call_args_list[3].args[0]
+    assert "## Member 2: ~moonshotai/kimi-latest" in synthesis_prompt
+    assert "council member failed: ProviderError" in synthesis_prompt
+    payload = json.loads(result.stdout)
+    council = payload["raw"]["conductor_council"]
+    assert payload["usage"]["council_complete"] is True
+    assert payload["usage"]["council_failed_members"] == 1
+    assert payload["usage"]["cost_accounting_complete"] is False
+    assert payload["cost_usd"] is None
+    assert council["member_errors"] == [
+        {
+            "model": "~moonshotai/kimi-latest",
+            "type": "ProviderError",
+            "message": "OpenRouter produced empty response content: finish_reason=length",
+        }
+    ]
+
+
+def test_ask_council_fails_when_all_members_fail(mocker):
+    _stub_all_configured(mocker, {"openrouter"})
+    call_mock = mocker.patch.object(
+        OpenRouterProvider,
+        "call",
+        side_effect=[
+            ProviderError("member one failed"),
+            ProviderError("member two failed"),
+            ProviderError("member three failed"),
+        ],
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "ask",
+            "--kind",
+            "council",
+            "--effort",
+            "medium",
+            "--brief",
+            "Debate this architecture decision.",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert call_mock.call_count == 3
+    assert "council failed: all member calls failed" in result.output
 
 
 def test_ask_council_known_cost_cap_returns_partial_error(mocker):


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
