### PR TITLE
Reserve review fallback budget for ready final providers

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -513,13 +513,15 @@ def _bounded_review_attempt_budget(
     deadline_monotonic: float | None,
     provider_name: str,
     is_fallback: bool,
+    remaining_fallback_count: int = 0,
 ) -> tuple[int | None, int | None]:
     """Return the review attempt budget under shared and per-fallback caps.
 
-    Invariant: once a review provider fails and the route is in fallback, a
-    later provider cannot receive a wall-clock timeout larger than the derived
-    review stall budget. This matters for HTTP providers that cannot emit
-    progress and do not implement the no-output watchdog separately.
+    Invariant: a review provider attempt cannot consume time reserved for
+    later fallback providers. Once the route is in fallback, a later provider
+    also cannot receive a wall-clock timeout larger than the derived review
+    stall budget. This matters for HTTP providers that cannot emit progress
+    and do not implement the no-output watchdog separately.
     """
     attempt_timeout_sec, attempt_max_stall_sec = _bounded_attempt_budget(
         timeout_sec=timeout_sec,
@@ -528,6 +530,19 @@ def _bounded_review_attempt_budget(
         budget_label="review gate budget",
         provider_name=provider_name,
     )
+    if (
+        remaining_fallback_count > 0
+        and attempt_timeout_sec is not None
+        and attempt_max_stall_sec is not None
+    ):
+        reserved_sec = remaining_fallback_count * attempt_max_stall_sec
+        if reserved_sec >= attempt_timeout_sec:
+            attempt_timeout_sec = max(
+                1,
+                attempt_timeout_sec // (remaining_fallback_count + 1),
+            )
+        else:
+            attempt_timeout_sec = max(1, attempt_timeout_sec - reserved_sec)
     if is_fallback and attempt_max_stall_sec is not None:
         attempt_timeout_sec = (
             attempt_max_stall_sec
@@ -2388,14 +2403,15 @@ def _invoke_review_with_fallback(
     for idx, candidate in enumerate(candidates):
         provider = get_provider(candidate.name)
         contract_prompt = task
-        attempt_timeout_sec, attempt_max_stall_sec = _bounded_review_attempt_budget(
-            timeout_sec=timeout_sec,
-            max_stall_sec=max_stall_sec,
-            deadline_monotonic=fallback_deadline_monotonic,
-            provider_name=candidate.name,
-            is_fallback=idx > 0,
-        )
         try:
+            attempt_timeout_sec, attempt_max_stall_sec = _bounded_review_attempt_budget(
+                timeout_sec=timeout_sec,
+                max_stall_sec=max_stall_sec,
+                deadline_monotonic=fallback_deadline_monotonic,
+                provider_name=candidate.name,
+                is_fallback=idx > 0,
+                remaining_fallback_count=max(0, len(candidates) - idx - 1),
+            )
             if isinstance(provider, NativeReviewProvider):
                 response = provider.review(
                     task,

--- a/tests/test_review_cascade.py
+++ b/tests/test_review_cascade.py
@@ -33,6 +33,7 @@ from conductor.providers import (
     KimiProvider,
     OllamaProvider,
     OpenRouterProvider,
+    ProviderError,
     review_contract,
 )
 from conductor.router import RankedCandidate, RouteDecision, reset_health
@@ -239,7 +240,89 @@ def test_review_fallback_attempts_share_one_deadline(mocker, monkeypatch) -> Non
     )
 
     assert response.provider == "codex"
-    assert seen == [("claude", 300, 180), ("codex", 75, 75)]
+    assert seen == [("claude", 120, 120), ("codex", 75, 75)]
+
+
+def test_review_fallback_reserves_budget_for_ready_final_provider(
+    mocker, monkeypatch
+) -> None:
+    from conductor.providers.interface import ProviderStalledError
+
+    now = [1_000.0]
+    seen: list[tuple[str, int | None, int | None]] = []
+    monkeypatch.setattr(cli.time, "monotonic", lambda: now[0])
+
+    def stalled(name: str):
+        def fail(*_args, timeout_sec=None, max_stall_sec=None, **_kwargs):
+            seen.append((name, timeout_sec, max_stall_sec))
+            now[0] += timeout_sec or 0
+            raise ProviderStalledError(f"{name} review stalled")
+
+        return fail
+
+    def gemini_succeeds(*_args, timeout_sec=None, max_stall_sec=None, **_kwargs):
+        seen.append(("gemini", timeout_sec, max_stall_sec))
+        return _fake_response("gemini")
+
+    mocker.patch.object(ClaudeProvider, "review", side_effect=stalled("claude"))
+    mocker.patch.object(CodexProvider, "review", side_effect=stalled("codex"))
+    mocker.patch.object(OpenRouterProvider, "call", side_effect=stalled("openrouter"))
+    mocker.patch.object(GeminiProvider, "review", side_effect=gemini_succeeds)
+
+    response, _fallbacks = cli._invoke_review_with_fallback(
+        _decision("claude", "codex", "openrouter", "gemini"),
+        task="Review this merge using the project reviewer guide.",
+        effort="high",
+        cwd=None,
+        timeout_sec=300,
+        max_stall_sec=60,
+        base=None,
+        commit=None,
+        uncommitted=False,
+        title=None,
+        silent=True,
+        max_fallbacks=4,
+        fallback_deadline_monotonic=cli._review_gate_deadline(300),
+    )
+
+    assert response.provider == "gemini"
+    assert seen == [
+        ("claude", 120, 60),
+        ("codex", 60, 60),
+        ("openrouter", 60, 60),
+        ("gemini", 60, 60),
+    ]
+
+
+def test_review_budget_exhaustion_before_provider_is_reported(
+    mocker, monkeypatch
+) -> None:
+    now = [1_000.0]
+    monkeypatch.setattr(cli.time, "monotonic", lambda: now[0])
+    mocker.patch.object(GeminiProvider, "review", return_value=_fake_response("gemini"))
+    deadline = cli._review_gate_deadline(10)
+    now[0] += 11
+
+    with pytest.raises(ProviderError) as exc_info:
+        cli._invoke_review_with_fallback(
+            _decision("gemini"),
+            task="Review this merge using the project reviewer guide.",
+            effort="high",
+            cwd=None,
+            timeout_sec=10,
+            max_stall_sec=5,
+            base=None,
+            commit=None,
+            uncommitted=False,
+            title=None,
+            silent=True,
+            max_fallbacks=1,
+            fallback_deadline_monotonic=deadline,
+        )
+
+    message = str(exc_info.value)
+    assert "gemini (stall)" in message
+    assert "review gate budget exhausted before trying gemini" in message
 
 
 def test_large_review_codex_contract_failure_falls_back_to_openrouter_next(


### PR DESCRIPTION
A slow first review provider could consume the entire shared deadline,
leaving zero time for a ready final provider to complete. Reserve the
sum of remaining fallback stall budgets from each attempt's timeout so
the chain's last provider still has wall-clock to run when its turn
comes; collapse to a per-attempt share when the reservation would
exceed the remaining budget. Also surface budget exhaustion via the
existing fallback error handling so the operator sees `(stall)` against
the candidate plus the "review gate budget exhausted before trying X"
detail.

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
