### PR TITLE
Harden review fallback for large diffs

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -1225,6 +1225,47 @@ def _review_attempt_log_state(status: str) -> str:
     return "unavailable" if status in availability_statuses else "failed"
 
 
+def _large_review_input(decision: RouteDecision) -> bool:
+    """Return whether review input is large enough to use scaled review budgets."""
+    return (
+        _review_gate_timeout_sec(decision.estimated_input_tokens)
+        > REVIEW_GATE_MIN_TIMEOUT_SEC
+    )
+
+
+def _prioritize_openrouter_after_codex_review_failure(
+    candidates: list[RankedCandidate],
+    *,
+    failed_index: int,
+    decision: RouteDecision,
+    err: Exception,
+) -> None:
+    """Move OpenRouter to the next fallback slot after large Codex review failures.
+
+    Invariant: this only reorders candidates already admitted by routing and
+    the caller's ``--max-fallbacks`` cap; it never expands the fallback set.
+    """
+    if (
+        failed_index >= len(candidates)
+        or candidates[failed_index].name != "codex"
+        or not _large_review_input(decision)
+    ):
+        return
+
+    retryable, category = _is_retryable(err)
+    if not retryable:
+        return
+    if not isinstance(err, ReviewOutputContractError) and category != "timeout":
+        return
+
+    next_index = failed_index + 1
+    for openrouter_index in range(next_index, len(candidates)):
+        if candidates[openrouter_index].name == "openrouter":
+            if openrouter_index != next_index:
+                candidates.insert(next_index, candidates.pop(openrouter_index))
+            return
+
+
 def _validate_max_fallbacks(raw: int) -> int:
     if raw < 1:
         raise click.UsageError(f"--max-fallbacks must be >= 1, got {raw}")
@@ -2478,6 +2519,12 @@ def _invoke_review_with_fallback(
                     mode,
                     _format_fallback_error_detail(e),
                 )
+            )
+            _prioritize_openrouter_after_codex_review_failure(
+                candidates,
+                failed_index=idx,
+                decision=decision,
+                err=e,
             )
         except ReviewContextError as e:
             last_exc = e

--- a/tests/test_review_cascade.py
+++ b/tests/test_review_cascade.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import os
 import subprocess
 import textwrap
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -239,6 +240,143 @@ def test_review_fallback_attempts_share_one_deadline(mocker, monkeypatch) -> Non
 
     assert response.provider == "codex"
     assert seen == [("claude", 300, 180), ("codex", 75, 75)]
+
+
+def test_large_review_codex_contract_failure_falls_back_to_openrouter_next(
+    mocker, capsys
+) -> None:
+    _stub_all_configured(mocker, {"codex", "claude", "openrouter"})
+    codex_review = mocker.patch.object(
+        CodexProvider,
+        "review",
+        return_value=CallResponse(
+            text="The review completed but omitted the required sentinel.",
+            provider="codex",
+            model="codex-review",
+            duration_ms=10,
+            usage={},
+            raw={},
+        ),
+    )
+    claude_review = mocker.patch.object(
+        ClaudeProvider,
+        "review",
+        return_value=CallResponse(
+            text="No blocking issues found.\nCODEX_REVIEW_CLEAN",
+            provider="claude",
+            model="sonnet",
+            duration_ms=10,
+            usage={},
+            raw={},
+        ),
+    )
+    openrouter_call = mocker.patch.object(
+        OpenRouterProvider,
+        "call",
+        return_value=CallResponse(
+            text="No blocking issues found.\nCODEX_REVIEW_CLEAN",
+            provider="openrouter",
+            model="test-model",
+            duration_ms=10,
+            usage={},
+            raw={},
+        ),
+    )
+
+    response, fallbacks = cli._invoke_review_with_fallback(
+        replace(
+            _decision("codex", "claude", "openrouter"),
+            estimated_input_tokens=8_000,
+        ),
+        task=(
+            "Review this merge. The last line must be exactly "
+            "CODEX_REVIEW_CLEAN or CODEX_REVIEW_BLOCKED."
+        ),
+        effort="high",
+        cwd=None,
+        timeout_sec=300,
+        max_stall_sec=75,
+        base=None,
+        commit=None,
+        uncommitted=False,
+        title=None,
+        silent=False,
+        fallback_deadline_monotonic=cli._review_gate_deadline(300),
+    )
+
+    captured = capsys.readouterr()
+    assert response.provider == "openrouter"
+    assert fallbacks == ["codex"]
+    assert codex_review.called
+    assert openrouter_call.called
+    assert not claude_review.called
+    assert "codex review failed (output-contract)" in captured.err
+    assert "falling back → openrouter" in captured.err
+    assert (
+        "review tried providers: codex (output-contract), openrouter (success)"
+        in captured.err
+    )
+
+
+def test_large_review_codex_timeout_falls_back_to_openrouter_next(mocker) -> None:
+    from conductor.providers.interface import ProviderStalledError
+
+    _stub_all_configured(mocker, {"codex", "claude", "openrouter"})
+    mocker.patch.object(
+        CodexProvider,
+        "review",
+        side_effect=ProviderStalledError("codex review timed out after 300s"),
+    )
+    claude_review = mocker.patch.object(
+        ClaudeProvider,
+        "review",
+        return_value=CallResponse(
+            text="No blocking issues found.\nCODEX_REVIEW_CLEAN",
+            provider="claude",
+            model="sonnet",
+            duration_ms=10,
+            usage={},
+            raw={},
+        ),
+    )
+    openrouter_call = mocker.patch.object(
+        OpenRouterProvider,
+        "call",
+        return_value=CallResponse(
+            text="No blocking issues found.\nCODEX_REVIEW_CLEAN",
+            provider="openrouter",
+            model="test-model",
+            duration_ms=10,
+            usage={},
+            raw={},
+        ),
+    )
+
+    response, fallbacks = cli._invoke_review_with_fallback(
+        replace(
+            _decision("codex", "claude", "openrouter"),
+            estimated_input_tokens=8_000,
+        ),
+        task=(
+            "Review this merge. The last line must be exactly "
+            "CODEX_REVIEW_CLEAN or CODEX_REVIEW_BLOCKED."
+        ),
+        effort="high",
+        cwd=None,
+        timeout_sec=300,
+        max_stall_sec=75,
+        base=None,
+        commit=None,
+        uncommitted=False,
+        title=None,
+        silent=True,
+        fallback_deadline_monotonic=cli._review_gate_deadline(300),
+    )
+
+    assert response.provider == "openrouter"
+    assert fallbacks == ["codex"]
+    assert openrouter_call.called
+    assert not claude_review.called
 
 
 def test_review_rate_limit_fallback_caps_late_provider_timeout(mocker) -> None:


### PR DESCRIPTION
Prioritize OpenRouter as the next review fallback for large inputs after Codex output-contract failures or timeouts, while preserving the existing ranked provider set and max-fallback cap.

Closes #386

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
