### PR TITLE
fix: keep codex review targets in prompt

### DIFF
--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -617,18 +617,16 @@ class CodexProvider:
         codex_effort_flag = (
             _EFFORT_TO_CODEX_FLAG.get(effort) if isinstance(effort, str) else None
         )
-        review_prompt = task
+        review_prompt = self._build_review_prompt(
+            task,
+            base=base,
+            commit=commit,
+            uncommitted=uncommitted,
+            title=title,
+        )
         args = [self._cli, "review"]
         if codex_effort_flag:
             args.extend(["-c", f"model_reasoning_effort={codex_effort_flag}"])
-        if base:
-            args.extend(["--base", base])
-        if commit:
-            args.extend(["--commit", commit])
-        if uncommitted:
-            args.append("--uncommitted")
-        if title:
-            args.extend(["--title", title])
         args.append("-")
 
         # `codex review` is not a streaming interface: it commonly writes no
@@ -723,6 +721,28 @@ class CodexProvider:
             },
             raw=raw,
         )
+
+    @staticmethod
+    def _build_review_prompt(
+        task: str,
+        *,
+        base: str | None,
+        commit: str | None,
+        uncommitted: bool,
+        title: str | None,
+    ) -> str:
+        target_lines: list[str] = []
+        if base:
+            target_lines.append(f"- Review changes against base branch/ref: {base}")
+        if commit:
+            target_lines.append(f"- Review commit: {commit}")
+        if uncommitted:
+            target_lines.append("- Include staged, unstaged, and untracked changes.")
+        if title:
+            target_lines.append(f"- Review title: {title}")
+        if not target_lines:
+            return task
+        return "Review target:\n" + "\n".join(target_lines) + "\n\n" + task
 
     def _parse_ndjson(
         self, stdout: str

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -1626,17 +1626,19 @@ def test_codex_review_uses_native_review_command(mocker):
     assert args[0:2] == ["codex", "review"]
     assert "-c" in args
     assert args[args.index("-c") + 1] == "model_reasoning_effort=medium"
-    assert args[args.index("--base") + 1] == "origin/main"
-    assert args[args.index("--title") + 1] == "PR review"
+    assert "--base" not in args
+    assert "--title" not in args
     assert args[-1] == "-"
     prompt = captured.call_args.kwargs["input"]
-    assert prompt == "Use AGENTS.md rubric."
+    assert "Review changes against base branch/ref: origin/main" in prompt
+    assert "Review title: PR review" in prompt
+    assert "Use AGENTS.md rubric." in prompt
     assert response.provider == "codex"
     assert response.model == "codex-review"
     assert response.text == "LGTM"
 
 
-def test_codex_review_forwards_commit_flag(mocker):
+def test_codex_review_encodes_commit_target_in_prompt(mocker):
     mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
     captured = mocker.patch(
         "conductor.providers.codex.subprocess.run",
@@ -1650,13 +1652,15 @@ def test_codex_review_forwards_commit_flag(mocker):
 
     args = captured.call_args.args[0]
     assert args[0:2] == ["codex", "review"]
-    assert args[args.index("--commit") + 1] == "abc123"
+    assert "--commit" not in args
     assert "--uncommitted" not in args
     assert args[-1] == "-"
-    assert captured.call_args.kwargs["input"] == "Use AGENTS.md rubric."
+    prompt = captured.call_args.kwargs["input"]
+    assert "Review commit: abc123" in prompt
+    assert "Use AGENTS.md rubric." in prompt
 
 
-def test_codex_review_forwards_uncommitted_flag(mocker):
+def test_codex_review_encodes_uncommitted_target_in_prompt(mocker):
     mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
     captured = mocker.patch(
         "conductor.providers.codex.subprocess.run",
@@ -1670,10 +1674,12 @@ def test_codex_review_forwards_uncommitted_flag(mocker):
 
     args = captured.call_args.args[0]
     assert args[0:2] == ["codex", "review"]
-    assert "--uncommitted" in args
+    assert "--uncommitted" not in args
     assert "--commit" not in args
     assert args[-1] == "-"
-    assert captured.call_args.kwargs["input"] == "Use AGENTS.md rubric."
+    prompt = captured.call_args.kwargs["input"]
+    assert "Include staged, unstaged, and untracked changes." in prompt
+    assert "Use AGENTS.md rubric." in prompt
 
 
 def test_codex_review_retries_missing_requested_sentinel_once(mocker):
@@ -1695,9 +1701,10 @@ def test_codex_review_retries_missing_requested_sentinel_once(mocker):
     first_args = captured.call_args_list[0].args[0]
     second_args = captured.call_args_list[1].args[0]
     assert first_args == second_args
-    assert second_args[second_args.index("--base") + 1] == "origin/main"
+    assert "--base" not in second_args
     retry_prompt = captured.call_args_list[1].kwargs["input"]
     assert "Conductor review output contract retry" in retry_prompt
+    assert "Review changes against base branch/ref: origin/main" in retry_prompt
     assert "Contract failure: missing" in retry_prompt
     assert "Do not include any text after the sentinel." in retry_prompt
     assert "No blocking issues were found." in retry_prompt

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -1687,6 +1687,8 @@ def test_review_auto_codex_subprocess_rejects_missing_requested_sentinel(mocker)
             "review",
             "--auto",
             "--silent-route",
+            "--base",
+            "origin/main",
             "--brief",
             (
                 "The LAST line of your output must be exactly one of these "
@@ -1736,6 +1738,8 @@ def test_review_auto_codex_subprocess_retries_missing_requested_sentinel(mocker)
             "review",
             "--auto",
             "--silent-route",
+            "--base",
+            "origin/main",
             "--brief",
             (
                 "The LAST line of your output must be exactly one of these "
@@ -1747,6 +1751,10 @@ def test_review_auto_codex_subprocess_retries_missing_requested_sentinel(mocker)
 
     assert result.exit_code == 0, result.output
     assert captured.call_count == 2
+    assert "--base" not in captured.call_args_list[0].args[0]
+    assert "Review changes against base branch/ref: origin/main" in (
+        captured.call_args_list[1].kwargs["input"]
+    )
     assert not claude_review.called
     assert result.stdout.strip().endswith("CODEX_REVIEW_CLEAN")
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
