### PR TITLE
fix: reject no-context OpenRouter review output (#338)

### DIFF
--- a/.cursor/rules/conductor-delegation.mdc
+++ b/.cursor/rules/conductor-delegation.mdc
@@ -2,7 +2,7 @@
 description: Use when delegating or routing tasks to a different LLM via the conductor CLI — e.g., cheap second opinions, long-context reads, web search, or offline runs.
 globs: ""
 alwaysApply: false
-managed-by: conductor v0.10.18
+managed-by: conductor v0.10.19
 ---
 
 # Conductor delegation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ If there are zero blocking issues, the review is just: "LGTM."
 
 @.cortex/protocol.md
 
-<!-- conductor:begin v0.10.18 -->
+<!-- conductor:begin v0.10.19 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
 
-<!-- conductor:begin v0.10.18 -->
+<!-- conductor:begin v0.10.19 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/src/conductor/providers/review_contract.py
+++ b/src/conductor/providers/review_contract.py
@@ -15,7 +15,14 @@ _MISSING_REVIEW_CONTEXT_RE = re.compile(
     r"no files? (?:were )?provided|"
     r"no (?:code )?changes? (?:were )?provided|"
     r"no diff (?:was )?provided|"
-    r"provide (?:the )?(?:code changes?|diff|file diffs?|files? themselves)"
+    r"provide (?:the )?(?:code changes?|diff|file diffs?|files? themselves)|"
+    r"(?:cannot|can not|can't|unable to|do not|don't) "
+    r"[^.\n]{0,80}\b"
+    r"(?:code changes?|diff|patch|files?|repo(?:sitory)?|tools?)|"
+    r"no access to (?:the )?"
+    r"(?:code changes?|diff|patch|files?|repo(?:sitory)?(?: tools?)?|tools?)|"
+    r"lack(?:ing|s)? (?:the )?(?:necessary )?"
+    r"(?:code changes?|diff|patch|files?|repo(?:sitory)?|tool access|tools?)"
     r")\b",
     re.IGNORECASE,
 )

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -1663,6 +1663,74 @@ def test_review_auto_generic_fallback_rejects_missing_requested_sentinel(
     assert "ReviewOutputContractError" in result.stderr
 
 
+def test_review_auto_openrouter_no_context_blocked_is_infrastructure_failure(
+    mocker, tmp_path
+):
+    from conductor.providers.interface import ProviderStalledError
+
+    repo = _make_diff_repo(tmp_path)
+    _stub_all_configured(mocker, {"codex", "claude", "openrouter"})
+    mocker.patch.object(CodexProvider, "review_configured", return_value=(True, None))
+    mocker.patch.object(ClaudeProvider, "review_configured", return_value=(True, None))
+    mocker.patch.object(
+        CodexProvider,
+        "review",
+        side_effect=ProviderStalledError("codex review stalled"),
+    )
+    mocker.patch.object(
+        ClaudeProvider,
+        "review",
+        side_effect=ProviderStalledError("claude review stalled"),
+    )
+    openrouter_call = mocker.patch.object(
+        OpenRouterProvider,
+        "call",
+        return_value=CallResponse(
+            text=(
+                "I cannot access repository tools or inspect the diff, so I "
+                "cannot provide an actionable code review.\nCODEX_REVIEW_BLOCKED"
+            ),
+            provider="openrouter",
+            model="test-model",
+            duration_ms=10,
+            usage={},
+            raw={},
+        ),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "review",
+            "--auto",
+            "--max-fallbacks",
+            "3",
+            "--cwd",
+            str(repo),
+            "--base",
+            "HEAD~1",
+            "--tags",
+            "code-review,tool-use",
+            "--brief",
+            (
+                "The LAST line of your output must be exactly one of these "
+                "three sentinels: CODEX_REVIEW_CLEAN, CODEX_REVIEW_FIXED, "
+                "or CODEX_REVIEW_BLOCKED."
+            ),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    prompt = openrouter_call.call_args.args[0]
+    assert "Patch context for generic review fallback" in prompt
+    assert "diff --git a/README.md b/README.md" in prompt
+    assert "+fallback diff marker" in prompt
+    assert "openrouter (output-contract)" in result.stderr
+    assert "missing-context" in result.stderr
+    assert "cannot provide an actionable code review" in result.stderr
+
+
 def test_review_auto_codex_subprocess_rejects_missing_requested_sentinel(mocker):
     # Exercises the same conductor review --auto -> codex subprocess path used
     # by scripts/codex-review.sh when codex is the selected native reviewer.

--- a/tests/test_review_contract.py
+++ b/tests/test_review_contract.py
@@ -95,6 +95,27 @@ def test_review_sentinel_contract_rejects_missing_context_claim_with_embedded_pa
     assert exc_info.value.reason == "missing-context"
 
 
+def test_review_sentinel_contract_rejects_no_tool_access_claim_with_embedded_patch():
+    prompt = (
+        STRICT_SENTINEL_PROMPT
+        + "\n\nPatch context for generic review fallback:\n"
+        + "```diff\n"
+        + "diff --git a/app.py b/app.py\n"
+        + "+print('review me')\n"
+        + "```"
+    )
+
+    with pytest.raises(ReviewOutputContractError, match="missing-context"):
+        validate_requested_review_sentinel(
+            provider_name="openrouter",
+            prompt=prompt,
+            text=(
+                "I cannot access repository tools or inspect the diff, so I "
+                "cannot perform a meaningful review.\nCODEX_REVIEW_BLOCKED"
+            ),
+        )
+
+
 def test_review_sentinel_contract_allows_missing_context_claim_without_patch():
     prompt = (
         STRICT_SENTINEL_PROMPT


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->

Closes #338
