### PR TITLE
Fix review fallback timeout budget

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -505,6 +505,39 @@ def _bounded_attempt_budget(
     return attempt_timeout_sec, attempt_max_stall_sec
 
 
+def _bounded_review_attempt_budget(
+    *,
+    timeout_sec: int | None,
+    max_stall_sec: int | None,
+    deadline_monotonic: float | None,
+    provider_name: str,
+    is_fallback: bool,
+) -> tuple[int | None, int | None]:
+    """Return the review attempt budget under shared and per-fallback caps.
+
+    Invariant: once a review provider fails and the route is in fallback, a
+    later provider cannot receive a wall-clock timeout larger than the derived
+    review stall budget. This matters for HTTP providers that cannot emit
+    progress and do not implement the no-output watchdog separately.
+    """
+    attempt_timeout_sec, attempt_max_stall_sec = _bounded_attempt_budget(
+        timeout_sec=timeout_sec,
+        max_stall_sec=max_stall_sec,
+        deadline_monotonic=deadline_monotonic,
+        budget_label="review gate budget",
+        provider_name=provider_name,
+    )
+    if is_fallback and attempt_max_stall_sec is not None:
+        attempt_timeout_sec = (
+            attempt_max_stall_sec
+            if attempt_timeout_sec is None
+            else min(attempt_timeout_sec, attempt_max_stall_sec)
+        )
+    if attempt_timeout_sec is not None and attempt_max_stall_sec is not None:
+        attempt_max_stall_sec = min(attempt_max_stall_sec, attempt_timeout_sec)
+    return attempt_timeout_sec, attempt_max_stall_sec
+
+
 def _read_task(
     task: str | None,
     task_file: str | None,
@@ -1955,6 +1988,7 @@ def _invoke_with_fallback(
     allow_completion_stretch: bool = False,
     fallback_deadline_monotonic: float | None = None,
     fallback_budget_label: str = "fallback budget",
+    cap_fallback_attempt_timeout_to_stall: bool = False,
 ) -> tuple[CallResponse, list[str]]:
     """Try the decision's ranked providers in order; fallback on retryable errors.
 
@@ -2067,6 +2101,17 @@ def _invoke_with_fallback(
             budget_label=fallback_budget_label,
             provider_name=candidate.name,
         )
+        if (
+            cap_fallback_attempt_timeout_to_stall
+            and idx > 0
+            and attempt_max_stall_sec is not None
+        ):
+            attempt_timeout_sec = (
+                attempt_max_stall_sec
+                if attempt_timeout_sec is None
+                else min(attempt_timeout_sec, attempt_max_stall_sec)
+            )
+            attempt_max_stall_sec = min(attempt_max_stall_sec, attempt_timeout_sec)
         try:
             if mode == "exec":
                 if isinstance(provider, OpenRouterProvider):
@@ -2301,12 +2346,12 @@ def _invoke_review_with_fallback(
     for idx, candidate in enumerate(candidates):
         provider = get_provider(candidate.name)
         contract_prompt = task
-        attempt_timeout_sec, attempt_max_stall_sec = _bounded_attempt_budget(
+        attempt_timeout_sec, attempt_max_stall_sec = _bounded_review_attempt_budget(
             timeout_sec=timeout_sec,
             max_stall_sec=max_stall_sec,
             deadline_monotonic=fallback_deadline_monotonic,
-            budget_label="review gate budget",
             provider_name=candidate.name,
+            is_fallback=idx > 0,
         )
         try:
             if isinstance(provider, NativeReviewProvider):
@@ -4850,6 +4895,7 @@ def call(
                 attachments=attachments,
                 fallback_deadline_monotonic=review_deadline,
                 fallback_budget_label="review gate budget",
+                cap_fallback_attempt_timeout_to_stall=review_deadline is not None,
             )
         except ProviderConfigError as e:
             _record_failed_delegation(
@@ -7237,6 +7283,7 @@ def _run_exec_phase_dispatch(
                 strict_stall=strict_stall,
                 fallback_deadline_monotonic=review_deadline,
                 fallback_budget_label="review gate budget",
+                cap_fallback_attempt_timeout_to_stall=review_deadline is not None,
             )
         except UnsupportedCapability as e:
             if session_log is not None:

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -1754,7 +1754,7 @@ def test_review_auto_generic_fallback_prompt_includes_diff(mocker, tmp_path):
     assert result.exit_code == 0, result.output
     assert openrouter_call.call_args.kwargs["models"] == OPENROUTER_CODING_HIGH
     assert openrouter_call.call_args.kwargs["task_tags"] == ["code-review"]
-    assert openrouter_call.call_args.kwargs["timeout_sec"] == 300
+    assert openrouter_call.call_args.kwargs["timeout_sec"] == 75
     assert openrouter_call.call_args.kwargs["max_stall_sec"] == 75
     prompt = openrouter_call.call_args.args[0]
     assert "Patch context for generic review fallback" in prompt
@@ -1814,7 +1814,7 @@ def test_ask_review_uses_openrouter_code_stack_instead_of_gemini(mocker, tmp_pat
     assert openrouter_call.called
     assert openrouter_call.call_args.kwargs["models"] == OPENROUTER_CODING_HIGH
     assert openrouter_call.call_args.kwargs["task_tags"] == ["code-review"]
-    assert openrouter_call.call_args.kwargs["timeout_sec"] == 300
+    assert openrouter_call.call_args.kwargs["timeout_sec"] == 75
     assert openrouter_call.call_args.kwargs["max_stall_sec"] == 75
     prompt = openrouter_call.call_args.args[0]
     assert "Patch context for generic review fallback" in prompt

--- a/tests/test_review_cascade.py
+++ b/tests/test_review_cascade.py
@@ -197,7 +197,7 @@ def test_review_fallback_call_uses_conductor_owned_budget(mocker) -> None:
     )
 
     assert result.exit_code == 0, result.output
-    assert 250 <= openrouter_call.call_args.kwargs["timeout_sec"] <= 300
+    assert openrouter_call.call_args.kwargs["timeout_sec"] == 75
     assert openrouter_call.call_args.kwargs["max_stall_sec"] == 75
     assert "review gate budget: timeout=300s stall=75s" in result.stderr
     assert "ignored caller timeout=7s max-stall=3s" in result.stderr
@@ -239,6 +239,56 @@ def test_review_fallback_attempts_share_one_deadline(mocker, monkeypatch) -> Non
 
     assert response.provider == "codex"
     assert seen == [("claude", 300, 180), ("codex", 75, 75)]
+
+
+def test_review_rate_limit_fallback_caps_late_provider_timeout(mocker) -> None:
+    from conductor.providers.interface import (
+        ProviderError,
+        ProviderHTTPError,
+        ProviderStalledError,
+    )
+
+    seen: list[tuple[int | None, int | None]] = []
+    mocker.patch.object(
+        GeminiProvider,
+        "review",
+        side_effect=ProviderHTTPError("Gemini returned 429 rate limit"),
+    )
+    mocker.patch.object(
+        ClaudeProvider,
+        "review",
+        side_effect=ProviderHTTPError("Anthropic returned 429 rate limit"),
+    )
+
+    def openrouter_stalls(*_args, timeout_sec=None, max_stall_sec=None, **_kwargs):
+        seen.append((timeout_sec, max_stall_sec))
+        raise ProviderStalledError("openrouter review stalled")
+
+    mocker.patch.object(OpenRouterProvider, "call", side_effect=openrouter_stalls)
+
+    with pytest.raises(ProviderError) as exc_info:
+        cli._invoke_review_with_fallback(
+            _decision("gemini", "claude", "openrouter"),
+            task="Review this merge using the project reviewer guide.",
+            effort="high",
+            cwd=None,
+            timeout_sec=300,
+            max_stall_sec=75,
+            base=None,
+            commit=None,
+            uncommitted=False,
+            title=None,
+            silent=True,
+            fallback_deadline_monotonic=cli._review_gate_deadline(300),
+        )
+
+    assert seen == [(75, 75)]
+    assert "gemini (rate-limit), claude (rate-limit), openrouter (stall)" in str(
+        exc_info.value
+    )
+    assert "Last error: ProviderStalledError: openrouter review stalled" in str(
+        exc_info.value
+    )
 
 
 def test_exec_code_review_routes_cap_default_agent_iterations(mocker) -> None:


### PR DESCRIPTION
Cap review fallback provider attempts to the derived stall budget so quota/rate-limit failures do not leave the last fallback able to consume the full review gate timeout without progress.

Closes #373

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
