### PR TITLE
fix: skip optional validation tools cleanly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,7 +86,12 @@ repos:
     hooks:
       - id: conductor-refresh
         name: Refresh conductor integrations if stale
-        entry: uv run conductor refresh-on-commit
+        entry: >-
+          /usr/bin/env bash -c 'if command -v conductor >/dev/null 2>&1; then
+          exec conductor refresh-on-commit; fi; if command -v uv >/dev/null
+          2>&1; then exec uv run conductor refresh-on-commit; fi; echo
+          "conductor-refresh: skipping because neither conductor nor uv is
+          installed; install this project or run uv sync to enable." >&2'
         language: system
         pass_filenames: false
         always_run: true

--- a/scripts/touchstone-run.sh
+++ b/scripts/touchstone-run.sh
@@ -166,22 +166,42 @@ run_shell_command() {
   bash -c "$command"
 }
 
+resolve_cortex_command() {
+  if command -v cortex >/dev/null 2>&1; then
+    printf 'cortex\n'
+    return 0
+  fi
+
+  if ! command -v uv >/dev/null 2>&1; then
+    return 1
+  fi
+
+  if uv run cortex --version >/dev/null 2>&1; then
+    printf 'uv run cortex\n'
+    return 0
+  fi
+
+  return 1
+}
+
 run_cortex_update_check() {
+  local cortex_cmd
+
   [ -d .cortex ] || return 0
 
-  if command -v cortex >/dev/null 2>&1; then
-    if [ ! -f .cortex/.index.json ]; then
-      run_shell_command "cortex refresh-index --path ."
-    fi
-    run_shell_command "cortex update --check --path ."
-  elif command -v uv >/dev/null 2>&1 && uv run cortex --version >/dev/null 2>&1; then
-    if [ ! -f .cortex/.index.json ]; then
-      run_shell_command "uv run cortex refresh-index --path ."
-    fi
-    run_shell_command "uv run cortex update --check --path ."
-  else
-    warn "skipping cortex update check: cortex CLI is not installed"
+  if ! cortex_cmd="$(resolve_cortex_command)"; then
+    warn "skipping cortex update check: cortex CLI is not available"
+    warn "install cortex, then rebuild generated state with: cortex refresh-index --path ."
+    warn "if this repo provides cortex through uv, use: uv run cortex refresh-index --path ."
+    return 0
   fi
+
+  if [ ! -f .cortex/.index.json ]; then
+    warn ".cortex/.index.json is generated and missing; rebuilding with: $cortex_cmd refresh-index --path ."
+    run_shell_command "$cortex_cmd refresh-index --path ."
+  fi
+
+  run_shell_command "$cortex_cmd update --check --path ."
 }
 
 configured_command_for_action() {

--- a/tests/test_touchstone_run.py
+++ b/tests/test_touchstone_run.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "touchstone-run.sh"
+PRE_COMMIT_CONFIG = Path(__file__).resolve().parents[1] / ".pre-commit-config.yaml"
+
+pytestmark = pytest.mark.skipif(shutil.which("bash") is None, reason="bash not installed")
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".cortex").mkdir()
+    (repo / ".touchstone-config").write_text("project_type=generic\n", encoding="utf-8")
+    return repo
+
+
+def _path_with_fake_bin(fake_bin: Path) -> str:
+    system_dirs = ["/bin", "/usr/bin"]
+    return os.pathsep.join([str(fake_bin), *[path for path in system_dirs if Path(path).is_dir()]])
+
+
+def _run_validate(repo: Path, fake_bin: Path) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "PATH": _path_with_fake_bin(fake_bin),
+    }
+    return subprocess.run(
+        ["bash", str(SCRIPT), "validate"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_validate_skips_cortex_check_when_optional_cli_is_missing(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+
+    result = _run_validate(repo, fake_bin)
+
+    assert result.returncode == 0
+    assert "skipping cortex update check: cortex CLI is not available" in result.stderr
+    assert "cortex refresh-index --path ." in result.stderr
+    assert "generic project has no default 'lint' command" in result.stdout
+
+
+def test_validate_rebuilds_missing_cortex_index_when_cli_exists(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    log_file = tmp_path / "cortex.log"
+    cortex = fake_bin / "cortex"
+    cortex.write_text(
+        f"#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> {log_file}\n",
+        encoding="utf-8",
+    )
+    cortex.chmod(0o755)
+
+    result = _run_validate(repo, fake_bin)
+
+    assert result.returncode == 0
+    assert ".cortex/.index.json is generated and missing" in result.stderr
+    assert log_file.read_text(encoding="utf-8").splitlines() == [
+        "refresh-index --path .",
+        "update --check --path .",
+    ]
+
+
+def test_validate_skips_when_uv_cannot_provide_cortex(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    uv = fake_bin / "uv"
+    uv.write_text("#!/usr/bin/env bash\nexit 127\n", encoding="utf-8")
+    uv.chmod(0o755)
+
+    result = _run_validate(repo, fake_bin)
+
+    assert result.returncode == 0
+    assert "skipping cortex update check: cortex CLI is not available" in result.stderr
+    assert "uv run cortex refresh-index --path ." in result.stderr
+
+
+def test_conductor_refresh_hook_checks_optional_cli_before_invoking() -> None:
+    text = PRE_COMMIT_CONFIG.read_text(encoding="utf-8")
+    normalized = " ".join(text.split())
+
+    assert "id: conductor-refresh" in text
+    assert "command -v conductor" in text
+    assert "command -v uv" in text
+    assert "conductor-refresh: skipping because neither conductor nor uv is installed" in normalized


### PR DESCRIPTION
Closes #366

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
