### PR TITLE
fix: classify exhausted review fallback infra failures (#344)

### DIFF
--- a/.cursor/rules/conductor-delegation.mdc
+++ b/.cursor/rules/conductor-delegation.mdc
@@ -2,7 +2,7 @@
 description: Use when delegating or routing tasks to a different LLM via the conductor CLI — e.g., cheap second opinions, long-context reads, web search, or offline runs.
 globs: ""
 alwaysApply: false
-managed-by: conductor v0.10.18
+managed-by: conductor v0.10.19
 ---
 
 # Conductor delegation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ If there are zero blocking issues, the review is just: "LGTM."
 
 @.cortex/protocol.md
 
-<!-- conductor:begin v0.10.18 -->
+<!-- conductor:begin v0.10.19 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
 
-<!-- conductor:begin v0.10.18 -->
+<!-- conductor:begin v0.10.19 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -2333,8 +2333,9 @@ def _invoke_review_with_fallback(
             "`conductor list` to check configured code-review providers"
         )
         raise ProviderError(
-            f"code review failed for all tried providers: {trail}. "
-            f"Last error: {last_detail}. Next step: {hint}."
+            f"review infrastructure failed before any provider returned a "
+            f"valid verdict; no review findings were emitted. Tried providers: "
+            f"{trail}. Last error: {last_detail}. Next step: {hint}."
         ) from last_exc
     raise last_exc
 

--- a/src/conductor/exec_completion.py
+++ b/src/conductor/exec_completion.py
@@ -97,14 +97,15 @@ def detect_missing_deliverables(
             )
         )
 
-    for command in _requested_validation_commands(brief):
-        if not _recent_bash_invoked(tool_calls, command):
-            missing.append(
-                MissingDeliverable(
-                    "validation",
-                    f"Validation calls for `{command}`; not invoked in this session.",
+    if not _review_preflight_already_passed(brief):
+        for command in _requested_validation_commands(brief):
+            if not _recent_bash_invoked(tool_calls, command):
+                missing.append(
+                    MissingDeliverable(
+                        "validation",
+                        f"Validation calls for `{command}`; not invoked in this session.",
+                    )
                 )
-            )
 
     if _brief_requests_open_pr_ship(brief) and not _recent_shipping_invoked(tool_calls):
         missing.append(
@@ -172,6 +173,39 @@ def _requested_validation_commands(brief: str) -> tuple[str, ...]:
     if re.search(r"(?i)\btypecheck\b", brief):
         commands.append("typecheck")
     return tuple(dict.fromkeys(commands))
+
+
+def _review_preflight_already_passed(brief: str) -> bool:
+    """Return True when review context says deterministic validation is done.
+
+    Invariant: this only suppresses cap-time validation-tool-call hints for
+    review gates. Implementation briefs still have to execute requested
+    validation in the current session.
+    """
+
+    if not _brief_is_review_gate(brief):
+        return False
+    return bool(
+        re.search(
+            r"(?is)\b(?:pre[- ]?flight|validation)\b.{0,120}"
+            r"\b(?:passed|succeeded|completed successfully|already passed)\b",
+            brief,
+        )
+        or re.search(
+            r"(?is)\b(?:passed|succeeded)\b.{0,120}"
+            r"\b(?:pre[- ]?flight|validation)\b",
+            brief,
+        )
+    )
+
+
+def _brief_is_review_gate(brief: str) -> bool:
+    return bool(
+        re.search(r"\bCODEX_REVIEW_(?:CLEAN|FIXED|BLOCKED)\b", brief)
+        or re.search(r"(?i)\bcode-review\b", brief)
+        or re.search(r"(?i)\breview this merge\b", brief)
+        or re.search(r"(?i)\breviewer guide\b", brief)
+    )
 
 
 def _brief_requests_open_pr_ship(brief: str) -> bool:

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -1436,7 +1436,10 @@ def test_review_auto_exhausted_fallback_names_stalled_codex_and_claude(mocker):
     )
 
     assert result.exit_code == 1
-    assert "code review failed for all tried providers" in result.stderr
+    assert (
+        "review infrastructure failed before any provider returned a valid verdict"
+        in result.stderr
+    )
     assert "codex (stall), claude (timeout)" in result.stderr
 
 
@@ -1658,7 +1661,10 @@ def test_review_auto_generic_fallback_rejects_missing_requested_sentinel(
     )
 
     assert result.exit_code == 1
-    assert "code review failed for all tried providers" in result.stderr
+    assert (
+        "review infrastructure failed before any provider returned a valid verdict"
+        in result.stderr
+    )
     assert "openrouter (output-contract)" in result.stderr
     assert "ReviewOutputContractError" in result.stderr
 
@@ -1699,7 +1705,10 @@ def test_review_auto_codex_subprocess_rejects_missing_requested_sentinel(mocker)
     )
 
     assert result.exit_code == 1
-    assert "code review failed for all tried providers" in result.stderr
+    assert (
+        "review infrastructure failed before any provider returned a valid verdict"
+        in result.stderr
+    )
     assert "codex (output-contract)" in result.stderr
 
 

--- a/tests/test_exec_completion.py
+++ b/tests/test_exec_completion.py
@@ -33,3 +33,27 @@ def test_validation_command_requested_without_recent_tool_call_is_flagged() -> N
 
     assert [item.kind for item in missing] == ["validation"]
     assert "uv run pytest" in missing[0].message
+
+
+def test_review_preflight_passed_does_not_require_fresh_validation_call() -> None:
+    missing = detect_missing_deliverables(
+        (
+            "Review this merge using the project reviewer guide.\n\n"
+            "Preflight passed before fallback dispatch: uv run ruff check.\n\n"
+            "The LAST line must be CODEX_REVIEW_CLEAN or CODEX_REVIEW_BLOCKED."
+        ),
+        changed_paths=(),
+        recent_tool_calls=[],
+    )
+
+    assert missing == []
+
+
+def test_implementation_preflight_passed_still_requires_requested_validation() -> None:
+    missing = detect_missing_deliverables(
+        "Implement the fix.\n\nPreflight passed: uv run ruff check.",
+        changed_paths=("src/conductor/foo.py",),
+        recent_tool_calls=[],
+    )
+
+    assert [item.kind for item in missing] == ["validation"]

--- a/tests/test_review_cascade.py
+++ b/tests/test_review_cascade.py
@@ -386,7 +386,11 @@ def test_review_exhausted_error_includes_tried_provider_trail(mocker) -> None:
     )
 
     assert result.exit_code == 1
-    assert "code review failed for all tried providers" in result.stderr
+    assert (
+        "review infrastructure failed before any provider returned a valid verdict"
+        in result.stderr
+    )
+    assert "no review findings were emitted" in result.stderr
     assert "codex (stall), claude (rate-limit), openrouter (5xx)" in result.stderr
     assert "ProviderHTTPError: OpenRouter returned HTTP 503" in result.stderr
     assert "Next step:" in result.stderr


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->

Closes #344
