### PR TITLE
fix: respect read-only test recommendations (#342)

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -60,6 +60,7 @@ from conductor.delegation_ledger import (
     read_delegations,
     record_delegation,
 )
+from conductor.exec_completion import brief_declares_read_only_text_output
 from conductor.git_state import (
     DEFAULT_BRANCH_SCAN_LIMIT,
     DEFAULT_KEEP_WORKTREE_DAYS,
@@ -621,6 +622,8 @@ def _warn_if_short_exec_brief(
 
 
 def _call_mode_side_effect_reason(body: str) -> str | None:
+    if brief_declares_read_only_text_output(body):
+        return None
     patterns = (
         (
             re.compile(

--- a/src/conductor/exec_completion.py
+++ b/src/conductor/exec_completion.py
@@ -89,7 +89,11 @@ def detect_missing_deliverables(
 
     missing: list[MissingDeliverable] = []
     tool_calls = list(recent_tool_calls)[-RECENT_TOOL_CALL_LIMIT:]
-    if _brief_requests_tests(brief) and not _has_test_path_change(changed_paths):
+    if (
+        _brief_requests_tests(brief)
+        and not brief_declares_read_only_text_output(brief)
+        and not _has_test_path_change(changed_paths)
+    ):
         missing.append(
             MissingDeliverable(
                 "tests",
@@ -139,6 +143,28 @@ def completion_stretch_prompt(missing: Iterable[MissingDeliverable]) -> str:
         "You're at the iteration cap. Detected unfinished: "
         f"{labels}. Spend this final turn finishing them or surfacing why you can't."
     )
+
+
+def brief_declares_read_only_text_output(brief: str) -> bool:
+    """Return true when the brief explicitly forbids workspace mutation.
+
+    This is intentionally narrow: it captures read-only investigations and
+    text-only asks, but does not treat every mention of editing restrictions as
+    permission to skip implementation-task deliverables.
+    """
+
+    patterns = (
+        r"(?i)\bread[- ]?only\b",
+        r"(?i)\banalysis[- ]only\b",
+        r"(?i)\binvestigation[- ]only\b",
+        r"(?i)\btext[- ]only\b",
+        r"(?i)\bno\s+(?:file\s+)?(?:edits?|changes?|writes?)\b",
+        r"(?i)\bno\s+diff\b",
+        r"(?i)\bdo\s+not\s+(?:edit|modify|write|change)\s+(?:local\s+)?files?\b",
+        r"(?i)\bdon't\s+(?:edit|modify|write|change)\s+(?:local\s+)?files?\b",
+        r"(?i)\bwithout\s+(?:editing|modifying|writing|changing)\s+(?:local\s+)?files?\b",
+    )
+    return any(re.search(pattern, brief) for pattern in patterns)
 
 
 def _brief_requests_tests(brief: str) -> bool:

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -538,6 +538,34 @@ def test_ask_research_rejects_repo_side_effect_brief(mocker):
     assert "conductor ask --kind code --effort high" in result.output
 
 
+def test_ask_call_mode_allows_read_only_text_recommendations(mocker):
+    _stub_all_configured(mocker, {"openrouter"})
+    call_mock = mocker.patch.object(
+        OpenRouterProvider,
+        "call",
+        return_value=_fake_response("openrouter", "openrouter/auto"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "ask",
+            "--kind",
+            "code",
+            "--effort",
+            "low",
+            "--brief",
+            (
+                "Read-only investigation; do not edit files. "
+                "Expected output: files to update and regression tests to add/update."
+            ),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert call_mock.called
+
+
 def test_ask_code_high_routes_to_codex_exec_with_default_tools(mocker):
     _stub_all_configured(mocker, {"codex"})
     exec_mock = mocker.patch.object(CodexProvider, "exec", return_value=_fake_response("codex"))

--- a/tests/test_exec_completion.py
+++ b/tests/test_exec_completion.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from conductor.exec_completion import detect_missing_deliverables
+from conductor.exec_completion import (
+    brief_declares_read_only_text_output,
+    detect_missing_deliverables,
+)
 
 
 def test_tests_requested_without_test_path_change_is_flagged() -> None:
@@ -22,6 +25,33 @@ def test_tests_requested_with_test_path_change_is_not_flagged() -> None:
     )
 
     assert missing == []
+
+
+def test_read_only_test_recommendations_are_text_output_not_required_edits() -> None:
+    brief = """
+Goal:
+Investigate the failure. Do not edit files; this is read-only.
+
+Expected output:
+- Root cause
+- Regression tests to add/update
+"""
+
+    missing = detect_missing_deliverables(
+        brief,
+        changed_paths=(),
+        recent_tool_calls=[],
+    )
+
+    assert missing == []
+
+
+def test_read_only_classifier_requires_explicit_no_edit_semantics() -> None:
+    assert brief_declares_read_only_text_output("Read-only investigation; no diff.")
+    assert brief_declares_read_only_text_output("Do not edit files; report findings.")
+    assert not brief_declares_read_only_text_output(
+        "Implement the fix, but do not edit generated files."
+    )
 
 
 def test_validation_command_requested_without_recent_tool_call_is_flagged() -> None:

--- a/tests/test_openrouter.py
+++ b/tests/test_openrouter.py
@@ -1205,6 +1205,59 @@ def test_exec_iteration_cap_reports_missing_tests(configured, tmp_path):
     assert "Detected unfinished items" in str(exc.value)
 
 
+def test_exec_iteration_cap_does_not_require_tests_for_read_only_recommendations(
+    configured, tmp_path
+):
+    _init_clean_git_repo(tmp_path)
+    response = {
+        "model": "openai/gpt-5.5",
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_read",
+                            "type": "function",
+                            "function": {
+                                "name": "Read",
+                                "arguments": json.dumps({"path": "pyproject.toml"}),
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 2},
+    }
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.post("/chat/completions").mock(
+            return_value=httpx.Response(200, json=response)
+        )
+        with pytest.raises(ProviderExecutionError) as exc:
+            OpenRouterProvider().exec(
+                (
+                    "Read-only investigation. Do not edit files.\n\n"
+                    "Expected output:\n- Root cause\n"
+                    "- Regression tests to add/update"
+                ),
+                model="openai/gpt-5.5",
+                tools=frozenset({"Read"}),
+                task_tags=("code", "tool-use"),
+                sandbox="read-only",
+                cwd=str(tmp_path),
+                max_iterations=1,
+            )
+
+    status = exc.value.status
+    assert status["state"] == "iteration-cap"
+    assert status["missing_deliverables"] == []
+    assert "diff did not add to tests/" not in str(exc.value)
+
+
 def test_exec_allow_completion_stretch_runs_one_extra_turn(configured, tmp_path):
     _init_clean_git_repo(tmp_path)
     requests: list[dict] = []


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->

Closes #342
