### PR TITLE
fix: classify OpenRouter pre-output failures (#314)

### DIFF
--- a/.cursor/rules/conductor-delegation.mdc
+++ b/.cursor/rules/conductor-delegation.mdc
@@ -2,7 +2,7 @@
 description: Use when delegating or routing tasks to a different LLM via the conductor CLI — e.g., cheap second opinions, long-context reads, web search, or offline runs.
 globs: ""
 alwaysApply: false
-managed-by: conductor v0.10.18
+managed-by: conductor v0.10.19
 ---
 
 # Conductor delegation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ If there are zero blocking issues, the review is just: "LGTM."
 
 @.cortex/protocol.md
 
-<!-- conductor:begin v0.10.18 -->
+<!-- conductor:begin v0.10.19 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
 
-<!-- conductor:begin v0.10.18 -->
+<!-- conductor:begin v0.10.19 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -1067,6 +1067,15 @@ def _is_retryable(err: Exception) -> tuple[bool, str]:
         return True, "timeout"
     if isinstance(err, ProviderExecutionError):
         return True, "provider-error"
+    if isinstance(err, ProviderHTTPError) and err.failure_reason:
+        reason_categories = {
+            "auth_quota": "rate-limit",
+            "malformed_response": "provider-error",
+            "provider_outage": "5xx",
+            "transient_network": "network",
+            "usage_config_error": "provider-error",
+        }
+        return True, reason_categories.get(err.failure_reason, "provider-error")
     msg = str(err).lower()
     if "429" in msg or any(sig in msg for sig in _RATE_LIMIT_ERROR_SIGNALS):
         return True, "rate-limit"

--- a/src/conductor/providers/interface.py
+++ b/src/conductor/providers/interface.py
@@ -75,6 +75,21 @@ class ProviderHTTPError(ProviderError):
     """Raised when an HTTP-backed provider receives an upstream error
     (non-2xx, malformed JSON, timeout)."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        failure_reason: str | None = None,
+        provider: str | None = None,
+        status_code: int | None = None,
+        upstream_body: str | None = None,
+    ) -> None:
+        self.failure_reason = failure_reason
+        self.provider = provider
+        self.status_code = status_code
+        self.upstream_body = upstream_body
+        super().__init__(message)
+
 
 class ProviderExecutionError(ProviderError):
     """Raised when a provider completes transport but fails execution policy."""

--- a/src/conductor/providers/openrouter.py
+++ b/src/conductor/providers/openrouter.py
@@ -199,17 +199,35 @@ class OpenRouterProvider:
                     headers=self._headers(),
                     json=payload,
                 )
+        except httpx.TimeoutException as e:
+            raise ProviderHTTPError(
+                f"network error calling OpenRouter: {e}",
+                failure_reason="transient_network",
+                provider=self.name,
+            ) from e
         except httpx.HTTPError as e:
-            raise ProviderHTTPError(f"network error calling OpenRouter: {e}") from e
+            raise ProviderHTTPError(
+                f"network error calling OpenRouter: {e}",
+                failure_reason="transient_network",
+                provider=self.name,
+            ) from e
 
         if resp.status_code != 200:
             raise ProviderHTTPError(
-                _format_openrouter_http_error(resp.status_code, resp.text, payload)
+                _format_openrouter_http_error(resp.status_code, resp.text, payload),
+                failure_reason=_openrouter_http_failure_reason(resp.status_code, resp.text),
+                provider=self.name,
+                status_code=resp.status_code,
+                upstream_body=resp.text[:500],
             )
         try:
             return resp.json()
         except ValueError as e:
-            raise ProviderHTTPError(f"OpenRouter response was not JSON: {e}") from e
+            raise ProviderHTTPError(
+                f"OpenRouter response was not JSON: {e}",
+                failure_reason="malformed_response",
+                provider=self.name,
+            ) from e
 
     def _completion_target_payload(
         self,
@@ -342,7 +360,9 @@ class OpenRouterProvider:
             )
             if retry_payload is None:
                 raise ProviderHTTPError(
-                    _empty_call_response_message(body, fallback_model=selected_model)
+                    _empty_call_response_message(body, fallback_model=selected_model),
+                    failure_reason="malformed_response",
+                    provider=self.name,
                 )
             attempts.append(
                 {
@@ -703,7 +723,11 @@ class OpenRouterProvider:
                 status=execution_status,
             )
         if not final_text.strip():
-            raise ProviderHTTPError("OpenRouter exec produced empty final response")
+            raise ProviderHTTPError(
+                "OpenRouter exec produced empty final response",
+                failure_reason="malformed_response",
+                provider=self.name,
+            )
 
         return CallResponse(
             text=final_text,
@@ -1159,6 +1183,19 @@ def _format_openrouter_http_error(status_code: int, response_text: str, payload:
     return " ".join(parts)
 
 
+def _openrouter_http_failure_reason(status_code: int, response_text: str) -> str:
+    if status_code in {401, 403, 429}:
+        return "auth_quota"
+    if 500 <= status_code <= 599:
+        return "provider_outage"
+    if 400 <= status_code <= 499:
+        lowered = response_text.lower()
+        if any(token in lowered for token in ("quota", "rate limit", "credit", "billing")):
+            return "auth_quota"
+        return "usage_config_error"
+    return "provider_outage"
+
+
 def _openrouter_attempted_models(payload: dict) -> list[str]:
     attempted: list[str] = []
     model = payload.get("model")
@@ -1193,7 +1230,11 @@ def _remaining_timeout_sec(
         return None
     remaining = float(timeout_sec) - (time.monotonic() - start)
     if remaining <= 0:
-        raise ProviderHTTPError(f"{provider_name} timed out after {timeout_sec:g}s")
+        raise ProviderHTTPError(
+            f"{provider_name} timed out after {timeout_sec:g}s",
+            failure_reason="transient_network",
+            provider=provider_name,
+        )
     return remaining
 
 
@@ -1202,15 +1243,21 @@ def _call_response_text(body: dict) -> str:
         message = body["choices"][0]["message"]
     except (KeyError, IndexError, TypeError) as e:
         raise ProviderHTTPError(
-            f"OpenRouter response missing choices[0].message.content: {body!r:.500}"
+            f"OpenRouter response missing choices[0].message.content: {body!r:.500}",
+            failure_reason="malformed_response",
+            provider="openrouter",
         ) from e
     if not isinstance(message, dict):
         raise ProviderHTTPError(
-            f"OpenRouter response choices[0].message was not an object: {message!r:.500}"
+            f"OpenRouter response choices[0].message was not an object: {message!r:.500}",
+            failure_reason="malformed_response",
+            provider="openrouter",
         )
     if "content" not in message:
         raise ProviderHTTPError(
-            f"OpenRouter response missing choices[0].message.content: {body!r:.500}"
+            f"OpenRouter response missing choices[0].message.content: {body!r:.500}",
+            failure_reason="malformed_response",
+            provider="openrouter",
         )
     text = message["content"]
     if text is None:
@@ -1221,7 +1268,9 @@ def _call_response_text(body: dict) -> str:
             "OpenRouter response content was not text: "
             f"model={_response_model(body, fallback=None)} "
             f"content_type={type(text).__name__} "
-            f"finish_reason={finish_reason or '<unknown>'}"
+            f"finish_reason={finish_reason or '<unknown>'}",
+            failure_reason="malformed_response",
+            provider="openrouter",
         )
     return text
 
@@ -1297,11 +1346,15 @@ def _first_message(body: dict) -> dict:
         message = body["choices"][0]["message"]
     except (KeyError, IndexError, TypeError) as e:
         raise ProviderHTTPError(
-            f"OpenRouter response missing choices[0].message: {body!r:.500}"
+            f"OpenRouter response missing choices[0].message: {body!r:.500}",
+            failure_reason="malformed_response",
+            provider="openrouter",
         ) from e
     if not isinstance(message, dict):
         raise ProviderHTTPError(
-            f"OpenRouter response choices[0].message was not an object: {message!r:.500}"
+            f"OpenRouter response choices[0].message was not an object: {message!r:.500}",
+            failure_reason="malformed_response",
+            provider="openrouter",
         )
     return message
 

--- a/tests/test_offline_fallback.py
+++ b/tests/test_offline_fallback.py
@@ -174,6 +174,29 @@ def test_is_retryable_still_handles_known_categories():
     assert _is_retryable(ValueError("some other failure")) == (False, "other")
 
 
+@pytest.mark.parametrize(
+    ("failure_reason", "expected_category"),
+    [
+        ("auth_quota", "rate-limit"),
+        ("malformed_response", "provider-error"),
+        ("provider_outage", "5xx"),
+        ("transient_network", "network"),
+        ("usage_config_error", "provider-error"),
+    ],
+)
+def test_is_retryable_prefers_provider_http_failure_reason(
+    failure_reason,
+    expected_category,
+):
+    error = ProviderHTTPError(
+        "OpenRouter failed before review output",
+        failure_reason=failure_reason,
+        provider="openrouter",
+    )
+
+    assert _is_retryable(error) == (True, expected_category)
+
+
 # --------------------------------------------------------------------------- #
 # 2. offline_mode sticky flag
 # --------------------------------------------------------------------------- #

--- a/tests/test_openrouter.py
+++ b/tests/test_openrouter.py
@@ -225,6 +225,48 @@ def test_call_none_response_without_fallback_includes_response_shape(configured)
     assert "finish_reason=stop" in message
 
 
+@pytest.mark.parametrize(
+    ("status_code", "body", "expected_reason"),
+    [
+        (429, "rate limit exceeded", "auth_quota"),
+        (400, "invalid model request", "usage_config_error"),
+        (503, "service unavailable", "provider_outage"),
+    ],
+)
+def test_call_http_error_exposes_failure_taxonomy(
+    configured,
+    status_code,
+    body,
+    expected_reason,
+):
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.post("/chat/completions").mock(
+            return_value=httpx.Response(status_code, text=body)
+        )
+        with pytest.raises(ProviderHTTPError) as exc:
+            OpenRouterProvider().call("Review this.", model="model-a")
+
+    error = exc.value
+    assert error.provider == "openrouter"
+    assert error.status_code == status_code
+    assert error.upstream_body == body
+    assert error.failure_reason == expected_reason
+    assert f"upstream HTTP {status_code}" in str(error)
+
+
+def test_call_malformed_json_exposes_failure_taxonomy(configured):
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.post("/chat/completions").mock(
+            return_value=httpx.Response(200, text="not json")
+        )
+        with pytest.raises(ProviderHTTPError) as exc:
+            OpenRouterProvider().call("Review this.", model="model-a")
+
+    assert exc.value.provider == "openrouter"
+    assert exc.value.failure_reason == "malformed_response"
+    assert "not JSON" in str(exc.value)
+
+
 def test_call_raises_config_error_when_unconfigured(no_key):
     with pytest.raises(ProviderConfigError):
         OpenRouterProvider().call("hello")


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->

Closes #314
