### PR TITLE
fix: allow read-only text delegations (#340)

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -661,6 +661,8 @@ def _call_mode_side_effect_reason(body: str) -> str | None:
 
 
 def _reject_call_mode_side_effect_brief(kind: str, body: str) -> None:
+    if brief_declares_read_only_text_output(body):
+        return
     reason = _call_mode_side_effect_reason(body)
     if reason is None:
         return

--- a/src/conductor/exec_completion.py
+++ b/src/conductor/exec_completion.py
@@ -149,23 +149,36 @@ def completion_stretch_prompt(missing: Iterable[MissingDeliverable]) -> str:
 def brief_declares_read_only_text_output(brief: str) -> bool:
     """Return true when the brief explicitly forbids workspace mutation.
 
-    This is intentionally narrow: it captures read-only investigations and
-    text-only asks, but does not treat every mention of editing restrictions as
-    permission to skip implementation-task deliverables.
+    Test-shape language is common in read-only diagnosis. The invariant is that
+    an explicit no-edit/read-only brief may discuss tests to recommend, but it
+    is not an implementation task unless the caller separately asks for edits.
     """
 
-    patterns = (
-        r"(?i)\bread[- ]?only\b",
-        r"(?i)\banalysis[- ]only\b",
-        r"(?i)\binvestigation[- ]only\b",
-        r"(?i)\btext[- ]only\b",
-        r"(?i)\bno\s+(?:file\s+)?(?:edits?|changes?|writes?)\b",
-        r"(?i)\bno\s+diff\b",
-        r"(?i)\bdo\s+not\s+(?:edit|modify|write|change)\s+(?:local\s+)?files?\b",
-        r"(?i)\bdon't\s+(?:edit|modify|write|change)\s+(?:local\s+)?files?\b",
-        r"(?i)\bwithout\s+(?:editing|modifying|writing|changing)\s+(?:local\s+)?files?\b",
+    no_edit_patterns = (
+        r"(?i)\bdo\s+not\s+(modify|edit|write|change|create|update)\s+"
+        r"(files?|the\s+repo|the\s+repository|the\s+worktree|code|the\s+codebase)\b",
+        r"(?i)\bdon't\s+(modify|edit|write|change|create|update)\s+"
+        r"(files?|the\s+repo|the\s+repository|the\s+worktree|code|the\s+codebase)\b",
+        r"(?i)\bwithout\s+(modifying|editing|writing|changing)\s+"
+        r"(files?|the\s+repo|the\s+repository|the\s+worktree|code|the\s+codebase)\b",
+        r"(?i)\bno\s+(file\s+)?(edits?|changes?|modifications?|writes?)\b",
+        r"(?i)\bno\s+implementation\b",
+        r"(?i)\bdo\s+not\s+implement\b",
+        r"(?i)\bdon't\s+implement\b",
+        r"(?i)\bread[- ]only\s+"
+        r"(delegation|task|brief|prompt|analysis|investigation|diagnos(?:is|tic)|mode)\b",
+        r"(?i)\b(permission[- ]profile|profile)\s+read[- ]only\b",
+        r"(?i)\btext[- ]only\s+(delegation|task|brief|prompt|analysis|output|response)\b",
+        r"(?i)\banalysis\s+only\b",
+        r"(?i)\brecommend\s+(focused\s+)?(regression\s+)?tests?\s+only\b",
     )
-    return any(re.search(pattern, brief) for pattern in patterns)
+    if not any(re.search(pattern, brief) for pattern in no_edit_patterns):
+        return False
+
+    implementation_patterns = (
+        r"(?im)^\s*[-*]?\s*(implement|fix|modify|edit|write|create|update)\b",
+    )
+    return not any(re.search(pattern, brief) for pattern in implementation_patterns)
 
 
 def _brief_requests_tests(brief: str) -> bool:

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -566,6 +566,62 @@ def test_ask_call_mode_allows_read_only_text_recommendations(mocker):
     assert call_mock.called
 
 
+def test_ask_research_allows_text_only_test_recommendation_brief(mocker):
+    _stub_all_configured(mocker, {"openrouter"})
+    call_mock = mocker.patch.object(
+        OpenRouterProvider,
+        "call",
+        return_value=_fake_response("openrouter", "openrouter/auto"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "ask",
+            "--kind",
+            "research",
+            "--effort",
+            "medium",
+            "--brief",
+            (
+                "Read-only analysis task. Do not modify files, commit changes, "
+                "push, or open a PR. Recommend focused regression tests only."
+            ),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert call_mock.called
+
+
+def test_ask_code_call_mode_allows_text_only_code_analysis(mocker):
+    _stub_all_configured(mocker, {"openrouter"})
+    call_mock = mocker.patch.object(
+        OpenRouterProvider,
+        "call",
+        return_value=_fake_response("openrouter", "openrouter/auto"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "ask",
+            "--kind",
+            "code",
+            "--effort",
+            "low",
+            "--brief",
+            (
+                "Text-only code analysis. Do not modify files or implement the fix. "
+                "Explain the likely root cause and recommend tests to add."
+            ),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert call_mock.called
+
+
 def test_ask_code_high_routes_to_codex_exec_with_default_tools(mocker):
     _stub_all_configured(mocker, {"codex"})
     exec_mock = mocker.patch.object(CodexProvider, "exec", return_value=_fake_response("codex"))
@@ -2483,6 +2539,37 @@ def test_exec_permission_profile_auto_routes_to_enforcing_provider(mocker):
     assert not gemini_exec.called
     assert claude_exec.call_args.kwargs["tools"] == frozenset({"Read", "Grep", "Glob"})
     assert "→ claude" in result.stderr
+
+
+def test_exec_read_only_brief_with_test_recommendations_returns_text(mocker):
+    _stub_all_configured(mocker, {"claude"})
+    exec_mock = mocker.patch.object(
+        ClaudeProvider,
+        "exec",
+        return_value=_fake_response("claude", text="Root cause analysis."),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--auto",
+            "--permission-profile",
+            "read-only",
+            "--no-preflight",
+            "--allow-short-brief",
+            "--task",
+            (
+                "Read-only analysis task. Do not modify files. "
+                "Recommend focused regression tests only."
+            ),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert exec_mock.called
+    assert exec_mock.call_args.kwargs["tools"] == frozenset({"Read", "Grep", "Glob"})
+    assert "Root cause analysis." in result.output
 
 
 def test_exec_permission_profile_rejects_non_enforcing_direct_provider(mocker):

--- a/tests/test_exec_completion.py
+++ b/tests/test_exec_completion.py
@@ -17,6 +17,33 @@ def test_tests_requested_without_test_path_change_is_flagged() -> None:
     assert "diff did not add to tests/" in missing[0].message
 
 
+def test_read_only_test_recommendations_do_not_require_test_path_change() -> None:
+    missing = detect_missing_deliverables(
+        (
+            "Read-only analysis task. Do not modify files.\n\n"
+            "Recommend focused regression tests only; do not implement or commit changes."
+        ),
+        changed_paths=(),
+        recent_tool_calls=[],
+    )
+
+    assert missing == []
+
+
+def test_implementation_brief_still_requires_requested_tests() -> None:
+    missing = detect_missing_deliverables(
+        (
+            "Implement the fix.\n\n"
+            "Do not modify files outside src/conductor.\n\n"
+            "## Tests\nAdd regression tests."
+        ),
+        changed_paths=("src/conductor/foo.py",),
+        recent_tool_calls=[],
+    )
+
+    assert [item.kind for item in missing] == ["tests"]
+
+
 def test_tests_requested_with_test_path_change_is_not_flagged() -> None:
     missing = detect_missing_deliverables(
         "Implement it.\n\n## Tests\nAdd regression coverage.",


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->

Closes #340
