### PR TITLE
Clean shipped swarm branches

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -5788,6 +5788,74 @@ def _remove_swarm_worktree(worktree: Path, *, repo_root: Path) -> None:
         _run_swarm_git(["worktree", "remove", str(worktree)], cwd=repo_root)
 
 
+def _swarm_branch_worktrees(branch: str, *, repo_root: Path) -> list[str]:
+    output = _run_swarm_git(["worktree", "list", "--porcelain"], cwd=repo_root).stdout
+    attached: list[str] = []
+    current_path: str | None = None
+    for raw_line in output.splitlines():
+        if not raw_line:
+            current_path = None
+            continue
+        key, _, value = raw_line.partition(" ")
+        if key == "worktree":
+            current_path = value
+        elif key == "branch" and value == f"refs/heads/{branch}" and current_path is not None:
+            attached.append(current_path)
+    return attached
+
+
+def _delete_shipped_swarm_branch(
+    branch: str,
+    *,
+    repo_root: Path,
+    merge_sha: str | None,
+) -> str | None:
+    if not branch.startswith(f"{SWARM_BRANCH_PREFIX}/"):
+        return f"refusing to delete non-swarm branch {branch!r}"
+    if merge_sha is None:
+        return f"preserving local branch {branch!r}: shipped PR has no merge commit SHA"
+
+    branch_ref = f"refs/heads/{branch}"
+    branch_exists = _run_swarm_git(
+        ["show-ref", "--verify", "--quiet", branch_ref],
+        cwd=repo_root,
+        check=False,
+    )
+    if branch_exists.returncode != 0:
+        return None
+
+    try:
+        branch_tree = _run_swarm_git(
+            ["rev-parse", f"{branch_ref}^{{tree}}"],
+            cwd=repo_root,
+        ).stdout.strip()
+        merge_tree = _run_swarm_git(
+            ["rev-parse", f"{merge_sha}^{{tree}}"],
+            cwd=repo_root,
+        ).stdout.strip()
+    except RuntimeError as e:
+        return f"preserving local branch {branch!r}: could not verify shipped tree: {e}"
+
+    if branch_tree != merge_tree:
+        return (
+            f"preserving local branch {branch!r}: branch tree {branch_tree} does not "
+            f"match merge commit {merge_sha} tree {merge_tree}"
+        )
+
+    attached_worktrees = _swarm_branch_worktrees(branch, repo_root=repo_root)
+    if attached_worktrees:
+        return (
+            f"preserving local branch {branch!r}: still checked out in "
+            + ", ".join(attached_worktrees)
+        )
+
+    try:
+        _run_swarm_git(["branch", "-D", branch], cwd=repo_root)
+    except RuntimeError as e:
+        return f"could not delete local branch {branch!r} after shipped cleanup: {e}"
+    return None
+
+
 def _extract_pr_url(output: str) -> str | None:
     match = re.search(r"https://github\.com/[^\s]+/pull/\d+", output)
     return match.group(0) if match else None
@@ -6063,6 +6131,15 @@ def _run_swarm_task(
     ):
         try:
             _remove_swarm_worktree(worktree, repo_root=repo_root)
+            if result.status == "shipped":
+                cleanup_warning = _delete_shipped_swarm_branch(
+                    branch,
+                    repo_root=repo_root,
+                    merge_sha=merge_sha,
+                )
+                if cleanup_warning is not None:
+                    click.echo(f"[conductor] warning: {cleanup_warning}", err=True)
+                    result.failure_reason = cleanup_warning
         except RuntimeError as e:
             result.status = "failed"
             result.failure_reason = f"{result.failure_reason or result.status}; cleanup failed: {e}"

--- a/tests/test_cli_swarm.py
+++ b/tests/test_cli_swarm.py
@@ -23,6 +23,16 @@ def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _git_returncode(repo: Path, *args: str) -> int:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    ).returncode
+
+
 def _repo(tmp_path: Path) -> Path:
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -83,6 +93,25 @@ def _fake_ship(worktree: Path, *, base_branch: str, branch: str, auto_merge: boo
     if auto_merge:
         return "shipped", "https://github.com/example/repo/pull/123", "abc1234"
     return "pushed-not-merged", "https://github.com/example/repo/pull/123", None
+
+
+def _fake_merged_ship(repo: Path):
+    def fake_ship(worktree: Path, *, base_branch: str, branch: str, auto_merge: bool):
+        _ = (branch, auto_merge)
+        tree = _git(worktree, "rev-parse", "HEAD^{tree}").stdout.strip()
+        merge_sha = _git(
+            repo,
+            "commit-tree",
+            tree,
+            "-p",
+            base_branch,
+            "-m",
+            "squash merge",
+        ).stdout.strip()
+        _git(repo, "update-ref", f"refs/heads/{base_branch}", merge_sha)
+        return "shipped", "https://github.com/example/repo/pull/123", merge_sha
+
+    return fake_ship
 
 
 @pytest.mark.parametrize(
@@ -228,7 +257,7 @@ def test_swarm_one_brief_succeeds_as_shipped(monkeypatch, tmp_path: Path) -> Non
     brief = _brief(repo, "foo.md")
     monkeypatch.chdir(repo)
     monkeypatch.setattr(cli, "_run_exec_phase_dispatch", _fake_exec_factory())
-    monkeypatch.setattr(cli, "_ship_swarm_pr", _fake_ship)
+    monkeypatch.setattr(cli, "_ship_swarm_pr", _fake_merged_ship(repo))
 
     result = CliRunner().invoke(
         main,
@@ -241,6 +270,11 @@ def test_swarm_one_brief_succeeds_as_shipped(monkeypatch, tmp_path: Path) -> Non
     assert payload["shipped_count"] == 1
     assert payload["tasks"][0]["status"] == "shipped"
     assert payload["tasks"][0]["commits"] == 1
+    assert not Path(payload["tasks"][0]["worktree"]).exists()
+    assert (
+        _git_returncode(repo, "show-ref", "--verify", "--quiet", "refs/heads/feat/swarm/foo")
+        == 1
+    )
 
 
 def test_swarm_ship_appends_closing_ref_to_last_commit_body(
@@ -383,6 +417,10 @@ def test_swarm_second_failure_preserves_worktree(monkeypatch, tmp_path: Path) ->
     assert [task["status"] for task in payload["tasks"]] == ["shipped", "failed"]
     failed_worktree = Path(payload["tasks"][1]["worktree"])
     assert failed_worktree.exists()
+    assert (
+        _git_returncode(repo, "show-ref", "--verify", "--quiet", "refs/heads/feat/swarm/bar")
+        == 0
+    )
     assert payload["tasks"][1]["failure_reason"] == "max-iterations cap reached"
 
 
@@ -425,6 +463,46 @@ def test_swarm_auto_merge_off_leaves_pushed_not_merged(monkeypatch, tmp_path: Pa
     assert payload["ok"] is False
     assert payload["tasks"][0]["status"] == "pushed-not-merged"
     assert payload["tasks"][0]["pr_url"] == "https://github.com/example/repo/pull/123"
+    assert Path(payload["tasks"][0]["worktree"]).exists()
+    assert (
+        _git_returncode(repo, "show-ref", "--verify", "--quiet", "refs/heads/feat/swarm/foo")
+        == 0
+    )
+
+
+def test_swarm_shipped_branch_delete_failure_is_reported(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    brief = _brief(repo, "foo.md")
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(cli, "_run_exec_phase_dispatch", _fake_exec_factory())
+    monkeypatch.setattr(cli, "_ship_swarm_pr", _fake_merged_ship(repo))
+    original_run_swarm_git = cli._run_swarm_git
+
+    def fake_run_swarm_git(args, **kwargs):
+        if args == ["branch", "-D", "feat/swarm/foo"]:
+            raise RuntimeError("branch delete failed for test")
+        return original_run_swarm_git(args, **kwargs)
+
+    monkeypatch.setattr(cli, "_run_swarm_git", fake_run_swarm_git)
+
+    result = CliRunner().invoke(
+        main,
+        ["swarm", "--provider", "codex", "--brief", str(brief), "--auto-merge", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["tasks"][0]["status"] == "shipped"
+    assert "branch delete failed for test" in payload["tasks"][0]["failure_reason"]
+    assert "branch delete failed for test" in result.stderr
+    assert not Path(payload["tasks"][0]["worktree"]).exists()
+    assert (
+        _git_returncode(repo, "show-ref", "--verify", "--quiet", "refs/heads/feat/swarm/foo")
+        == 0
+    )
 
 
 def test_swarm_sanitizes_brief_stem_for_branch(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
After a shipped swarm lane removes its temporary worktree, delete the generated local swarm branch only when its tree matches the recorded merge commit. Preserve and warn on any lane where that safety check or branch deletion fails.

Closes #360

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
