### PR TITLE
feat: add swarm resume command

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -25,6 +25,7 @@ import json
 import math
 import os
 import re
+import shlex
 import signal
 import subprocess
 import sys
@@ -6233,6 +6234,97 @@ def _swarm_task_string(task: dict[str, object], key: str, *, selector: str) -> s
     return value
 
 
+def _swarm_worktree_branch_state(worktree: Path) -> str:
+    current = _run_swarm_git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=worktree).stdout.strip()
+    if current != "HEAD":
+        return current
+    head_sha = _run_swarm_git(["rev-parse", "--short", "HEAD"], cwd=worktree).stdout.strip()
+    return f"detached at {head_sha}"
+
+
+def _swarm_readonly_worktree_state(worktree: Path | None) -> tuple[bool, str, str]:
+    if worktree is None or not worktree.exists():
+        return False, "unknown (worktree missing)", "unknown (worktree missing)"
+    try:
+        dirty_paths = _swarm_dirty_paths(worktree)
+        dirty = "yes" if dirty_paths else "no"
+        if dirty_paths:
+            dirty += f" ({', '.join(path[:200] for path in dirty_paths[:10])})"
+    except RuntimeError as e:
+        dirty = f"unknown ({e})"
+    try:
+        branch_state = _swarm_worktree_branch_state(worktree)
+    except RuntimeError as e:
+        branch_state = f"unknown ({e})"
+    return True, dirty, branch_state
+
+
+def _format_swarm_resume(
+    *,
+    payload: dict[str, object],
+    path: Path,
+    task_index: int,
+    task: dict[str, object],
+) -> list[str]:
+    selector = str(task_index + 1)
+    run_id = str(payload.get("run_id") or path.stem)
+    brief = str(task.get("brief") or "")
+    branch = str(task.get("branch") or "")
+    raw_worktree = task.get("worktree")
+    worktree = Path(raw_worktree) if isinstance(raw_worktree, str) and raw_worktree else None
+    exists, dirty, branch_state = _swarm_readonly_worktree_state(worktree)
+    worktree_display = str(worktree) if worktree is not None else ""
+    raw_commits = task.get("commits")
+    commits = (
+        raw_commits
+        if isinstance(raw_commits, int) and not isinstance(raw_commits, bool)
+        else 0
+    )
+    retry_available = exists and commits > 0
+    retry_command = (
+        f"conductor swarm retry-ship {shlex.quote(str(path))} {shlex.quote(selector)}"
+    )
+    rerun_parts = ["conductor", "swarm", "--provider", "codex"]
+    base_branch = payload.get("base_branch")
+    if isinstance(base_branch, str) and base_branch:
+        rerun_parts.extend(["--base-branch", base_branch])
+    if brief:
+        rerun_parts.extend(["--brief", brief])
+    rerun_command = " ".join(shlex.quote(part) for part in rerun_parts)
+
+    lines = [
+        f"swarm resume {run_id} task {task_index + 1}",
+        f"manifest: {path}",
+        f"run id: {run_id}",
+        f"task index: {task_index + 1}",
+        f"status: {task.get('status', 'unknown')}",
+        f"provider: {task.get('provider') or payload.get('provider') or 'codex'}",
+        f"brief: {brief}",
+        f"branch: {branch}",
+        f"worktree: {worktree_display}",
+        f"commits: {commits}",
+        f"pr url: {task.get('pr_url') or ''}",
+        f"failure reason: {task.get('failure_reason') or ''}",
+        f"base: {payload.get('base_branch', '')}@{payload.get('base_ref', '')}",
+        f"worktree exists: {'yes' if exists else 'no'}",
+        f"worktree dirty: {dirty}",
+        f"worktree branch: {branch_state}",
+        "suggested commands:",
+    ]
+    if worktree is not None:
+        lines.append(
+            f"  inspect worktree: cd {shlex.quote(str(worktree))} && git status --short --branch"
+        )
+    if retry_available:
+        lines.append(f"  retry shipping: {retry_command}")
+    else:
+        lines.append("  retry shipping: unavailable until the worktree exists and has commits")
+    if branch:
+        lines.append(f"  inspect branch: git log --oneline {shlex.quote(branch)} --")
+    lines.append(f"  rerun implementation: {rerun_command}")
+    return lines
+
+
 def _retry_ship_swarm_task(
     *,
     manifest_path: Path,
@@ -6343,6 +6435,38 @@ def _retry_ship_swarm_task(
         duration_ms=run_duration_ms,
         tasks=tasks,
     )
+
+
+def _run_swarm_retry_ship_command(
+    *,
+    run_id_or_path: str,
+    task_selector: str,
+    auto_merge: bool,
+) -> None:
+    path = _resolve_swarm_manifest_path(run_id_or_path, latest=False)
+    payload = _read_swarm_manifest(path)
+    tasks = _swarm_manifest_tasks(payload, path=path)
+    task_index, task = _select_swarm_manifest_task(tasks, task_selector)
+    branch = task.get("branch")
+    brief = task.get("brief")
+    updated = _retry_ship_swarm_task(
+        manifest_path=path,
+        payload=payload,
+        task_index=task_index,
+        auto_merge=auto_merge,
+    )
+    _write_swarm_manifest(path, updated)
+    updated_task = _swarm_manifest_tasks(updated, path=path)[task_index]
+    detail = "{status}: {brief} -> {branch}".format(
+        status=updated_task.get("status", "unknown"),
+        brief=brief or updated_task.get("brief", ""),
+        branch=branch or updated_task.get("branch", ""),
+    )
+    if updated_task.get("pr_url"):
+        detail += f" ({updated_task['pr_url']})"
+    click.echo(detail)
+    if updated_task.get("status") not in SWARM_SUCCESS_STATUSES:
+        sys.exit(1)
 
 
 def _format_swarm_manifest_status(payload: dict[str, object], *, path: Path) -> list[str]:
@@ -7890,6 +8014,52 @@ def swarm_status(run_id_or_path: str | None, latest: bool) -> None:
         click.echo(line)
 
 
+@swarm.command(name="resume")
+@click.argument("run_id_or_path")
+@click.argument("task_selector")
+@click.option(
+    "--retry-ship",
+    is_flag=True,
+    default=False,
+    help="Delegate to swarm retry-ship for the selected task.",
+)
+@click.option(
+    "--auto-merge/--no-auto-merge",
+    default=True,
+    show_default=True,
+    help="When --retry-ship is set, retry shipping with open-pr.sh auto-merge enabled.",
+)
+def swarm_resume(
+    run_id_or_path: str,
+    task_selector: str,
+    retry_ship: bool,
+    auto_merge: bool,
+) -> None:
+    """Orient recovery for one manifest task without rerunning implementation.
+
+    TASK_SELECTOR is a 1-based task index, exact branch name, or exact brief path
+    from the manifest.
+    """
+    if retry_ship:
+        _run_swarm_retry_ship_command(
+            run_id_or_path=run_id_or_path,
+            task_selector=task_selector,
+            auto_merge=auto_merge,
+        )
+        return
+    path = _resolve_swarm_manifest_path(run_id_or_path, latest=False)
+    payload = _read_swarm_manifest(path)
+    tasks = _swarm_manifest_tasks(payload, path=path)
+    task_index, task = _select_swarm_manifest_task(tasks, task_selector)
+    for line in _format_swarm_resume(
+        payload=payload,
+        path=path,
+        task_index=task_index,
+        task=task,
+    ):
+        click.echo(line)
+
+
 @swarm.command(name="retry-ship")
 @click.argument("run_id_or_path")
 @click.argument("task_selector")
@@ -7905,30 +8075,11 @@ def swarm_retry_ship(run_id_or_path: str, task_selector: str, auto_merge: bool) 
     TASK_SELECTOR is a 1-based task index, exact branch name, or exact brief path
     from the manifest.
     """
-    path = _resolve_swarm_manifest_path(run_id_or_path, latest=False)
-    payload = _read_swarm_manifest(path)
-    tasks = _swarm_manifest_tasks(payload, path=path)
-    task_index, task = _select_swarm_manifest_task(tasks, task_selector)
-    branch = task.get("branch")
-    brief = task.get("brief")
-    updated = _retry_ship_swarm_task(
-        manifest_path=path,
-        payload=payload,
-        task_index=task_index,
+    _run_swarm_retry_ship_command(
+        run_id_or_path=run_id_or_path,
+        task_selector=task_selector,
         auto_merge=auto_merge,
     )
-    _write_swarm_manifest(path, updated)
-    updated_task = _swarm_manifest_tasks(updated, path=path)[task_index]
-    detail = "{status}: {brief} -> {branch}".format(
-        status=updated_task.get("status", "unknown"),
-        brief=brief or updated_task.get("brief", ""),
-        branch=branch or updated_task.get("branch", ""),
-    )
-    if updated_task.get("pr_url"):
-        detail += f" ({updated_task['pr_url']})"
-    click.echo(detail)
-    if updated_task.get("status") not in SWARM_SUCCESS_STATUSES:
-        sys.exit(1)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_cli_swarm.py
+++ b/tests/test_cli_swarm.py
@@ -596,6 +596,244 @@ def test_swarm_retry_ship_updates_review_blocked_manifest(
     assert not Path(task["worktree"]).exists()
 
 
+def test_swarm_resume_reports_failed_lane_with_worktree_and_commits(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo = _repo(tmp_path)
+    brief = _brief(repo, "foo.md")
+    base_ref = _git(repo, "rev-parse", "main").stdout.strip()
+    worktree = repo / ".cache" / "conductor" / "swarm" / "foo"
+    _git(repo, "worktree", "add", str(worktree), "-b", "feat/swarm/foo", base_ref)
+    _commit_change(worktree, "feature.txt", "feature")
+    monkeypatch.chdir(repo)
+    manifest_path = _manual_swarm_manifest(
+        repo,
+        base_ref=base_ref,
+        tasks=[
+            {
+                "brief": str(brief),
+                "branch": "feat/swarm/foo",
+                "worktree": str(worktree),
+                "status": "review-blocked",
+                "commits": 1,
+                "pr_url": "https://github.com/example/repo/pull/123",
+                "merge_sha": None,
+                "duration_ms": 10,
+                "failure_reason": "review flaked",
+                "cleanup_status": "preserved",
+            }
+        ],
+    )
+
+    result = CliRunner().invoke(main, ["swarm", "resume", str(manifest_path), "1"])
+
+    assert result.exit_code == 0, result.output
+    assert f"manifest: {manifest_path}" in result.output
+    assert f"run id: {manifest_path.stem}" in result.output
+    assert "task index: 1" in result.output
+    assert "status: review-blocked" in result.output
+    assert f"brief: {brief}" in result.output
+    assert "branch: feat/swarm/foo" in result.output
+    assert f"worktree: {worktree}" in result.output
+    assert "commits: 1" in result.output
+    assert "pr url: https://github.com/example/repo/pull/123" in result.output
+    assert "failure reason: review flaked" in result.output
+    assert "worktree exists: yes" in result.output
+    assert "worktree dirty: no" in result.output
+    assert "worktree branch: feat/swarm/foo" in result.output
+    assert f"retry shipping: conductor swarm retry-ship {manifest_path} 1" in result.output
+    assert (
+        f"rerun implementation: conductor swarm --provider codex "
+        f"--base-branch main --brief {brief}"
+    ) in result.output
+
+
+def test_swarm_resume_reports_missing_worktree(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo = _repo(tmp_path)
+    brief = _brief(repo, "foo.md")
+    worktree = repo / ".cache" / "conductor" / "swarm" / "foo"
+    monkeypatch.chdir(repo)
+    manifest_path = _manual_swarm_manifest(
+        repo,
+        tasks=[
+            {
+                "brief": str(brief),
+                "branch": "feat/swarm/foo",
+                "worktree": str(worktree),
+                "status": "failed",
+                "commits": 1,
+                "pr_url": None,
+                "merge_sha": None,
+                "duration_ms": 10,
+                "failure_reason": "implementation failed",
+                "cleanup_status": "preserved",
+            }
+        ],
+    )
+
+    result = CliRunner().invoke(main, ["swarm", "resume", str(manifest_path), "1"])
+
+    assert result.exit_code == 0, result.output
+    assert "worktree exists: no" in result.output
+    assert "worktree dirty: unknown (worktree missing)" in result.output
+    assert "worktree branch: unknown (worktree missing)" in result.output
+    assert "retry shipping: unavailable until the worktree exists and has commits" in result.output
+
+
+@pytest.mark.parametrize("selector_kind", ["index", "branch", "brief"])
+def test_swarm_resume_selects_by_index_branch_or_brief(
+    tmp_path: Path,
+    monkeypatch,
+    selector_kind: str,
+) -> None:
+    repo = _repo(tmp_path)
+    first = _brief(repo, "foo.md")
+    second = _brief(repo, "bar.md")
+    base_ref = _git(repo, "rev-parse", "main").stdout.strip()
+    foo_worktree = repo / ".cache" / "conductor" / "swarm" / "foo"
+    bar_worktree = repo / ".cache" / "conductor" / "swarm" / "bar"
+    _git(repo, "worktree", "add", str(foo_worktree), "-b", "feat/swarm/foo", base_ref)
+    _commit_change(foo_worktree, "foo.txt", "foo")
+    _git(repo, "worktree", "add", str(bar_worktree), "-b", "feat/swarm/bar", base_ref)
+    _commit_change(bar_worktree, "bar.txt", "bar")
+    monkeypatch.chdir(repo)
+    manifest_path = _manual_swarm_manifest(
+        repo,
+        base_ref=base_ref,
+        tasks=[
+            {
+                "brief": str(first),
+                "branch": "feat/swarm/foo",
+                "worktree": str(foo_worktree),
+                "status": "failed",
+                "commits": 1,
+                "pr_url": None,
+                "merge_sha": None,
+                "duration_ms": 10,
+                "failure_reason": "push failed",
+                "cleanup_status": "preserved",
+            },
+            {
+                "brief": str(second),
+                "branch": "feat/swarm/bar",
+                "worktree": str(bar_worktree),
+                "status": "review-blocked",
+                "commits": 1,
+                "pr_url": "https://github.com/example/repo/pull/124",
+                "merge_sha": None,
+                "duration_ms": 10,
+                "failure_reason": "review flaked",
+                "cleanup_status": "preserved",
+            },
+        ],
+    )
+    selector = {
+        "index": "2",
+        "branch": "feat/swarm/bar",
+        "brief": str(second),
+    }[selector_kind]
+
+    result = CliRunner().invoke(main, ["swarm", "resume", str(manifest_path), selector])
+
+    assert result.exit_code == 0, result.output
+    assert "task index: 2" in result.output
+    assert f"brief: {second}" in result.output
+    assert "branch: feat/swarm/bar" in result.output
+    assert "failure reason: review flaked" in result.output
+
+
+def test_swarm_resume_retry_ship_delegates_to_retry_ship_update_path(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo = _repo(tmp_path)
+    brief = _brief(repo, "foo.md")
+    base_ref = _git(repo, "rev-parse", "main").stdout.strip()
+    worktree = repo / ".cache" / "conductor" / "swarm" / "foo"
+    _git(repo, "worktree", "add", str(worktree), "-b", "feat/swarm/foo", base_ref)
+    _commit_change(worktree, "feature.txt", "feature")
+    monkeypatch.chdir(repo)
+    manifest_path = _manual_swarm_manifest(
+        repo,
+        base_ref=base_ref,
+        tasks=[
+            {
+                "brief": str(brief),
+                "branch": "feat/swarm/foo",
+                "worktree": str(worktree),
+                "status": "review-blocked",
+                "commits": 1,
+                "pr_url": "https://github.com/example/repo/pull/123",
+                "merge_sha": None,
+                "duration_ms": 10,
+                "failure_reason": "review flaked",
+                "cleanup_status": "preserved",
+            }
+        ],
+    )
+    monkeypatch.setattr(cli, "_ship_swarm_pr", _fake_merged_ship(repo))
+
+    result = CliRunner().invoke(main, ["swarm", "resume", str(manifest_path), "1", "--retry-ship"])
+
+    assert result.exit_code == 0, result.output
+    assert "shipped:" in result.output
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    task = manifest["tasks"][0]
+    assert manifest["ok"] is True
+    assert manifest["metrics"]["shipped_count"] == 1
+    assert task["status"] == "shipped"
+    assert task["cleanup_status"] == "removed"
+    assert not worktree.exists()
+
+
+def test_swarm_resume_reports_dirty_detached_worktree_read_only(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo = _repo(tmp_path)
+    brief = _brief(repo, "foo.md")
+    base_ref = _git(repo, "rev-parse", "main").stdout.strip()
+    worktree = repo / ".cache" / "conductor" / "swarm" / "foo"
+    _git(repo, "worktree", "add", str(worktree), "-b", "feat/swarm/foo", base_ref)
+    _commit_change(worktree, "feature.txt", "feature")
+    branch_head = _git(worktree, "rev-parse", "HEAD").stdout.strip()
+    _git(worktree, "checkout", "--detach", "HEAD")
+    (worktree / "dirty.txt").write_text("dirty\n", encoding="utf-8")
+    monkeypatch.chdir(repo)
+    manifest_path = _manual_swarm_manifest(
+        repo,
+        base_ref=base_ref,
+        tasks=[
+            {
+                "brief": str(brief),
+                "branch": "feat/swarm/foo",
+                "worktree": str(worktree),
+                "status": "failed",
+                "commits": 1,
+                "pr_url": None,
+                "merge_sha": None,
+                "duration_ms": 10,
+                "failure_reason": "ship failed",
+                "cleanup_status": "preserved",
+            }
+        ],
+    )
+
+    result = CliRunner().invoke(main, ["swarm", "resume", str(manifest_path), "1"])
+
+    assert result.exit_code == 0, result.output
+    assert "worktree dirty: yes" in result.output
+    assert "dirty.txt" in result.output
+    assert "worktree branch: detached at " in result.output
+    assert _git(repo, "rev-parse", "feat/swarm/foo").stdout.strip() == branch_head
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["tasks"][0]["status"] == "failed"
+
+
 def test_swarm_retry_ship_refuses_missing_worktree(tmp_path: Path, monkeypatch) -> None:
     repo = _repo(tmp_path)
     brief = _brief(repo, "foo.md")


### PR DESCRIPTION
Add a first-class swarm resume orientation command for failed lanes, including worktree state and recovery commands. Route explicit retry shipping through the existing retry-ship implementation.

Closes #367

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
