### PR TITLE
Add durable swarm run manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ build/
 .next/
 out/
 
+# Conductor runtime cache
+.cache/conductor/
+
 # Touchstone
 *.bak
 .cortex/.index.json

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -32,6 +32,7 @@ import tempfile
 import threading
 import time
 import tomllib
+import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass, replace
 from datetime import UTC, datetime
@@ -5539,6 +5540,7 @@ SWARM_WORKTREE_LOCK = threading.Lock()
 SWARM_GIT_TIMEOUT_SEC = 30.0
 SWARM_GH_TIMEOUT_SEC = 30.0
 SWARM_SHIP_TIMEOUT_SEC = 1800.0
+SWARM_MANIFEST_SCHEMA_VERSION = 1
 _SWARM_FENCED_CODE_BLOCK_RE = re.compile(r"(?ms)^```.*?^```")
 _SWARM_CLOSING_LINE_RE = re.compile(
     r"(?im)^\s*(?:Closes|Fixes|Resolves)\s+"
@@ -5602,6 +5604,18 @@ def _swarm_branch_for_brief(path: str) -> str:
 
 def _swarm_worktree_for_brief(path: str, *, repo_root: Path) -> Path:
     return (repo_root / ".cache" / "conductor" / "swarm" / _sanitize_swarm_stem(path)).resolve()
+
+
+def _swarm_runs_dir(repo_root: Path) -> Path:
+    return repo_root / ".cache" / "conductor" / "swarm" / "runs"
+
+
+def _new_swarm_run_id(started_at: datetime) -> str:
+    return f"{started_at.strftime('%Y%m%dT%H%M%S%fZ')}-{uuid.uuid4().hex[:8]}"
+
+
+def _swarm_now_iso() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
 def _append_unique_issue_ref(refs: list[str], seen: set[str], number: str) -> None:
@@ -5713,6 +5727,12 @@ def _append_swarm_closing_refs_to_head_commit(worktree: Path, refs: list[str]) -
 def _validate_swarm_briefs(briefs: tuple[str, ...], *, repo_root: Path) -> None:
     seen_branches: dict[str, str] = {}
     for brief_path in briefs:
+        stem = _sanitize_swarm_stem(brief_path)
+        if stem == "runs":
+            raise click.UsageError(
+                f"--brief {brief_path!r} maps to reserved swarm worktree slug 'runs'; "
+                "rename the brief file."
+            )
         branch = _swarm_branch_for_brief(brief_path)
         if branch in seen_branches:
             raise click.UsageError(
@@ -5992,6 +6012,171 @@ def _swarm_summary(results: list[SwarmTaskResult]) -> dict[str, object]:
         "failed_count": failed_count,
         "no_changes_count": no_changes_count,
     }
+
+
+def _swarm_initial_task_records(
+    briefs: tuple[str, ...],
+    *,
+    repo_root: Path,
+) -> list[dict[str, object]]:
+    tasks: list[dict[str, object]] = []
+    for brief_path in briefs:
+        tasks.append(
+            {
+                "brief": brief_path,
+                "branch": _swarm_branch_for_brief(brief_path),
+                "worktree": str(_swarm_worktree_for_brief(brief_path, repo_root=repo_root)),
+                "status": "pending",
+                "commits": 0,
+                "pr_url": None,
+                "merge_sha": None,
+                "duration_ms": 0,
+                "failure_reason": None,
+                "cleanup_status": "pending",
+            }
+        )
+    return tasks
+
+
+def _swarm_manifest_payload(
+    *,
+    run_id: str,
+    repo_root: Path,
+    base_branch: str,
+    base_ref: str | None,
+    started_at: str,
+    ended_at: str | None,
+    duration_ms: int | None,
+    tasks: list[dict[str, object]],
+) -> dict[str, object]:
+    shipped_count = sum(1 for task in tasks if task.get("status") == "shipped")
+    failed_count = sum(1 for task in tasks if task.get("status") == "failed")
+    no_changes_count = sum(1 for task in tasks if task.get("status") == "no-changes")
+    ok = bool(tasks) and all(task.get("status") in SWARM_SUCCESS_STATUSES for task in tasks)
+    return {
+        "schema_version": SWARM_MANIFEST_SCHEMA_VERSION,
+        "run_id": run_id,
+        "repo_root": str(repo_root),
+        "base_branch": base_branch,
+        "base_ref": base_ref,
+        "started_at": started_at,
+        "ended_at": ended_at,
+        "duration_ms": duration_ms,
+        "tasks": tasks,
+        "ok": ok,
+        "shipped_count": shipped_count,
+        "failed_count": failed_count,
+        "no_changes_count": no_changes_count,
+    }
+
+
+def _write_swarm_manifest(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        temp_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        temp_path.replace(path)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+def _swarm_manifest_task_records(results: list[SwarmTaskResult]) -> list[dict[str, object]]:
+    tasks: list[dict[str, object]] = []
+    for result in results:
+        task = result.to_json()
+        task["cleanup_status"] = "removed" if not Path(result.worktree).exists() else "preserved"
+        tasks.append(task)
+    return tasks
+
+
+def _read_swarm_manifest(path: Path) -> dict[str, object]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as e:
+        raise click.ClickException(f"could not read swarm manifest {path}: {e}") from e
+    except json.JSONDecodeError as e:
+        raise click.ClickException(f"invalid swarm manifest JSON at {path}: {e}") from e
+    if not isinstance(payload, dict):
+        raise click.ClickException(
+            f"invalid swarm manifest at {path}: top-level value is not an object"
+        )
+    return payload
+
+
+def _latest_swarm_manifest_path(repo_root: Path) -> Path:
+    runs_dir = _swarm_runs_dir(repo_root)
+    manifests = sorted(runs_dir.glob("*.json"), key=lambda path: path.stem, reverse=True)
+    if not manifests:
+        raise click.ClickException(f"no swarm manifests found in {runs_dir}")
+    return manifests[0]
+
+
+def _resolve_swarm_manifest_path(run_id_or_path: str | None, *, latest: bool) -> Path:
+    if latest:
+        return _latest_swarm_manifest_path(_swarm_repo_root())
+    if run_id_or_path is None:
+        raise click.UsageError("pass --latest or a run id/path.")
+    candidate = Path(run_id_or_path).expanduser()
+    if candidate.exists():
+        return candidate
+    repo_root = _swarm_repo_root()
+    run_id_path = _swarm_runs_dir(repo_root) / f"{run_id_or_path.removesuffix('.json')}.json"
+    if run_id_path.exists():
+        return run_id_path
+    raise click.ClickException(f"swarm manifest not found: {run_id_or_path}")
+
+
+def _format_swarm_manifest_status(payload: dict[str, object], *, path: Path) -> list[str]:
+    run_id = payload.get("run_id", path.stem)
+    ok = payload.get("ok")
+    if payload.get("ended_at") is None:
+        status = "running"
+    else:
+        status = "ok" if ok is True else "failed" if ok is False else "unknown"
+    lines = [
+        f"swarm run {run_id} ({status})",
+        f"manifest: {path}",
+        (
+            "repo: {repo} base: {branch}@{ref}".format(
+                repo=payload.get("repo_root", ""),
+                branch=payload.get("base_branch", ""),
+                ref=payload.get("base_ref", ""),
+            )
+        ),
+        (
+            "started: {started} ended: {ended} duration_ms={duration}".format(
+                started=payload.get("started_at", ""),
+                ended=payload.get("ended_at") or "running",
+                duration=payload.get("duration_ms"),
+            )
+        ),
+        (
+            "ok={ok} shipped={shipped} failed={failed} no-changes={no_changes}".format(
+                ok=payload.get("ok"),
+                shipped=payload.get("shipped_count", 0),
+                failed=payload.get("failed_count", 0),
+                no_changes=payload.get("no_changes_count", 0),
+            )
+        ),
+    ]
+    tasks = payload.get("tasks", [])
+    if isinstance(tasks, list):
+        for raw_task in tasks:
+            if not isinstance(raw_task, dict):
+                continue
+            line = (
+                "- {status}: {brief} -> {branch}".format(
+                    status=raw_task.get("status", "unknown"),
+                    brief=raw_task.get("brief", ""),
+                    branch=raw_task.get("branch", ""),
+                )
+            )
+            if raw_task.get("pr_url"):
+                line += f" ({raw_task['pr_url']})"
+            if raw_task.get("failure_reason"):
+                line += f" reason={raw_task['failure_reason']}"
+            lines.append(line)
+    return lines
 
 
 def _run_swarm_task(
@@ -7246,18 +7431,17 @@ def exec_cmd(
 # --------------------------------------------------------------------------- #
 
 
-@main.command(name="swarm")
+@main.group(name="swarm", invoke_without_command=True)
+@click.pass_context
 @click.option(
     "--brief",
     "briefs",
     multiple=True,
-    required=True,
     help="Path to one task brief. Repeat for multiple independent tasks.",
 )
 @click.option(
     "--provider",
     "provider_id",
-    required=True,
     help="Provider to run for every task. v0 supports codex only.",
 )
 @click.option(
@@ -7313,8 +7497,9 @@ def exec_cmd(
     help="Maximum number of swarm tasks to run concurrently.",
 )
 def swarm(
+    ctx: click.Context,
     briefs: tuple[str, ...],
-    provider_id: str,
+    provider_id: str | None,
     base_branch: str,
     auto_merge: bool,
     max_iterations: int | None,
@@ -7325,6 +7510,12 @@ def swarm(
     max_parallel: int,
 ) -> None:
     """Run independent coding briefs under Conductor's supervisor."""
+    if ctx.invoked_subcommand is not None:
+        return
+    if not briefs:
+        raise click.UsageError("pass at least one --brief.")
+    if provider_id is None:
+        raise click.UsageError("pass --provider <id>.")
     if provider_id != "codex":
         raise click.UsageError("conductor swarm currently supports --provider codex only.")
 
@@ -7338,6 +7529,25 @@ def swarm(
         ).stdout.strip()
     except RuntimeError as e:
         raise click.UsageError(str(e)) from e
+    run_started_monotonic = time.monotonic()
+    started_datetime = datetime.now(UTC)
+    started_at = started_datetime.isoformat().replace("+00:00", "Z")
+    run_id = _new_swarm_run_id(started_datetime)
+    manifest_path = _swarm_runs_dir(repo_root) / f"{run_id}.json"
+    manifest_tasks = _swarm_initial_task_records(briefs, repo_root=repo_root)
+    _write_swarm_manifest(
+        manifest_path,
+        _swarm_manifest_payload(
+            run_id=run_id,
+            repo_root=repo_root,
+            base_branch=base_branch,
+            base_ref=base_ref,
+            started_at=started_at,
+            ended_at=None,
+            duration_ms=None,
+            tasks=manifest_tasks,
+        ),
+    )
 
     def run_one(brief_path: str) -> SwarmTaskResult:
         return _run_swarm_task(
@@ -7355,7 +7565,10 @@ def swarm(
 
     if max_parallel == 1 or len(briefs) == 1:
         for brief_path in briefs:
-            results.append(run_one(brief_path))
+            try:
+                results.append(run_one(brief_path))
+            except Exception as e:
+                results.append(_failed_swarm_thread_result(brief_path, e))
     else:
         result_slots: list[SwarmTaskResult | None] = [None] * len(briefs)
         with ThreadPoolExecutor(max_workers=max_parallel) as executor:
@@ -7372,6 +7585,23 @@ def swarm(
                     result_slots[index] = _failed_swarm_thread_result(brief_path, e)
         results = [result for result in result_slots if result is not None]
 
+    ended_at = _swarm_now_iso()
+    duration_ms = int((time.monotonic() - run_started_monotonic) * 1000)
+    manifest_tasks = _swarm_manifest_task_records(results)
+    _write_swarm_manifest(
+        manifest_path,
+        _swarm_manifest_payload(
+            run_id=run_id,
+            repo_root=repo_root,
+            base_branch=base_branch,
+            base_ref=base_ref,
+            started_at=started_at,
+            ended_at=ended_at,
+            duration_ms=duration_ms,
+            tasks=manifest_tasks,
+        ),
+    )
+
     payload = _swarm_summary(results)
     if as_json:
         click.echo(json.dumps(payload, indent=2))
@@ -7387,6 +7617,22 @@ def swarm(
         )
     if not payload["ok"]:
         sys.exit(1)
+
+
+@swarm.command(name="status")
+@click.argument("run_id_or_path", required=False)
+@click.option(
+    "--latest",
+    is_flag=True,
+    default=False,
+    help="Inspect the newest manifest in .cache/conductor/swarm/runs.",
+)
+def swarm_status(run_id_or_path: str | None, latest: bool) -> None:
+    """Print a concise status view for a swarm run manifest."""
+    path = _resolve_swarm_manifest_path(run_id_or_path, latest=latest)
+    payload = _read_swarm_manifest(path)
+    for line in _format_swarm_manifest_status(payload, path=path):
+        click.echo(line)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_cli_swarm.py
+++ b/tests/test_cli_swarm.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import threading
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -50,6 +52,19 @@ def _brief(repo: Path, name: str, body: str = "make a focused change") -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(body, encoding="utf-8")
     return path
+
+
+def _swarm_manifests(repo: Path) -> list[Path]:
+    return sorted((repo / ".cache" / "conductor" / "swarm" / "runs").glob("*.json"))
+
+
+def test_new_swarm_run_id_preserves_subsecond_ordering() -> None:
+    first = cli._new_swarm_run_id(datetime(2026, 1, 1, 0, 0, 0, 1, tzinfo=UTC))
+    second = cli._new_swarm_run_id(datetime(2026, 1, 1, 0, 0, 0, 2, tzinfo=UTC))
+
+    assert first.startswith("20260101T000000000001Z-")
+    assert second.startswith("20260101T000000000002Z-")
+    assert first < second
 
 
 def _commit_change(worktree: Path, filename: str, message: str) -> None:
@@ -275,6 +290,239 @@ def test_swarm_one_brief_succeeds_as_shipped(monkeypatch, tmp_path: Path) -> Non
         _git_returncode(repo, "show-ref", "--verify", "--quiet", "refs/heads/feat/swarm/foo")
         == 1
     )
+
+
+def test_swarm_writes_manifest_for_successful_run(monkeypatch, tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    brief = _brief(repo, "foo.md")
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(cli, "_run_exec_phase_dispatch", _fake_exec_factory())
+    monkeypatch.setattr(cli, "_ship_swarm_pr", _fake_merged_ship(repo))
+
+    result = CliRunner().invoke(
+        main,
+        ["swarm", "--provider", "codex", "--brief", str(brief), "--auto-merge", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    manifests = _swarm_manifests(repo)
+    assert len(manifests) == 1
+    manifest = json.loads(manifests[0].read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == 1
+    assert manifest["run_id"] == manifests[0].stem
+    assert manifest["repo_root"] == str(repo)
+    assert manifest["base_branch"] == "main"
+    assert manifest["base_ref"]
+    assert manifest["started_at"]
+    assert manifest["ended_at"]
+    assert isinstance(manifest["duration_ms"], int)
+    assert manifest["ok"] is True
+    assert manifest["shipped_count"] == 1
+    assert manifest["failed_count"] == 0
+    assert manifest["no_changes_count"] == 0
+    assert manifest["tasks"][0]["brief"] == str(brief)
+    assert manifest["tasks"][0]["branch"] == "feat/swarm/foo"
+    assert manifest["tasks"][0]["status"] == "shipped"
+    assert manifest["tasks"][0]["commits"] == 1
+    assert manifest["tasks"][0]["pr_url"] == "https://github.com/example/repo/pull/123"
+    assert manifest["tasks"][0]["merge_sha"]
+    assert manifest["tasks"][0]["cleanup_status"] == "removed"
+
+
+def test_swarm_writes_manifest_for_failed_run(monkeypatch, tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    brief = _brief(repo, "foo.md", "fail change")
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(
+        cli,
+        "_run_exec_phase_dispatch",
+        _fake_exec_factory(fail_on={"fail change"}),
+    )
+    monkeypatch.setattr(cli, "_ship_swarm_pr", _fake_ship)
+
+    result = CliRunner().invoke(
+        main,
+        ["swarm", "--provider", "codex", "--brief", str(brief), "--auto-merge", "--json"],
+    )
+
+    assert result.exit_code == 1
+    manifests = _swarm_manifests(repo)
+    assert len(manifests) == 1
+    manifest = json.loads(manifests[0].read_text(encoding="utf-8"))
+    assert manifest["ok"] is False
+    assert manifest["failed_count"] == 1
+    assert manifest["tasks"][0]["status"] == "failed"
+    assert manifest["tasks"][0]["failure_reason"] == "max-iterations cap reached"
+    assert manifest["tasks"][0]["cleanup_status"] == "preserved"
+    assert Path(manifest["tasks"][0]["worktree"]).exists()
+
+
+def test_swarm_sequential_internal_error_updates_manifest(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    brief = _brief(repo, "foo.md")
+    monkeypatch.chdir(repo)
+
+    def fake_run_swarm_task(**kwargs):
+        _ = kwargs
+        raise ValueError("boom")
+
+    monkeypatch.setattr(cli, "_run_swarm_task", fake_run_swarm_task)
+
+    result = CliRunner().invoke(
+        main,
+        ["swarm", "--provider", "codex", "--brief", str(brief), "--auto-merge", "--json"],
+    )
+
+    assert result.exit_code == 1
+    manifests = _swarm_manifests(repo)
+    assert len(manifests) == 1
+    manifest = json.loads(manifests[0].read_text(encoding="utf-8"))
+    assert manifest["ended_at"]
+    assert manifest["ok"] is False
+    assert manifest["failed_count"] == 1
+    assert manifest["tasks"][0]["status"] == "failed"
+    assert manifest["tasks"][0]["failure_reason"] == "internal swarm task error: boom"
+
+
+def test_swarm_does_not_write_manifest_for_preflight_failure(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    missing_brief = repo / "tasks" / "missing.md"
+    monkeypatch.chdir(repo)
+
+    result = CliRunner().invoke(
+        main,
+        ["swarm", "--provider", "codex", "--brief", str(missing_brief), "--json"],
+    )
+
+    assert result.exit_code == 2
+    assert _swarm_manifests(repo) == []
+
+
+def test_swarm_rejects_reserved_manifest_worktree_slug(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    brief = _brief(repo, "runs.md")
+    monkeypatch.chdir(repo)
+
+    result = CliRunner().invoke(
+        main,
+        ["swarm", "--provider", "codex", "--brief", str(brief), "--json"],
+    )
+
+    assert result.exit_code == 2
+    assert "reserved swarm worktree slug 'runs'" in result.output
+    assert _swarm_manifests(repo) == []
+
+
+def test_swarm_status_latest_and_explicit_lookup(monkeypatch, tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    brief = _brief(repo, "foo.md")
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(cli, "_run_exec_phase_dispatch", _fake_exec_factory())
+    monkeypatch.setattr(cli, "_ship_swarm_pr", _fake_merged_ship(repo))
+    runner = CliRunner()
+
+    run_result = runner.invoke(
+        main,
+        ["swarm", "--provider", "codex", "--brief", str(brief), "--auto-merge", "--json"],
+    )
+
+    assert run_result.exit_code == 0, run_result.output
+    manifest_path = _swarm_manifests(repo)[0]
+    run_id = manifest_path.stem
+
+    latest_result = runner.invoke(main, ["swarm", "status", "--latest"])
+    assert latest_result.exit_code == 0, latest_result.output
+    assert f"swarm run {run_id} (ok)" in latest_result.output
+    assert "shipped=1 failed=0 no-changes=0" in latest_result.output
+    assert "shipped:" in latest_result.output
+
+    id_result = runner.invoke(main, ["swarm", "status", run_id])
+    assert id_result.exit_code == 0, id_result.output
+    assert f"manifest: {manifest_path}" in id_result.output
+
+    path_result = runner.invoke(main, ["swarm", "status", str(manifest_path)])
+    assert path_result.exit_code == 0, path_result.output
+    assert f"swarm run {run_id} (ok)" in path_result.output
+
+
+def test_swarm_status_latest_uses_run_id_not_mtime(monkeypatch, tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    monkeypatch.chdir(repo)
+    runs_dir = repo / ".cache" / "conductor" / "swarm" / "runs"
+    runs_dir.mkdir(parents=True)
+    older = runs_dir / "20260101T000000000001Z-older.json"
+    newer = runs_dir / "20260101T000000000002Z-newer.json"
+    base_payload = {
+        "schema_version": 1,
+        "repo_root": str(repo),
+        "base_branch": "main",
+        "base_ref": "abc123",
+        "started_at": "2026-01-01T00:00:00Z",
+        "ended_at": "2026-01-01T00:00:01Z",
+        "duration_ms": 1,
+        "tasks": [],
+        "ok": True,
+        "shipped_count": 0,
+        "failed_count": 0,
+        "no_changes_count": 0,
+    }
+    older.write_text(
+        json.dumps({**base_payload, "run_id": older.stem}),
+        encoding="utf-8",
+    )
+    newer.write_text(
+        json.dumps({**base_payload, "run_id": newer.stem}),
+        encoding="utf-8",
+    )
+    os.utime(older, (200, 200))
+    os.utime(newer, (100, 100))
+
+    result = CliRunner().invoke(main, ["swarm", "status", "--latest"])
+
+    assert result.exit_code == 0, result.output
+    assert f"swarm run {newer.stem} (ok)" in result.output
+
+
+def test_repo_ignores_generated_conductor_cache() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    gitignore = (repo_root / ".gitignore").read_text(encoding="utf-8")
+
+    assert ".cache/conductor/" in gitignore
+
+
+def test_swarm_json_stdout_contract_keeps_top_level_fields(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    brief = _brief(repo, "foo.md")
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(cli, "_run_exec_phase_dispatch", _fake_exec_factory())
+    monkeypatch.setattr(cli, "_ship_swarm_pr", _fake_merged_ship(repo))
+
+    result = CliRunner().invoke(
+        main,
+        ["swarm", "--provider", "codex", "--brief", str(brief), "--auto-merge", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert set(payload) == {
+        "tasks",
+        "ok",
+        "shipped_count",
+        "failed_count",
+        "no_changes_count",
+    }
 
 
 def test_swarm_ship_appends_closing_ref_to_last_commit_body(


### PR DESCRIPTION
Write versioned swarm run manifests under .cache/conductor/swarm/runs and add a status view for latest or explicit manifests. Preserve the existing swarm --json stdout contract while recording final task state, aggregates, and cleanup state durably.

Closes #362

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
