### PR TITLE
feat: retry swarm shipping from manifests

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -5946,6 +5946,20 @@ def _ensure_swarm_branch_checked_out(worktree: Path, branch: str) -> None:
     _run_swarm_git(["checkout", branch], cwd=worktree)
 
 
+def _require_swarm_branch_checked_out(worktree: Path, branch: str, *, selector: str) -> None:
+    current = _run_swarm_git(
+        ["branch", "--show-current"],
+        cwd=worktree,
+    ).stdout.strip()
+    if current == branch:
+        return
+    actual = current or "detached HEAD"
+    raise click.ClickException(
+        f"swarm task {selector} worktree is on {actual!r}, expected {branch!r}; "
+        "retry-ship refuses to retarget the saved branch"
+    )
+
+
 def _ship_swarm_pr(
     worktree: Path,
     *,
@@ -6170,6 +6184,165 @@ def _resolve_swarm_manifest_path(run_id_or_path: str | None, *, latest: bool) ->
     if run_id_path.exists():
         return run_id_path
     raise click.ClickException(f"swarm manifest not found: {run_id_or_path}")
+
+
+def _swarm_manifest_tasks(payload: dict[str, object], *, path: Path) -> list[dict[str, object]]:
+    raw_tasks = payload.get("tasks")
+    if not isinstance(raw_tasks, list):
+        raise click.ClickException(f"invalid swarm manifest at {path}: tasks is not a list")
+    tasks = [task for task in raw_tasks if isinstance(task, dict)]
+    if len(tasks) != len(raw_tasks):
+        raise click.ClickException(
+            f"invalid swarm manifest at {path}: every task must be an object"
+        )
+    return tasks
+
+
+def _select_swarm_manifest_task(
+    tasks: list[dict[str, object]],
+    selector: str,
+) -> tuple[int, dict[str, object]]:
+    if selector.isdecimal():
+        index = int(selector) - 1
+        if 0 <= index < len(tasks):
+            return index, tasks[index]
+        raise click.ClickException(
+            f"swarm task selector {selector!r} is out of range; "
+            f"expected a 1-based index from 1 to {len(tasks)}"
+        )
+
+    matches = [
+        (index, task)
+        for index, task in enumerate(tasks)
+        if task.get("branch") == selector or task.get("brief") == selector
+    ]
+    if not matches:
+        raise click.ClickException(
+            f"swarm task selector {selector!r} matched no task; use a 1-based index, "
+            "exact branch, or exact brief path from the manifest"
+        )
+    if len(matches) > 1:
+        raise click.ClickException(f"swarm task selector {selector!r} matched multiple tasks")
+    return matches[0]
+
+
+def _swarm_task_string(task: dict[str, object], key: str, *, selector: str) -> str:
+    value = task.get(key)
+    if not isinstance(value, str) or not value:
+        raise click.ClickException(f"swarm task {selector!r} has no {key}")
+    return value
+
+
+def _retry_ship_swarm_task(
+    *,
+    manifest_path: Path,
+    payload: dict[str, object],
+    task_index: int,
+    auto_merge: bool,
+) -> dict[str, object]:
+    tasks = _swarm_manifest_tasks(payload, path=manifest_path)
+    task = tasks[task_index]
+    selector = str(task_index + 1)
+    repo_root_value = payload.get("repo_root")
+    repo_root = Path(repo_root_value) if isinstance(repo_root_value, str) else _swarm_repo_root()
+    base_branch = payload.get("base_branch")
+    if not isinstance(base_branch, str) or not base_branch:
+        raise click.ClickException(f"swarm manifest {manifest_path} has no base_branch")
+    base_ref = payload.get("base_ref")
+    if not isinstance(base_ref, str) or not base_ref:
+        raise click.ClickException(f"swarm manifest {manifest_path} has no base_ref")
+
+    branch = _swarm_task_string(task, "branch", selector=selector)
+    worktree = Path(_swarm_task_string(task, "worktree", selector=selector))
+    if not worktree.exists():
+        raise click.ClickException(f"swarm task {selector} worktree does not exist: {worktree}")
+
+    started_at = time.monotonic()
+    status = "failed"
+    pr_url: str | None = None
+    merge_sha: str | None = None
+    failure_reason: str | None = None
+    commits = 0
+    cleanup_warning: str | None = None
+    try:
+        _require_swarm_branch_checked_out(worktree, branch, selector=selector)
+        dirty_paths = _swarm_dirty_paths(worktree)
+        if dirty_paths:
+            raise click.ClickException(
+                "swarm task {selector} worktree has uncommitted changes: {paths}".format(
+                    selector=selector,
+                    paths=", ".join(path[:200] for path in dirty_paths[:10]),
+                )
+            )
+        commits = _swarm_commit_count(worktree, base_ref)
+        if commits == 0:
+            raise click.ClickException(
+                f"swarm task {selector} has no commits ahead of manifest base_ref {base_ref}"
+            )
+        shipped_status, shipped_pr_url, shipped_detail = _ship_swarm_pr(
+            worktree,
+            base_branch=base_branch,
+            branch=branch,
+            auto_merge=auto_merge,
+        )
+        status = shipped_status
+        pr_url = shipped_pr_url
+        if status == "shipped":
+            merge_sha = shipped_detail
+        elif status in {"failed", "review-blocked"}:
+            failure_reason = shipped_detail
+    except click.ClickException:
+        raise
+    except RuntimeError as e:
+        status = "failed"
+        failure_reason = str(e)
+    duration_ms = int((time.monotonic() - started_at) * 1000)
+
+    if status in SWARM_SUCCESS_STATUSES:
+        try:
+            _remove_swarm_worktree(worktree, repo_root=repo_root)
+            if status == "shipped":
+                cleanup_warning = _delete_shipped_swarm_branch(
+                    branch,
+                    repo_root=repo_root,
+                    merge_sha=merge_sha,
+                )
+                if cleanup_warning is not None:
+                    click.echo(f"[conductor] warning: {cleanup_warning}", err=True)
+                    failure_reason = cleanup_warning
+        except RuntimeError as e:
+            status = "failed"
+            failure_reason = f"{failure_reason or status}; cleanup failed: {e}"
+
+    updated_task = dict(task)
+    updated_task.update(
+        {
+            "status": status,
+            "commits": commits,
+            "pr_url": pr_url,
+            "merge_sha": merge_sha,
+            "duration_ms": duration_ms,
+            "failure_reason": failure_reason,
+            "cleanup_status": "removed" if not worktree.exists() else "preserved",
+        }
+    )
+    tasks[task_index] = updated_task
+
+    raw_duration = payload.get("duration_ms")
+    run_duration_ms = duration_ms
+    if isinstance(raw_duration, int) and not isinstance(raw_duration, bool):
+        run_duration_ms = max(0, raw_duration) + duration_ms
+
+    return _swarm_manifest_payload(
+        run_id=str(payload.get("run_id") or manifest_path.stem),
+        repo_root=repo_root,
+        base_branch=base_branch,
+        base_ref=base_ref,
+        started_at=str(payload.get("started_at") or _swarm_now_iso()),
+        ended_at=_swarm_now_iso(),
+        duration_ms=run_duration_ms,
+        tasks=tasks,
+    )
 
 
 def _format_swarm_manifest_status(payload: dict[str, object], *, path: Path) -> list[str]:
@@ -7715,6 +7888,47 @@ def swarm_status(run_id_or_path: str | None, latest: bool) -> None:
     payload = _read_swarm_manifest(path)
     for line in _format_swarm_manifest_status(payload, path=path):
         click.echo(line)
+
+
+@swarm.command(name="retry-ship")
+@click.argument("run_id_or_path")
+@click.argument("task_selector")
+@click.option(
+    "--auto-merge/--no-auto-merge",
+    default=True,
+    show_default=True,
+    help="Retry shipping with open-pr.sh auto-merge enabled.",
+)
+def swarm_retry_ship(run_id_or_path: str, task_selector: str, auto_merge: bool) -> None:
+    """Retry shipping one manifest task without rerunning implementation.
+
+    TASK_SELECTOR is a 1-based task index, exact branch name, or exact brief path
+    from the manifest.
+    """
+    path = _resolve_swarm_manifest_path(run_id_or_path, latest=False)
+    payload = _read_swarm_manifest(path)
+    tasks = _swarm_manifest_tasks(payload, path=path)
+    task_index, task = _select_swarm_manifest_task(tasks, task_selector)
+    branch = task.get("branch")
+    brief = task.get("brief")
+    updated = _retry_ship_swarm_task(
+        manifest_path=path,
+        payload=payload,
+        task_index=task_index,
+        auto_merge=auto_merge,
+    )
+    _write_swarm_manifest(path, updated)
+    updated_task = _swarm_manifest_tasks(updated, path=path)[task_index]
+    detail = "{status}: {brief} -> {branch}".format(
+        status=updated_task.get("status", "unknown"),
+        brief=brief or updated_task.get("brief", ""),
+        branch=branch or updated_task.get("branch", ""),
+    )
+    if updated_task.get("pr_url"):
+        detail += f" ({updated_task['pr_url']})"
+    click.echo(detail)
+    if updated_task.get("status") not in SWARM_SUCCESS_STATUSES:
+        sys.exit(1)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_cli_swarm.py
+++ b/tests/test_cli_swarm.py
@@ -58,6 +58,28 @@ def _swarm_manifests(repo: Path) -> list[Path]:
     return sorted((repo / ".cache" / "conductor" / "swarm" / "runs").glob("*.json"))
 
 
+def _manual_swarm_manifest(
+    repo: Path,
+    *,
+    tasks: list[dict[str, object]],
+    base_ref: str | None = None,
+    run_id: str = "20260101T000000000001Z-retry",
+) -> Path:
+    manifest_path = repo / ".cache" / "conductor" / "swarm" / "runs" / f"{run_id}.json"
+    payload = cli._swarm_manifest_payload(
+        run_id=run_id,
+        repo_root=repo,
+        base_branch="main",
+        base_ref=base_ref or _git(repo, "rev-parse", "main").stdout.strip(),
+        started_at="2026-01-01T00:00:00Z",
+        ended_at="2026-01-01T00:00:01Z",
+        duration_ms=100,
+        tasks=tasks,
+    )
+    cli._write_swarm_manifest(manifest_path, payload)
+    return manifest_path
+
+
 def test_new_swarm_run_id_preserves_subsecond_ordering() -> None:
     first = cli._new_swarm_run_id(datetime(2026, 1, 1, 0, 0, 0, 1, tzinfo=UTC))
     second = cli._new_swarm_run_id(datetime(2026, 1, 1, 0, 0, 0, 2, tzinfo=UTC))
@@ -514,6 +536,279 @@ def test_swarm_status_latest_and_explicit_lookup(monkeypatch, tmp_path: Path) ->
     path_result = runner.invoke(main, ["swarm", "status", str(manifest_path)])
     assert path_result.exit_code == 0, path_result.output
     assert f"swarm run {run_id} (ok)" in path_result.output
+
+
+def test_swarm_retry_ship_updates_review_blocked_manifest(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    brief = _brief(repo, "foo.md")
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(cli, "_run_exec_phase_dispatch", _fake_exec_factory())
+
+    def review_blocked_ship(
+        worktree: Path,
+        *,
+        base_branch: str,
+        branch: str,
+        auto_merge: bool,
+    ):
+        _ = (worktree, base_branch, branch, auto_merge)
+        return "review-blocked", "https://github.com/example/repo/pull/123", "review flaked"
+
+    monkeypatch.setattr(cli, "_ship_swarm_pr", review_blocked_ship)
+    run_result = CliRunner().invoke(
+        main,
+        ["swarm", "--provider", "codex", "--brief", str(brief), "--auto-merge", "--json"],
+    )
+    assert run_result.exit_code == 1, run_result.output
+    manifest_path = _swarm_manifests(repo)[0]
+    before = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert before["tasks"][0]["status"] == "review-blocked"
+    assert before["metrics"]["review_blocked_count"] == 1
+
+    def fail_if_exec_reruns(**kwargs):
+        _ = kwargs
+        raise AssertionError("retry-ship must not rerun implementation")
+
+    monkeypatch.setattr(cli, "_run_exec_phase_dispatch", fail_if_exec_reruns)
+    monkeypatch.setattr(cli, "_ship_swarm_pr", _fake_merged_ship(repo))
+
+    retry_result = CliRunner().invoke(main, ["swarm", "retry-ship", manifest_path.stem, "1"])
+
+    assert retry_result.exit_code == 0, retry_result.output
+    assert "shipped:" in retry_result.output
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    task = manifest["tasks"][0]
+    assert manifest["ok"] is True
+    assert manifest["shipped_count"] == 1
+    assert manifest["failed_count"] == 0
+    assert manifest["metrics"]["shipped_count"] == 1
+    assert manifest["metrics"]["review_blocked_count"] == 0
+    assert manifest["metrics"]["per_status_counts"] == {"shipped": 1}
+    assert manifest["metrics"]["total_commits"] == 1
+    assert task["status"] == "shipped"
+    assert task["pr_url"] == "https://github.com/example/repo/pull/123"
+    assert task["merge_sha"]
+    assert task["failure_reason"] is None
+    assert task["cleanup_status"] == "removed"
+    assert not Path(task["worktree"]).exists()
+
+
+def test_swarm_retry_ship_refuses_missing_worktree(tmp_path: Path, monkeypatch) -> None:
+    repo = _repo(tmp_path)
+    brief = _brief(repo, "foo.md")
+    monkeypatch.chdir(repo)
+    manifest_path = _manual_swarm_manifest(
+        repo,
+        tasks=[
+            {
+                "brief": str(brief),
+                "branch": "feat/swarm/foo",
+                "worktree": str(repo / ".cache" / "conductor" / "swarm" / "foo"),
+                "status": "review-blocked",
+                "commits": 1,
+                "pr_url": "https://github.com/example/repo/pull/123",
+                "merge_sha": None,
+                "duration_ms": 10,
+                "failure_reason": "review flaked",
+                "cleanup_status": "preserved",
+            }
+        ],
+    )
+
+    result = CliRunner().invoke(main, ["swarm", "retry-ship", str(manifest_path), "1"])
+
+    assert result.exit_code == 1
+    assert "worktree does not exist" in result.output
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["tasks"][0]["status"] == "review-blocked"
+
+
+def test_swarm_retry_ship_refuses_no_commits_ahead(tmp_path: Path, monkeypatch) -> None:
+    repo = _repo(tmp_path)
+    brief = _brief(repo, "foo.md")
+    base_ref = _git(repo, "rev-parse", "main").stdout.strip()
+    worktree = repo / ".cache" / "conductor" / "swarm" / "foo"
+    _git(repo, "worktree", "add", str(worktree), "-b", "feat/swarm/foo", base_ref)
+    monkeypatch.chdir(repo)
+    manifest_path = _manual_swarm_manifest(
+        repo,
+        base_ref=base_ref,
+        tasks=[
+            {
+                "brief": str(brief),
+                "branch": "feat/swarm/foo",
+                "worktree": str(worktree),
+                "status": "review-blocked",
+                "commits": 0,
+                "pr_url": None,
+                "merge_sha": None,
+                "duration_ms": 10,
+                "failure_reason": "ship failed",
+                "cleanup_status": "preserved",
+            }
+        ],
+    )
+
+    result = CliRunner().invoke(main, ["swarm", "retry-ship", str(manifest_path), "1"])
+
+    assert result.exit_code == 1
+    assert "has no commits ahead of manifest base_ref" in result.output
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["tasks"][0]["status"] == "review-blocked"
+    assert worktree.exists()
+
+
+def test_swarm_retry_ship_refuses_detached_worktree_without_moving_branch(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo = _repo(tmp_path)
+    brief = _brief(repo, "foo.md")
+    base_ref = _git(repo, "rev-parse", "main").stdout.strip()
+    worktree = repo / ".cache" / "conductor" / "swarm" / "foo"
+    _git(repo, "worktree", "add", str(worktree), "-b", "feat/swarm/foo", base_ref)
+    _commit_change(worktree, "feature.txt", "feature")
+    branch_head = _git(worktree, "rev-parse", "HEAD").stdout.strip()
+    _git(worktree, "checkout", "--detach", "HEAD")
+    _commit_change(worktree, "detached.txt", "detached")
+    detached_head = _git(worktree, "rev-parse", "HEAD").stdout.strip()
+    assert detached_head != branch_head
+    monkeypatch.chdir(repo)
+    manifest_path = _manual_swarm_manifest(
+        repo,
+        base_ref=base_ref,
+        tasks=[
+            {
+                "brief": str(brief),
+                "branch": "feat/swarm/foo",
+                "worktree": str(worktree),
+                "status": "review-blocked",
+                "commits": 1,
+                "pr_url": None,
+                "merge_sha": None,
+                "duration_ms": 10,
+                "failure_reason": "ship failed",
+                "cleanup_status": "preserved",
+            }
+        ],
+    )
+
+    result = CliRunner().invoke(main, ["swarm", "retry-ship", str(manifest_path), "1"])
+
+    assert result.exit_code == 1
+    assert "detached HEAD" in result.output
+    assert "refuses to retarget the saved branch" in result.output
+    assert _git(repo, "rev-parse", "feat/swarm/foo").stdout.strip() == branch_head
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["tasks"][0]["status"] == "review-blocked"
+
+
+def test_swarm_retry_ship_refuses_dirty_worktree(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo = _repo(tmp_path)
+    brief = _brief(repo, "foo.md")
+    base_ref = _git(repo, "rev-parse", "main").stdout.strip()
+    worktree = repo / ".cache" / "conductor" / "swarm" / "foo"
+    _git(repo, "worktree", "add", str(worktree), "-b", "feat/swarm/foo", base_ref)
+    _commit_change(worktree, "feature.txt", "feature")
+    (worktree / "dirty.txt").write_text("dirty\n", encoding="utf-8")
+    monkeypatch.chdir(repo)
+    manifest_path = _manual_swarm_manifest(
+        repo,
+        base_ref=base_ref,
+        tasks=[
+            {
+                "brief": str(brief),
+                "branch": "feat/swarm/foo",
+                "worktree": str(worktree),
+                "status": "review-blocked",
+                "commits": 1,
+                "pr_url": None,
+                "merge_sha": None,
+                "duration_ms": 10,
+                "failure_reason": "ship failed",
+                "cleanup_status": "preserved",
+            }
+        ],
+    )
+
+    result = CliRunner().invoke(main, ["swarm", "retry-ship", str(manifest_path), "1"])
+
+    assert result.exit_code == 1
+    assert "worktree has uncommitted changes" in result.output
+    assert "dirty.txt" in result.output
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["tasks"][0]["status"] == "review-blocked"
+
+
+@pytest.mark.parametrize("selector_kind", ["index", "branch", "brief"])
+def test_swarm_retry_ship_selects_by_index_branch_or_brief(
+    monkeypatch,
+    tmp_path: Path,
+    selector_kind: str,
+) -> None:
+    repo = _repo(tmp_path)
+    first = _brief(repo, "foo.md")
+    second = _brief(repo, "bar.md")
+    base_ref = _git(repo, "rev-parse", "main").stdout.strip()
+    foo_worktree = repo / ".cache" / "conductor" / "swarm" / "foo"
+    bar_worktree = repo / ".cache" / "conductor" / "swarm" / "bar"
+    _git(repo, "worktree", "add", str(foo_worktree), "-b", "feat/swarm/foo", base_ref)
+    _commit_change(foo_worktree, "foo.txt", "foo")
+    _git(repo, "worktree", "add", str(bar_worktree), "-b", "feat/swarm/bar", base_ref)
+    _commit_change(bar_worktree, "bar.txt", "bar")
+    monkeypatch.chdir(repo)
+    manifest_path = _manual_swarm_manifest(
+        repo,
+        base_ref=base_ref,
+        tasks=[
+            {
+                "brief": str(first),
+                "branch": "feat/swarm/foo",
+                "worktree": str(foo_worktree),
+                "status": "failed",
+                "commits": 1,
+                "pr_url": None,
+                "merge_sha": None,
+                "duration_ms": 10,
+                "failure_reason": "push failed",
+                "cleanup_status": "preserved",
+            },
+            {
+                "brief": str(second),
+                "branch": "feat/swarm/bar",
+                "worktree": str(bar_worktree),
+                "status": "review-blocked",
+                "commits": 1,
+                "pr_url": "https://github.com/example/repo/pull/124",
+                "merge_sha": None,
+                "duration_ms": 10,
+                "failure_reason": "review flaked",
+                "cleanup_status": "preserved",
+            },
+        ],
+    )
+    monkeypatch.setattr(cli, "_ship_swarm_pr", _fake_merged_ship(repo))
+    selector = {
+        "index": "2",
+        "branch": "feat/swarm/bar",
+        "brief": str(second),
+    }[selector_kind]
+
+    result = CliRunner().invoke(main, ["swarm", "retry-ship", str(manifest_path), selector])
+
+    assert result.exit_code == 0, result.output
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["tasks"][0]["status"] == "failed"
+    assert manifest["tasks"][1]["status"] == "shipped"
+    assert manifest["metrics"]["failed_count"] == 1
+    assert manifest["metrics"]["shipped_count"] == 1
+    assert manifest["metrics"]["total_commits"] == 2
 
 
 def test_swarm_status_latest_uses_run_id_not_mtime(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
Add conductor swarm retry-ship so operators can salvage committed lanes from durable swarm manifests without rerunning implementation agents. The command validates the saved worktree and branch, requires commits ahead of the manifest base ref, reuses the existing ship path, and rewrites manifest task state, counts, cleanup status, and metrics.

Closes #363

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
