### PR TITLE
Fix swarm post-merge cleanup status

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -5713,6 +5713,9 @@ class SwarmTaskResult:
     pr_url: str | None
     merge_sha: str | None
     duration_ms: int
+    merge_status: str | None = None
+    inspection_warning: str | None = None
+    cleanup_warning: str | None = None
     failure_reason: str | None = None
     provider: str | None = None
     selected_provider: str | None = None
@@ -5732,12 +5735,29 @@ class SwarmTaskResult:
         }
         if self.failure_reason is not None:
             payload["failure_reason"] = self.failure_reason
+        payload["merge_status"] = self.merge_status
+        payload["inspection_warning"] = self.inspection_warning
+        payload["cleanup_warning"] = self.cleanup_warning
         if include_provider_details:
             payload["provider"] = self.provider
             payload["selected_provider"] = self.selected_provider
             payload["fallback_provider"] = self.fallback_provider
             payload["fallback_reason"] = self.fallback_reason
         return payload
+
+
+@dataclass(frozen=True)
+class SwarmShipOutcome:
+    status: str
+    pr_url: str | None
+    detail: str | None
+    merge_status: str | None = None
+    inspection_warning: str | None = None
+
+    def __iter__(self):
+        yield self.status
+        yield self.pr_url
+        yield self.detail
 
 
 def _sanitize_swarm_stem(path: str) -> str:
@@ -6468,6 +6488,8 @@ def _swarm_unmerged_files(worktree: Path) -> list[str]:
 
 
 def _remove_swarm_worktree(worktree: Path, *, repo_root: Path) -> None:
+    if not worktree.exists():
+        return
     with SWARM_WORKTREE_LOCK:
         _run_swarm_git(["worktree", "remove", str(worktree)], cwd=repo_root)
 
@@ -6545,12 +6567,15 @@ def _extract_pr_url(output: str) -> str | None:
     return match.group(0) if match else None
 
 
-def _swarm_pr_merge_sha(worktree: Path, pr_url: str | None) -> str | None:
+def _swarm_pr_inspection(
+    cwd: Path,
+    pr_url: str | None,
+) -> tuple[str | None, str | None, str | None]:
     if pr_url is None:
-        return None
+        return None, None, None
     pr_number = pr_url.rstrip("/").rsplit("/", 1)[-1]
     if not pr_number.isdigit():
-        return None
+        return None, None, f"could not parse PR number from {pr_url}"
     try:
         result = subprocess.run(
             [
@@ -6559,37 +6584,59 @@ def _swarm_pr_merge_sha(worktree: Path, pr_url: str | None) -> str | None:
                 "view",
                 pr_number,
                 "--json",
-                "mergeCommit",
-                "--jq",
-                ".mergeCommit.oid // empty",
+                "state,mergeCommit",
             ],
-            cwd=worktree,
+            cwd=cwd,
             capture_output=True,
             text=True,
             timeout=SWARM_GH_TIMEOUT_SEC,
             check=False,
         )
     except subprocess.TimeoutExpired as e:
-        click.echo(
-            f"[conductor] warning: gh pr view timed out after {SWARM_GH_TIMEOUT_SEC:.0f}s "
-            f"for {pr_url}: {e}",
-            err=True,
+        return (
+            None,
+            None,
+            f"gh pr view timed out after {SWARM_GH_TIMEOUT_SEC:.0f}s for {pr_url}: {e}",
         )
-        return None
     except OSError as e:
-        click.echo(
-            f"[conductor] warning: could not inspect PR merge commit for {pr_url}: {e}",
-            err=True,
-        )
-        return None
+        return None, None, f"could not inspect PR state for {pr_url}: {e}"
     if result.returncode != 0:
         detail = (result.stderr or result.stdout or "").strip()
-        click.echo(
-            f"[conductor] warning: gh pr view failed for {pr_url}: {detail}",
-            err=True,
+        return None, None, f"gh pr view failed for {pr_url}: {detail}"
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError as e:
+        return None, None, f"gh pr view returned invalid JSON for {pr_url}: {e}"
+    if not isinstance(payload, dict):
+        return None, None, f"gh pr view returned non-object JSON for {pr_url}"
+    merge_commit = payload.get("mergeCommit")
+    merge_sha = None
+    if isinstance(merge_commit, dict):
+        oid = merge_commit.get("oid")
+        if isinstance(oid, str) and oid:
+            merge_sha = oid
+    state = payload.get("state")
+    return (state if isinstance(state, str) and state else None), merge_sha, None
+
+
+def _swarm_pr_merge_sha(worktree: Path, pr_url: str | None) -> str | None:
+    _merge_status, merge_sha, warning = _swarm_pr_inspection(worktree, pr_url)
+    if warning is not None:
+        click.echo(f"[conductor] warning: {warning}", err=True)
+    return merge_sha
+
+
+def _coerce_swarm_ship_outcome(value: object) -> SwarmShipOutcome:
+    if isinstance(value, SwarmShipOutcome):
+        return value
+    if isinstance(value, tuple) and len(value) == 3:
+        status, pr_url, detail = value
+        return SwarmShipOutcome(
+            str(status),
+            pr_url if isinstance(pr_url, str) else None,
+            detail if isinstance(detail, str) else None,
         )
-        return None
-    return result.stdout.strip() or None
+    raise TypeError(f"invalid swarm ship result: {value!r}")
 
 
 def _ensure_swarm_branch_checked_out(worktree: Path, branch: str) -> None:
@@ -6629,7 +6676,7 @@ def _ship_swarm_pr(
     base_branch: str,
     branch: str,
     auto_merge: bool,
-) -> tuple[str, str | None, str | None]:
+) -> SwarmShipOutcome:
     repo_root = _swarm_repo_root()
     script = repo_root / "scripts" / "open-pr.sh"
     _ensure_swarm_branch_checked_out(worktree, branch)
@@ -6657,17 +6704,44 @@ def _ship_swarm_pr(
             f"open-pr.sh timed out after {SWARM_SHIP_TIMEOUT_SEC:.0f}s"
             + (f": {output}" if output else "")
         )
-        return status, pr_url, reason
+        return SwarmShipOutcome(status, pr_url, reason)
     except OSError as e:
-        return "failed", None, f"open-pr.sh failed to start: {e}"
+        return SwarmShipOutcome("failed", None, f"open-pr.sh failed to start: {e}")
     output = f"{result.stdout}\n{result.stderr}".strip()
     pr_url = _extract_pr_url(output)
+    merge_status: str | None = None
+    merge_sha: str | None = None
+    inspection_warning: str | None = None
+    if auto_merge and pr_url is not None:
+        merge_status, merge_sha, inspection_warning = _swarm_pr_inspection(repo_root, pr_url)
+        if inspection_warning is not None:
+            click.echo(f"[conductor] warning: {inspection_warning}", err=True)
     if result.returncode != 0:
+        if auto_merge and pr_url is not None and merge_status == "MERGED":
+            return SwarmShipOutcome(
+                "shipped",
+                pr_url,
+                merge_sha,
+                merge_status=merge_status,
+                inspection_warning=inspection_warning,
+            )
         status = "review-blocked" if auto_merge and pr_url else "failed"
         reason = output or f"open-pr.sh exited {result.returncode}"
-        return status, pr_url, reason
-    merge_sha = _swarm_pr_merge_sha(worktree, pr_url) if auto_merge else None
-    return ("shipped" if auto_merge else "pushed-not-merged"), pr_url, merge_sha
+        return SwarmShipOutcome(
+            status,
+            pr_url,
+            reason,
+            merge_status=merge_status,
+            inspection_warning=inspection_warning,
+        )
+    status = "shipped" if auto_merge else "pushed-not-merged"
+    return SwarmShipOutcome(
+        status,
+        pr_url,
+        merge_sha,
+        merge_status=merge_status,
+        inspection_warning=inspection_warning,
+    )
 
 
 def _timeout_output_text(value: str | bytes | None) -> str:
@@ -6813,6 +6887,8 @@ def _swarm_initial_task_records(
                 "commits": 0,
                 "pr_url": None,
                 "merge_sha": None,
+                "merge_status": None,
+                "inspection_warning": None,
                 "duration_ms": 0,
                 "failure_reason": None,
                 "cleanup_status": "pending",
@@ -7046,6 +7122,9 @@ def _swarm_manifest_task_records(results: list[SwarmTaskResult]) -> list[dict[st
     tasks: list[dict[str, object]] = []
     for result in results:
         task = result.to_json()
+        task.setdefault("merge_status", None)
+        task.setdefault("inspection_warning", None)
+        task.setdefault("cleanup_warning", None)
         task["cleanup_status"] = "removed" if not Path(result.worktree).exists() else "preserved"
         tasks.append(task)
     return tasks
@@ -7216,14 +7295,21 @@ def _orchestrate_swarm_auto_merge(
             continue
         branch = _swarm_task_string(task, "branch", selector=selector)
         worktree = Path(_swarm_task_string(task, "worktree", selector=selector))
-        shipped_status, shipped_pr_url, shipped_detail = _ship_swarm_pr(
-            worktree,
-            base_branch=base_branch,
-            branch=branch,
-            auto_merge=True,
+        ship_outcome = _coerce_swarm_ship_outcome(
+            _ship_swarm_pr(
+                worktree,
+                base_branch=base_branch,
+                branch=branch,
+                auto_merge=True,
+            )
         )
+        shipped_status = ship_outcome.status
+        shipped_pr_url = ship_outcome.pr_url
+        shipped_detail = ship_outcome.detail
         task["status"] = shipped_status
         task["pr_url"] = shipped_pr_url
+        task["merge_status"] = ship_outcome.merge_status
+        task["inspection_warning"] = ship_outcome.inspection_warning
         if shipped_status == "shipped":
             task["merge_sha"] = shipped_detail
             task["failure_reason"] = None
@@ -7238,8 +7324,12 @@ def _orchestrate_swarm_auto_merge(
                     click.echo(f"[conductor] warning: {cleanup_warning}", err=True)
                     task["failure_reason"] = cleanup_warning
             except RuntimeError as e:
-                task["status"] = "failed"
-                task["failure_reason"] = f"cleanup failed after merge: {e}"
+                warning = f"cleanup failed after merge: {e}"
+                task["cleanup_warning"] = warning
+                click.echo(f"[conductor] warning: {warning}", err=True)
+                if ship_outcome.merge_status != "MERGED":
+                    task["status"] = "failed"
+                    task["failure_reason"] = warning
             updated_base = _run_swarm_git(
                 ["rev-parse", "--verify", base_branch],
                 cwd=repo_root,
@@ -7491,6 +7581,8 @@ def _retry_ship_swarm_task(
     status = "failed"
     pr_url: str | None = None
     merge_sha: str | None = None
+    merge_status: str | None = None
+    inspection_warning: str | None = None
     failure_reason: str | None = None
     commits = 0
     cleanup_warning: str | None = None
@@ -7509,18 +7601,22 @@ def _retry_ship_swarm_task(
             raise click.ClickException(
                 f"swarm task {selector} has no commits ahead of manifest base_ref {base_ref}"
             )
-        shipped_status, shipped_pr_url, shipped_detail = _ship_swarm_pr(
-            worktree,
-            base_branch=base_branch,
-            branch=branch,
-            auto_merge=auto_merge,
+        ship_outcome = _coerce_swarm_ship_outcome(
+            _ship_swarm_pr(
+                worktree,
+                base_branch=base_branch,
+                branch=branch,
+                auto_merge=auto_merge,
+            )
         )
-        status = shipped_status
-        pr_url = shipped_pr_url
+        status = ship_outcome.status
+        pr_url = ship_outcome.pr_url
+        merge_status = ship_outcome.merge_status
+        inspection_warning = ship_outcome.inspection_warning
         if status == "shipped":
-            merge_sha = shipped_detail
+            merge_sha = ship_outcome.detail
         elif status in {"failed", "review-blocked"}:
-            failure_reason = shipped_detail
+            failure_reason = ship_outcome.detail
     except click.ClickException:
         raise
     except RuntimeError as e:
@@ -7541,8 +7637,11 @@ def _retry_ship_swarm_task(
                     click.echo(f"[conductor] warning: {cleanup_warning}", err=True)
                     failure_reason = cleanup_warning
         except RuntimeError as e:
-            status = "failed"
-            failure_reason = f"{failure_reason or status}; cleanup failed: {e}"
+            cleanup_warning = f"cleanup failed: {e}"
+            click.echo(f"[conductor] warning: {cleanup_warning}", err=True)
+            if merge_status != "MERGED":
+                status = "failed"
+                failure_reason = f"{failure_reason or status}; {cleanup_warning}"
 
     updated_task = dict(task)
     updated_task.update(
@@ -7551,8 +7650,11 @@ def _retry_ship_swarm_task(
             "commits": commits,
             "pr_url": pr_url,
             "merge_sha": merge_sha,
+            "merge_status": merge_status,
+            "inspection_warning": inspection_warning,
             "duration_ms": duration_ms,
             "failure_reason": failure_reason,
+            "cleanup_warning": cleanup_warning,
             "cleanup_status": "removed" if not worktree.exists() else "preserved",
         }
     )
@@ -7798,6 +7900,9 @@ def _run_swarm_task(
     commits = 0
     pr_url: str | None = None
     merge_sha: str | None = None
+    merge_status: str | None = None
+    inspection_warning: str | None = None
+    cleanup_warning: str | None = None
     failure_reason: str | None = None
     provider_candidates: list[str] = []
     selected_provider: str | None = None
@@ -7935,18 +8040,22 @@ def _run_swarm_task(
                     status = "ready-to-ship"
                 else:
                     _append_swarm_closing_refs_to_head_commit(worktree, closing_refs)
-                    shipped_status, shipped_pr_url, shipped_detail = _ship_swarm_pr(
-                        worktree,
-                        base_branch=base_branch,
-                        branch=branch,
-                        auto_merge=auto_merge,
+                    ship_outcome = _coerce_swarm_ship_outcome(
+                        _ship_swarm_pr(
+                            worktree,
+                            base_branch=base_branch,
+                            branch=branch,
+                            auto_merge=auto_merge,
+                        )
                     )
-                    status = shipped_status
-                    pr_url = shipped_pr_url
+                    status = ship_outcome.status
+                    pr_url = ship_outcome.pr_url
+                    merge_status = ship_outcome.merge_status
+                    inspection_warning = ship_outcome.inspection_warning
                     if status == "shipped":
-                        merge_sha = shipped_detail
+                        merge_sha = ship_outcome.detail
                     elif status in {"failed", "review-blocked"}:
-                        failure_reason = shipped_detail
+                        failure_reason = ship_outcome.detail
         elif status == "failed":
             failure_reason = failure_reason or "provider dispatch did not complete"
     except _ExecPhaseError as e:
@@ -7972,6 +8081,9 @@ def _run_swarm_task(
         pr_url=pr_url,
         merge_sha=merge_sha,
         duration_ms=duration_ms,
+        merge_status=merge_status,
+        inspection_warning=inspection_warning,
+        cleanup_warning=cleanup_warning,
         failure_reason=failure_reason,
         provider=provider_used,
         selected_provider=selected_provider,
@@ -7994,10 +8106,17 @@ def _run_swarm_task(
                 )
                 if cleanup_warning is not None:
                     click.echo(f"[conductor] warning: {cleanup_warning}", err=True)
+                    result.cleanup_warning = cleanup_warning
                     result.failure_reason = cleanup_warning
         except RuntimeError as e:
-            result.status = "failed"
-            result.failure_reason = f"{result.failure_reason or result.status}; cleanup failed: {e}"
+            cleanup_warning = f"cleanup failed: {e}"
+            result.cleanup_warning = cleanup_warning
+            click.echo(f"[conductor] warning: {cleanup_warning}", err=True)
+            if result.merge_status != "MERGED":
+                result.status = "failed"
+                result.failure_reason = (
+                    f"{result.failure_reason or result.status}; {cleanup_warning}"
+                )
     if result.status in {"failed", SWARM_PROVIDER_FAILED_STATUS}:
         click.echo(
             f"[conductor] swarm task {result.status}: {brief_path}; inspect {worktree}; "

--- a/tests/test_cli_swarm.py
+++ b/tests/test_cli_swarm.py
@@ -181,7 +181,12 @@ def _route_decision(*providers: str, tags: tuple[str, ...] = ("tool-use",)) -> c
 def _fake_ship(worktree: Path, *, base_branch: str, branch: str, auto_merge: bool):
     _ = (worktree, base_branch, branch)
     if auto_merge:
-        return "shipped", "https://github.com/example/repo/pull/123", "abc1234"
+        return cli.SwarmShipOutcome(
+            "shipped",
+            "https://github.com/example/repo/pull/123",
+            "abc1234",
+            merge_status="MERGED",
+        )
     return "pushed-not-merged", "https://github.com/example/repo/pull/123", None
 
 
@@ -199,7 +204,12 @@ def _fake_merged_ship(repo: Path):
             "squash merge",
         ).stdout.strip()
         _git(repo, "update-ref", f"refs/heads/{base_branch}", merge_sha)
-        return "shipped", "https://github.com/example/repo/pull/123", merge_sha
+        return cli.SwarmShipOutcome(
+            "shipped",
+            "https://github.com/example/repo/pull/123",
+            merge_sha,
+            merge_status="MERGED",
+        )
 
     return fake_ship
 
@@ -399,18 +409,24 @@ def test_ship_swarm_pr_repairs_detached_head_before_open_pr(
         encoding="utf-8",
     )
     open_pr.chmod(0o755)
-    monkeypatch.setattr(cli, "_swarm_pr_merge_sha", lambda *_args, **_kwargs: "merge123")
+    monkeypatch.setattr(
+        cli,
+        "_swarm_pr_inspection",
+        lambda *_args, **_kwargs: ("MERGED", "merge123", None),
+    )
 
-    status, pr_url, merge_sha = cli._ship_swarm_pr(
+    outcome = cli._ship_swarm_pr(
         worktree,
         base_branch="main",
         branch="feat/swarm/foo",
         auto_merge=True,
     )
+    status, pr_url, merge_sha = outcome
 
     assert status == "shipped"
     assert pr_url == "https://github.com/example/repo/pull/123"
     assert merge_sha == "merge123"
+    assert outcome.merge_status == "MERGED"
     assert _git(worktree, "branch", "--show-current").stdout.strip() == "feat/swarm/foo"
     assert _git(worktree, "rev-parse", "HEAD").stdout.strip() == head_sha
 
@@ -426,6 +442,45 @@ def test_ship_swarm_pr_refuses_named_branch_mismatch(tmp_path: Path) -> None:
         cli._ensure_swarm_branch_checked_out(worktree, "feat/swarm/foo")
 
     assert _git(worktree, "branch", "--show-current").stdout.strip() == "scratch"
+
+
+def test_ship_swarm_pr_treats_github_merged_as_authoritative(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    worktree = tmp_path / "task-worktree"
+    _git(repo, "worktree", "add", str(worktree), "-b", "feat/swarm/foo", "main")
+    _commit_change(worktree, "feature.txt", "feature")
+    scripts = repo / "scripts"
+    scripts.mkdir()
+    open_pr = scripts / "open-pr.sh"
+    open_pr.write_text(
+        "#!/usr/bin/env bash\n"
+        'printf "https://github.com/example/repo/pull/123\\n"\n'
+        'printf "local cleanup failed\\n" >&2\n'
+        "exit 1\n",
+        encoding="utf-8",
+    )
+    open_pr.chmod(0o755)
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(
+        cli,
+        "_swarm_pr_inspection",
+        lambda *_args, **_kwargs: ("MERGED", "merge123", None),
+    )
+
+    outcome = cli._ship_swarm_pr(
+        worktree,
+        base_branch="main",
+        branch="feat/swarm/foo",
+        auto_merge=True,
+    )
+
+    assert outcome.status == "shipped"
+    assert outcome.pr_url == "https://github.com/example/repo/pull/123"
+    assert outcome.detail == "merge123"
+    assert outcome.merge_status == "MERGED"
 
 
 def test_swarm_one_brief_succeeds_as_shipped(monkeypatch, tmp_path: Path) -> None:
@@ -522,6 +577,97 @@ def test_swarm_writes_manifest_for_successful_run(monkeypatch, tmp_path: Path) -
     assert manifest["tasks"][0]["pr_url"] == "https://github.com/example/repo/pull/123"
     assert manifest["tasks"][0]["merge_sha"]
     assert manifest["tasks"][0]["cleanup_status"] == "removed"
+
+
+def test_swarm_keeps_merged_pr_success_when_worktree_already_removed(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    brief = _brief(repo, "foo.md")
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(cli, "_run_exec_phase_dispatch", _fake_exec_factory())
+
+    def ship_and_remove_worktree(
+        worktree: Path,
+        *,
+        base_branch: str,
+        branch: str,
+        auto_merge: bool,
+    ) -> cli.SwarmShipOutcome:
+        assert auto_merge is True
+        _ = branch
+        tree = _git(worktree, "rev-parse", "HEAD^{tree}").stdout.strip()
+        merge_sha = _git(
+            repo,
+            "commit-tree",
+            tree,
+            "-p",
+            base_branch,
+            "-m",
+            "squash merge",
+        ).stdout.strip()
+        _git(repo, "update-ref", f"refs/heads/{base_branch}", merge_sha)
+        _git(repo, "worktree", "remove", str(worktree))
+        return cli.SwarmShipOutcome(
+            "shipped",
+            "https://github.com/example/repo/pull/123",
+            merge_sha,
+            merge_status="MERGED",
+            inspection_warning="worktree was already removed before post-merge inspection",
+        )
+
+    monkeypatch.setattr(cli, "_ship_swarm_pr", ship_and_remove_worktree)
+
+    result = CliRunner().invoke(
+        main,
+        ["swarm", "--provider", "codex", "--brief", str(brief), "--auto-merge", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    task = payload["tasks"][0]
+    assert payload["ok"] is True
+    assert task["status"] == "shipped"
+    assert task.get("failure_reason") is None
+
+    manifest = json.loads(_swarm_manifests(repo)[0].read_text(encoding="utf-8"))
+    manifest_task = manifest["tasks"][0]
+    assert manifest_task["status"] == "shipped"
+    assert manifest_task["merge_status"] == "MERGED"
+    assert manifest_task["cleanup_status"] == "removed"
+    assert manifest_task["inspection_warning"] == (
+        "worktree was already removed before post-merge inspection"
+    )
+    assert manifest_task.get("failure_reason") is None
+    assert not Path(manifest_task["worktree"]).exists()
+
+
+def test_swarm_manifest_task_records_keep_cleanup_warning(tmp_path: Path) -> None:
+    worktree = tmp_path / "removed"
+
+    records = cli._swarm_manifest_task_records(
+        [
+            cli.SwarmTaskResult(
+                brief="tasks/foo.md",
+                branch="feat/swarm/foo",
+                worktree=str(worktree),
+                status="shipped",
+                commits=1,
+                pr_url="https://github.com/example/repo/pull/123",
+                merge_sha="abc123",
+                duration_ms=100,
+                merge_status="MERGED",
+                inspection_warning="inspect warning",
+                cleanup_warning="cleanup warning",
+            )
+        ]
+    )
+
+    assert records[0]["merge_status"] == "MERGED"
+    assert records[0]["inspection_warning"] == "inspect warning"
+    assert records[0]["cleanup_warning"] == "cleanup warning"
+    assert records[0]["cleanup_status"] == "removed"
 
 
 def test_swarm_auto_routes_lane_with_task_tags(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
Treat GitHub MERGED as authoritative for swarm shipping when a PR URL is available, and keep post-merge cleanup or inspection warnings as manifest metadata instead of failed task status.

Closes #384

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
