### PR TITLE
fix: classify review provider fallback statuses (#346)

### DIFF
--- a/scripts/touchstone-run.sh
+++ b/scripts/touchstone-run.sh
@@ -170,8 +170,14 @@ run_cortex_update_check() {
   [ -d .cortex ] || return 0
 
   if command -v cortex >/dev/null 2>&1; then
+    if [ ! -f .cortex/.index.json ]; then
+      run_shell_command "cortex refresh-index --path ."
+    fi
     run_shell_command "cortex update --check --path ."
   elif command -v uv >/dev/null 2>&1 && uv run cortex --version >/dev/null 2>&1; then
+    if [ ! -f .cortex/.index.json ]; then
+      run_shell_command "uv run cortex refresh-index --path ."
+    fi
     run_shell_command "uv run cortex update --check --path ."
   else
     warn "skipping cortex update check: cortex CLI is not installed"

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -297,6 +297,13 @@ class SessionPrunePlan:
     items: tuple[SessionPruneItem, ...]
 
 
+@dataclass(frozen=True)
+class ReviewProviderStatus:
+    provider: str
+    status: str
+    detail: str
+
+
 # --------------------------------------------------------------------------- #
 # Shared helpers
 # --------------------------------------------------------------------------- #
@@ -1084,10 +1091,10 @@ def _is_retryable(err: Exception) -> tuple[bool, str]:
     """Classify an error as retryable-with-fallback or fatal.
 
     Returns (retryable, category) — category is "rate-limit" | "5xx" |
-    "timeout" | "network" | "provider-error" | "other" for health-tracking
-    and fallback-UX routing purposes. "network" is separate from "timeout"
-    so the offline-mode prompt can fire on the real thing (DNS/TCP failure)
-    rather than on a slow-but-reachable upstream.
+    "timeout" | "network" | "transport" | "provider-error" | "other" for
+    health-tracking and fallback-UX routing purposes. "network" is separate
+    from "timeout" so the offline-mode prompt can fire on the real thing
+    (DNS/TCP failure) rather than on a slow-but-reachable upstream.
     """
     if isinstance(err, ReviewOutputContractError):
         return True, "output-contract"
@@ -1118,7 +1125,7 @@ def _is_retryable(err: Exception) -> tuple[bool, str]:
     if any(sig in msg for sig in _UPSTREAM_DOWN_ERROR_SIGNALS):
         return True, "5xx"
     if isinstance(err, ProviderHTTPError):
-        return True, "provider-error"
+        return True, "transport"
     return False, "other"
 
 
@@ -1142,6 +1149,26 @@ def _review_failure_mode(err: Exception) -> str:
 
 def _format_tried_providers(tried: list[tuple[str, str]]) -> str:
     return ", ".join(f"{name} ({mode})" for name, mode in tried)
+
+
+def _format_review_status_summary(statuses: list[ReviewProviderStatus]) -> str:
+    return "; ".join(
+        f"{status.provider}: {status.status} - {status.detail}"
+        for status in statuses
+    )
+
+
+def _review_attempt_log_state(status: str) -> str:
+    availability_statuses = {
+        "5xx",
+        "config",
+        "network",
+        "rate-limit",
+        "stall",
+        "timeout",
+        "transport",
+    }
+    return "unavailable" if status in availability_statuses else "failed"
 
 
 def _validate_max_fallbacks(raw: int) -> int:
@@ -2247,6 +2274,7 @@ def _invoke_review_with_fallback(
     last_exc: Exception | None = None
     fallbacks: list[str] = []
     tried: list[tuple[str, str]] = []
+    statuses: list[ReviewProviderStatus] = []
     candidates = list(decision.ranked[:max_fallbacks])
 
     for idx, candidate in enumerate(candidates):
@@ -2317,6 +2345,16 @@ def _invoke_review_with_fallback(
                 response = replace(response, text=validated_text)
             mark_outcome(candidate.name, "success")
             tried.append((candidate.name, "success"))
+            if statuses:
+                response = replace(
+                    response,
+                    raw={
+                        **response.raw,
+                        "review_provider_statuses": [
+                            asdict(status) for status in statuses
+                        ],
+                    },
+                )
             if not silent and len(tried) > 1:
                 click.echo(
                     f"[conductor] review tried providers: {_format_tried_providers(tried)}",
@@ -2328,10 +2366,24 @@ def _invoke_review_with_fallback(
             mark_outcome(candidate.name, "config")
             fallbacks.append(candidate.name)
             tried.append((candidate.name, "config"))
+            statuses.append(
+                ReviewProviderStatus(
+                    candidate.name,
+                    "config",
+                    _format_fallback_error_detail(e),
+                )
+            )
         except UnsupportedCapability as e:
             last_exc = e
             fallbacks.append(candidate.name)
             tried.append((candidate.name, "unsupported"))
+            statuses.append(
+                ReviewProviderStatus(
+                    candidate.name,
+                    "unsupported",
+                    _format_fallback_error_detail(e),
+                )
+            )
         except ProviderError as e:
             retryable, category = _is_retryable(e)
             if category == "rate-limit":
@@ -2341,12 +2393,27 @@ def _invoke_review_with_fallback(
             if not retryable:
                 raise
             fallbacks.append(candidate.name)
-            tried.append((candidate.name, _review_failure_mode(e)))
+            mode = _review_failure_mode(e)
+            tried.append((candidate.name, mode))
+            statuses.append(
+                ReviewProviderStatus(
+                    candidate.name,
+                    mode,
+                    _format_fallback_error_detail(e),
+                )
+            )
         except ReviewContextError as e:
             last_exc = e
             mark_outcome(candidate.name, "review-context")
             fallbacks.append(candidate.name)
             tried.append((candidate.name, "review-context"))
+            statuses.append(
+                ReviewProviderStatus(
+                    candidate.name,
+                    "review-context",
+                    _format_fallback_error_detail(e),
+                )
+            )
 
         if idx + 1 < len(candidates) and not silent:
             detail = (
@@ -2355,7 +2422,8 @@ def _invoke_review_with_fallback(
                 else "unknown error"
             )
             click.echo(
-                f"[conductor] {candidate.name} review failed ({tried[-1][1]}) · "
+                f"[conductor] {candidate.name} review "
+                f"{_review_attempt_log_state(tried[-1][1])} ({tried[-1][1]}) · "
                 f"{detail} · "
                 f"falling back → {candidates[idx + 1].name}",
                 err=True,
@@ -2365,14 +2433,23 @@ def _invoke_review_with_fallback(
     if tried:
         trail = _format_tried_providers(tried)
         last_detail = _format_fallback_error_detail(last_exc)
-        hint = (
-            "increase --max-fallbacks, exclude failing providers, or run "
-            "`conductor list` to check configured code-review providers"
+        status_summary = _format_review_status_summary(statuses)
+        direct_work = (
+            "Conductor did not complete a review; continue the coding/review "
+            "task directly in the driving agent, and do not treat this "
+            "Conductor output as clean or complete"
+        )
+        operator_hint = (
+            "Then inspect provider status, increase --max-fallbacks, exclude "
+            "failing providers, or run `conductor list` to check configured "
+            "code-review providers"
         )
         raise ProviderError(
             f"review infrastructure failed before any provider returned a "
             f"valid verdict; no review findings were emitted. Tried providers: "
-            f"{trail}. Last error: {last_detail}. Next step: {hint}."
+            f"{trail}. Provider status: {status_summary}. "
+            f"Last error: {last_detail}. Next step: {direct_work}. "
+            f"Operator follow-up: {operator_hint}."
         ) from last_exc
     raise last_exc
 

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -1469,6 +1469,98 @@ def test_review_auto_exhausted_fallback_names_stalled_codex_and_claude(mocker):
         in result.stderr
     )
     assert "codex (stall), claude (timeout)" in result.stderr
+    assert "Provider status:" in result.stderr
+    assert "codex: stall - ProviderStalledError: codex review stalled" in result.stderr
+    assert "claude: timeout - ProviderError: claude review timed out" in result.stderr
+    assert "continue the coding/review task directly in the driving agent" in result.stderr
+    assert "do not treat this Conductor output as clean or complete" in result.stderr
+
+
+def test_review_auto_claude_rate_limit_falls_through_to_next_provider(mocker):
+    from conductor.providers.interface import ProviderHTTPError
+
+    _stub_all_configured(mocker, {"claude", "openrouter"})
+    mocker.patch.object(ClaudeProvider, "review_configured", return_value=(True, None))
+    claude_review = mocker.patch.object(
+        ClaudeProvider,
+        "review",
+        side_effect=ProviderHTTPError("Anthropic returned 429 rate limit"),
+    )
+    openrouter_call = mocker.patch.object(
+        OpenRouterProvider,
+        "call",
+        return_value=_fake_response(
+            "openrouter",
+            OPENROUTER_CODING_HIGH[0],
+            text="No blocking issues found.\nCODEX_REVIEW_CLEAN",
+        ),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "review",
+            "--auto",
+            "--exclude",
+            "codex",
+            "--brief",
+            "Review this merge. End with CODEX_REVIEW_CLEAN or BLOCKED.",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert claude_review.called
+    assert openrouter_call.called
+    assert result.stdout.strip().endswith("CODEX_REVIEW_CLEAN")
+    assert "claude review unavailable (rate-limit)" in result.stderr
+    assert "falling back" in result.stderr
+    assert "code review failed for all tried providers" not in result.stderr
+
+
+def test_review_auto_next_provider_success_json_reports_winner_and_status(mocker):
+    from conductor.providers.interface import ProviderHTTPError
+
+    _stub_all_configured(mocker, {"claude", "openrouter"})
+    mocker.patch.object(ClaudeProvider, "review_configured", return_value=(True, None))
+    mocker.patch.object(
+        ClaudeProvider,
+        "review",
+        side_effect=ProviderHTTPError("Anthropic returned 429 rate limit"),
+    )
+    mocker.patch.object(
+        OpenRouterProvider,
+        "call",
+        return_value=_fake_response(
+            "openrouter",
+            OPENROUTER_CODING_HIGH[0],
+            text="No blocking issues found.\nCODEX_REVIEW_CLEAN",
+        ),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "review",
+            "--auto",
+            "--exclude",
+            "codex",
+            "--json",
+            "--brief",
+            "Review this merge. End with CODEX_REVIEW_CLEAN or BLOCKED.",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["provider"] == "openrouter"
+    assert payload["text"].endswith("CODEX_REVIEW_CLEAN")
+    assert payload["raw"]["review_provider_statuses"] == [
+        {
+            "provider": "claude",
+            "status": "rate-limit",
+            "detail": "ProviderHTTPError: Anthropic returned 429 rate limit",
+        }
+    ]
 
 
 def test_review_auto_output_contract_failure_falls_through_to_next_provider(mocker):

--- a/tests/test_review_cascade.py
+++ b/tests/test_review_cascade.py
@@ -155,8 +155,8 @@ def test_review_chain_walks_past_codex_to_next_code_review_provider(mocker) -> N
     assert codex_review.called
     assert openrouter_call.called
     assert result.stdout == "openrouter reviewed\n"
-    assert "claude review failed (stall)" in result.stderr
-    assert "codex review failed (stall)" in result.stderr
+    assert "claude review unavailable (stall)" in result.stderr
+    assert "codex review unavailable (stall)" in result.stderr
     assert "codex (stall), claude (stall), openrouter (success)" in result.stderr
 
 
@@ -392,8 +392,15 @@ def test_review_exhausted_error_includes_tried_provider_trail(mocker) -> None:
     )
     assert "no review findings were emitted" in result.stderr
     assert "codex (stall), claude (rate-limit), openrouter (5xx)" in result.stderr
+    assert "Provider status:" in result.stderr
+    assert (
+        "claude: rate-limit - ProviderHTTPError: Anthropic returned 429 rate limit"
+        in result.stderr
+    )
+    assert "openrouter: 5xx - ProviderHTTPError: OpenRouter returned HTTP 503" in result.stderr
     assert "ProviderHTTPError: OpenRouter returned HTTP 503" in result.stderr
     assert "Next step:" in result.stderr
+    assert "continue the coding/review task directly in the driving agent" in result.stderr
 
 
 def _write_executable(path: Path, body: str) -> None:


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->

Closes #346
