### PR TITLE
fix: use codex review target flags

### DIFF
--- a/.cursor/rules/conductor-delegation.mdc
+++ b/.cursor/rules/conductor-delegation.mdc
@@ -2,7 +2,7 @@
 description: Use when delegating or routing tasks to a different LLM via the conductor CLI — e.g., cheap second opinions, long-context reads, web search, or offline runs.
 globs: ""
 alwaysApply: false
-managed-by: conductor v0.10.15
+managed-by: conductor v0.10.16
 ---
 
 # Conductor delegation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ If there are zero blocking issues, the review is just: "LGTM."
 
 @.cortex/protocol.md
 
-<!-- conductor:begin v0.10.15 -->
+<!-- conductor:begin v0.10.16 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
 
-<!-- conductor:begin v0.10.15 -->
+<!-- conductor:begin v0.10.16 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -552,19 +552,18 @@ class CodexProvider:
         codex_effort_flag = (
             _EFFORT_TO_CODEX_FLAG.get(effort) if isinstance(effort, str) else None
         )
-        review_prompt = self._build_review_prompt(
-            task,
-            base=base,
-            commit=commit,
-            uncommitted=uncommitted,
-            title=title,
-        )
+        review_prompt = task
         args = [self._cli, "review"]
         if codex_effort_flag:
             args.extend(["-c", f"model_reasoning_effort={codex_effort_flag}"])
-        # `codex review` rejects target flags when a prompt is supplied.
-        # Touchstone always needs a strict sentinel/rubric prompt, so encode
-        # the target in the prompt instead of forwarding --base/--commit.
+        if base:
+            args.extend(["--base", base])
+        if commit:
+            args.extend(["--commit", commit])
+        if uncommitted:
+            args.append("--uncommitted")
+        if title:
+            args.extend(["--title", title])
         args.append("-")
 
         # `codex review` is not a streaming interface: it commonly writes no
@@ -630,28 +629,6 @@ class CodexProvider:
                 },
             },
         )
-
-    @staticmethod
-    def _build_review_prompt(
-        task: str,
-        *,
-        base: str | None,
-        commit: str | None,
-        uncommitted: bool,
-        title: str | None,
-    ) -> str:
-        target_lines: list[str] = []
-        if base:
-            target_lines.append(f"- Review changes against base branch/ref: {base}")
-        if commit:
-            target_lines.append(f"- Review commit: {commit}")
-        if uncommitted:
-            target_lines.append("- Include staged, unstaged, and untracked changes.")
-        if title:
-            target_lines.append(f"- Review title: {title}")
-        if not target_lines:
-            return task
-        return "Review target:\n" + "\n".join(target_lines) + "\n\n" + task
 
     def _parse_ndjson(
         self, stdout: str

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -1626,16 +1626,54 @@ def test_codex_review_uses_native_review_command(mocker):
     assert args[0:2] == ["codex", "review"]
     assert "-c" in args
     assert args[args.index("-c") + 1] == "model_reasoning_effort=medium"
-    assert "--base" not in args
-    assert "--title" not in args
+    assert args[args.index("--base") + 1] == "origin/main"
+    assert args[args.index("--title") + 1] == "PR review"
     assert args[-1] == "-"
     prompt = captured.call_args.kwargs["input"]
-    assert "Review changes against base branch/ref: origin/main" in prompt
-    assert "Review title: PR review" in prompt
-    assert "Use AGENTS.md rubric." in prompt
+    assert prompt == "Use AGENTS.md rubric."
     assert response.provider == "codex"
     assert response.model == "codex-review"
     assert response.text == "LGTM"
+
+
+def test_codex_review_forwards_commit_flag(mocker):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    captured = mocker.patch(
+        "conductor.providers.codex.subprocess.run",
+        return_value=_fake_completed(stdout="LGTM\n"),
+    )
+
+    CodexProvider().review(
+        "Use AGENTS.md rubric.",
+        commit="abc123",
+    )
+
+    args = captured.call_args.args[0]
+    assert args[0:2] == ["codex", "review"]
+    assert args[args.index("--commit") + 1] == "abc123"
+    assert "--uncommitted" not in args
+    assert args[-1] == "-"
+    assert captured.call_args.kwargs["input"] == "Use AGENTS.md rubric."
+
+
+def test_codex_review_forwards_uncommitted_flag(mocker):
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    captured = mocker.patch(
+        "conductor.providers.codex.subprocess.run",
+        return_value=_fake_completed(stdout="LGTM\n"),
+    )
+
+    CodexProvider().review(
+        "Use AGENTS.md rubric.",
+        uncommitted=True,
+    )
+
+    args = captured.call_args.args[0]
+    assert args[0:2] == ["codex", "review"]
+    assert "--uncommitted" in args
+    assert "--commit" not in args
+    assert args[-1] == "-"
+    assert captured.call_args.kwargs["input"] == "Use AGENTS.md rubric."
 
 
 def test_codex_review_rejects_missing_requested_sentinel(mocker):


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
