### PR TITLE
Add opt-in internal route telemetry and delegation report

### DIFF
--- a/.conductor/internal.toml
+++ b/.conductor/internal.toml
@@ -1,0 +1,3 @@
+[telemetry]
+capture_route_decisions = true
+delegation_report = true

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -12967,7 +12967,6 @@ def delegations_report(
     try:
         events = list(
             read_delegations(
-                last=last_n,
                 since=since,
                 command=command_filter,
                 provider=provider_filter,
@@ -12977,7 +12976,7 @@ def delegations_report(
     except ValueError as e:
         raise click.UsageError(str(e)) from e
 
-    report = build_delegation_report(events, since=since, tag=tag_filter)
+    report = build_delegation_report(events, since=since, tag=tag_filter, last=last_n)
     if as_json:
         click.echo(json.dumps(report, default=str, indent=2))
         return

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -64,6 +64,7 @@ from conductor.delegation_ledger import (
     read_delegations,
     record_delegation,
 )
+from conductor.delegation_report import build_delegation_report
 from conductor.exec_completion import brief_declares_read_only_text_output
 from conductor.git_state import (
     DEFAULT_BRANCH_SCAN_LIMIT,
@@ -77,6 +78,7 @@ from conductor.git_state import (
     StaleBranch,
     scan_git_state,
 )
+from conductor.internal_config import InternalConfigError, internal_telemetry_enabled
 from conductor.muted_providers import (
     MutedProvidersError,
     load_muted_provider_ids,
@@ -3394,6 +3396,10 @@ def _delegation_event_from_response(
     synthesis_delegation_id: str | None = None,
 ) -> DelegationEvent:
     usage = response.usage or {}
+    route_payload, semantic_payload = _internal_delegation_metadata(
+        decision=decision,
+        semantic_plan=semantic_plan,
+    )
     return DelegationEvent(
         delegation_id=delegation_id or DelegationEvent().delegation_id,
         command=command,
@@ -3414,6 +3420,8 @@ def _delegation_event_from_response(
         council_role=council_role,  # type: ignore[arg-type]
         members=members,
         synthesis_delegation_id=synthesis_delegation_id,
+        route=route_payload,
+        semantic=semantic_payload,
     )
 
 
@@ -3431,6 +3439,10 @@ def _record_failed_delegation(
 ) -> None:
     resolved_provider = provider_id or (decision.provider if decision is not None else None)
     resolved_model = model or _provider_default_model_by_id(resolved_provider)
+    route_payload, semantic_payload = _internal_delegation_metadata(
+        decision=decision,
+        semantic_plan=semantic_plan,
+    )
     record_delegation(
         DelegationEvent(
             command=command,
@@ -3442,8 +3454,37 @@ def _record_failed_delegation(
             error=str(error),
             tags=_delegation_tags(decision=decision, semantic_plan=semantic_plan),
             session_log_path=(str(session_log.log_path) if session_log is not None else None),
+            route=route_payload,
+            semantic=semantic_payload,
         )
     )
+
+
+_INTERNAL_CONFIG_WARNING_EMITTED = False
+
+
+def _internal_delegation_metadata(
+    *,
+    decision: RouteDecision | None,
+    semantic_plan: SemanticPlan | None,
+) -> tuple[dict | None, dict | None]:
+    if not _internal_route_capture_enabled():
+        return None, None
+    return (
+        asdict(decision) if decision is not None else None,
+        _semantic_plan_payload(semantic_plan) if semantic_plan is not None else None,
+    )
+
+
+def _internal_route_capture_enabled() -> bool:
+    global _INTERNAL_CONFIG_WARNING_EMITTED
+    try:
+        return internal_telemetry_enabled()
+    except InternalConfigError as e:
+        if not _INTERNAL_CONFIG_WARNING_EMITTED:
+            click.echo(f"[conductor] internal telemetry disabled: {e}", err=True)
+            _INTERNAL_CONFIG_WARNING_EMITTED = True
+        return False
 
 
 def _delegation_tags(
@@ -12874,6 +12915,63 @@ def delegations_list(
         click.echo(_format_delegation_row(event))
 
 
+@delegations.command("report")
+@click.option(
+    "--since",
+    default="7d",
+    show_default=True,
+    help="Only include events since 1h, 24h, 7d, etc.",
+)
+@click.option(
+    "--last",
+    "last_n",
+    default=None,
+    type=click.IntRange(min=1),
+    help="Only inspect the N most recent matching events.",
+)
+@click.option(
+    "--command",
+    "command_filter",
+    default=None,
+    type=click.Choice(["ask", "call", "review", "exec", "council"]),
+)
+@click.option("--provider", "provider_filter", default=None)
+@click.option("--tag", "tag_filter", default=None, help="Only include events with this tag.")
+@click.option("--include-members", is_flag=True, default=False)
+@click.option("--json", "as_json", is_flag=True, default=False)
+def delegations_report(
+    since: str | None,
+    last_n: int | None,
+    command_filter: str | None,
+    provider_filter: str | None,
+    tag_filter: str | None,
+    include_members: bool,
+    as_json: bool,
+) -> None:
+    """Internal diagnostic report for routing and token efficiency.
+
+    Output is intentionally not part of the stable consumer contract.
+    """
+    try:
+        events = list(
+            read_delegations(
+                last=last_n,
+                since=since,
+                command=command_filter,
+                provider=provider_filter,
+                include_members=include_members,
+            )
+        )
+    except ValueError as e:
+        raise click.UsageError(str(e)) from e
+
+    report = build_delegation_report(events, since=since, tag=tag_filter)
+    if as_json:
+        click.echo(json.dumps(report, default=str, indent=2))
+        return
+    _print_delegation_report(report)
+
+
 @delegations.command("show")
 @click.argument("delegation_id")
 @click.option("--json", "as_json", is_flag=True, default=False)
@@ -12909,6 +13007,79 @@ def _format_delegation_row(event: dict) -> str:
     )
 
 
+def _print_delegation_report(report: dict) -> None:
+    window = report.get("window") or {}
+    since = window.get("since") or "all"
+    events = window.get("events") or 0
+    tag = window.get("tag_filter")
+    heading = f"Delegation report since {since}: {events} events"
+    if tag:
+        heading += f" (tag={tag})"
+    click.echo(heading)
+    click.echo("Internal diagnostic output; not a stable consumer API.")
+    click.echo("")
+    if not events:
+        click.echo("(no matching delegations)")
+        return
+    fallbacks = report.get("route_fallbacks") or {}
+    if fallbacks:
+        formatted = ", ".join(f"{route}={count}" for route, count in sorted(fallbacks.items()))
+        click.echo(f"Fallbacks: {formatted}")
+        click.echo("")
+
+    click.echo("By provider:")
+    click.echo(
+        "PROVIDER  CALLS OK/ERR  MED_DUR  IN/OUT/THINK TOKENS  OUT/1K_IN  IN/OUT  MS/OUT  COST"
+    )
+    for row in report.get("providers") or []:
+        click.echo(_format_report_provider_row(row))
+
+    models = report.get("models") or []
+    if models:
+        click.echo("")
+        click.echo("By model:")
+        click.echo(
+            "PROVIDER  MODEL              CALLS OK/ERR  OUT/1K_IN  IN/OUT  MS/OUT  COST/1K_OUT"
+        )
+        for row in models[:20]:
+            click.echo(_format_report_model_row(row))
+
+
+def _format_report_provider_row(row: dict) -> str:
+    provider = _truncate_cell(row.get("provider") or "-", 8)
+    calls = _ledger_value(row.get("calls"))
+    ok_err = f"{_ledger_value(row.get('ok'))}/{_ledger_value(row.get('non_ok'))}"
+    duration = _format_duration_ms(row.get("median_duration_ms"))
+    tokens = (
+        f"{_ledger_value(row.get('input_tokens'))}/"
+        f"{_ledger_value(row.get('output_tokens'))}/"
+        f"{_ledger_value(row.get('thinking_tokens'))}"
+    )
+    out_per_in = _format_float(row.get("output_tokens_per_1k_input"))
+    in_per_out = _format_float(row.get("input_tokens_per_output_token"))
+    ms_per_out = _format_float(row.get("ms_per_output_token"))
+    cost = _format_cost(row.get("cost_usd"))
+    return (
+        f"{provider:<8} {calls:>5} {ok_err:>6} {duration:>8} "
+        f"{tokens:>20} {out_per_in:>10} {in_per_out:>7} {ms_per_out:>7} {cost:>8}"
+    )
+
+
+def _format_report_model_row(row: dict) -> str:
+    provider = _truncate_cell(row.get("provider") or "-", 8)
+    model = _truncate_cell(row.get("model") or "-", 18)
+    calls = _ledger_value(row.get("calls"))
+    ok_err = f"{_ledger_value(row.get('ok'))}/{_ledger_value(row.get('non_ok'))}"
+    out_per_in = _format_float(row.get("output_tokens_per_1k_input"))
+    in_per_out = _format_float(row.get("input_tokens_per_output_token"))
+    ms_per_out = _format_float(row.get("ms_per_output_token"))
+    cost_per_out = _format_cost(row.get("cost_per_1k_output_tokens"))
+    return (
+        f"{provider:<8} {model:<18} {calls:>5} {ok_err:>6} "
+        f"{out_per_in:>10} {in_per_out:>7} {ms_per_out:>7} {cost_per_out:>11}"
+    )
+
+
 def _compact_delegation_time(value: object) -> str:
     if not isinstance(value, str):
         return "-"
@@ -12938,6 +13109,12 @@ def _format_cost(value: object) -> str:
     if not isinstance(value, (int, float)):
         return "-"
     return f"${value:.4f}"
+
+
+def _format_float(value: object) -> str:
+    if not isinstance(value, (int, float)):
+        return "-"
+    return f"{value:.2f}"
 
 
 # --------------------------------------------------------------------------- #

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -3363,6 +3363,7 @@ def _record_response_delegation(
     council_role: str | None = None,
     members: list[dict] | None = None,
     synthesis_delegation_id: str | None = None,
+    fallback_chain: list[str] | None = None,
 ) -> str:
     event = _delegation_event_from_response(
         command,
@@ -3376,6 +3377,7 @@ def _record_response_delegation(
         council_role=council_role,
         members=members,
         synthesis_delegation_id=synthesis_delegation_id,
+        fallback_chain=fallback_chain,
     )
     record_delegation(event)
     return event.delegation_id
@@ -3394,6 +3396,7 @@ def _delegation_event_from_response(
     council_role: str | None = None,
     members: list[dict] | None = None,
     synthesis_delegation_id: str | None = None,
+    fallback_chain: list[str] | None = None,
 ) -> DelegationEvent:
     usage = response.usage or {}
     route_payload, semantic_payload = _internal_delegation_metadata(
@@ -3422,6 +3425,7 @@ def _delegation_event_from_response(
         synthesis_delegation_id=synthesis_delegation_id,
         route=route_payload,
         semantic=semantic_payload,
+        fallback_chain=fallback_chain if fallback_chain else None,
     )
 
 
@@ -4461,7 +4465,7 @@ def ask(
         max_stall_sec = _normalize_max_stall_sec(max_stall_sec)
         review_deadline = _review_gate_deadline(timeout_sec)
         try:
-            response, _fallbacks = _invoke_review_with_fallback(
+            response, fallbacks = _invoke_review_with_fallback(
                 decision,
                 task=body,
                 effort=effort_value,
@@ -4513,6 +4517,7 @@ def ask(
             effort=effort_value,
             decision=decision,
             semantic_plan=plan,
+            fallback_chain=fallbacks,
         )
         _emit_call(response, as_json=as_json, decision=decision, semantic_plan=plan)
         return
@@ -4595,7 +4600,7 @@ def ask(
         candidate.provider: candidate.models for candidate in plan.candidates if candidate.models
     }
     try:
-        response, _fallbacks = _invoke_with_fallback(
+        response, fallbacks = _invoke_with_fallback(
             decision,
             mode=plan.mode,
             task=body,
@@ -4686,6 +4691,7 @@ def ask(
         decision=decision,
         semantic_plan=plan,
         session_log=session_log,
+        fallback_chain=fallbacks,
     )
     _emit_call(
         response,
@@ -4930,6 +4936,7 @@ def call(
     dispatch_started_at = time.monotonic()
 
     decision: RouteDecision | None = None
+    fallbacks: list[str] = []
     if auto:
         try:
             provider, decision = pick(
@@ -4983,7 +4990,7 @@ def call(
         max_stall_sec = _normalize_max_stall_sec(max_stall_sec)
 
         try:
-            response, _fallbacks = _invoke_with_fallback(
+            response, fallbacks = _invoke_with_fallback(
                 decision,
                 mode="call",
                 task=body,
@@ -5124,6 +5131,7 @@ def call(
         response,
         effort=effort_value,
         decision=decision,
+        fallback_chain=fallbacks,
     )
     _emit_call(response, as_json=as_json, decision=decision)
 
@@ -5366,6 +5374,7 @@ def review(
     prefer_value = _validate_prefer(prefer) if prefer is not None else None
 
     decision: RouteDecision | None = None
+    fallbacks: list[str] = []
     if auto_route:
         plan = plan_for("review", effort_value)
         user_tags = tuple(_parse_csv(tags))
@@ -5409,7 +5418,7 @@ def review(
         max_stall_sec = _normalize_max_stall_sec(max_stall_sec)
         review_deadline = _review_gate_deadline(timeout_sec)
         try:
-            response, _fallbacks = _invoke_review_with_fallback(
+            response, fallbacks = _invoke_review_with_fallback(
                 decision,
                 task=body,
                 effort=effort_value,
@@ -5570,6 +5579,7 @@ def review(
         response,
         effort=effort_value,
         decision=decision,
+        fallback_chain=fallbacks,
     )
     _emit_call(response, as_json=as_json, decision=decision)
 
@@ -9184,6 +9194,7 @@ def _run_exec_phase_dispatch(
 
     decision: RouteDecision | None = None
     session_log: SessionLog | None = None
+    fallbacks: list[str] = []
     if auto:
         try:
             provider, decision = pick(
@@ -9309,7 +9320,7 @@ def _run_exec_phase_dispatch(
                 )
 
         try:
-            response, _fallbacks = _invoke_with_fallback(
+            response, fallbacks = _invoke_with_fallback(
                 decision,
                 mode="exec",
                 task=body,
@@ -9616,6 +9627,7 @@ def _run_exec_phase_dispatch(
         effort=effort_value,
         decision=decision,
         session_log=session_log,
+        fallback_chain=fallbacks,
     )
     return response, decision, session_log
 

--- a/src/conductor/delegation_ledger.py
+++ b/src/conductor/delegation_ledger.py
@@ -60,6 +60,7 @@ class DelegationEvent:
     synthesis_delegation_id: str | None = None
     route: dict | None = None
     semantic: dict | None = None
+    fallback_chain: list[str] | None = None
 
     def to_dict(self) -> dict:
         payload = asdict(self)

--- a/src/conductor/delegation_ledger.py
+++ b/src/conductor/delegation_ledger.py
@@ -5,9 +5,9 @@ and per-exec session logs are noisy, fragmented, and may be expensive or
 impossible for operators to reconstruct later. This NDJSON stream is the
 external truth for delegation billing and time/accounting visibility.
 
-Storage is intentionally simple for schema version 1: one JSON object per line
+Storage is intentionally simple for schema version 2: one JSON object per line
 at ``~/.cache/conductor/delegations.ndjson`` under ``offline_mode._cache_dir()``.
-File rotation is future work; v1 only appends.
+File rotation is future work; v2 only appends.
 """
 
 from __future__ import annotations
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
     from pathlib import Path
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 LEDGER_FILENAME = "delegations.ndjson"
 COMMANDS = ("ask", "call", "review", "exec", "council")
 STATUSES = ("ok", "error", "stalled", "timeout", "quota")
@@ -58,6 +58,8 @@ class DelegationEvent:
     council_role: CouncilRole | None = None
     members: list[dict] | None = None
     synthesis_delegation_id: str | None = None
+    route: dict | None = None
+    semantic: dict | None = None
 
     def to_dict(self) -> dict:
         payload = asdict(self)

--- a/src/conductor/delegation_report.py
+++ b/src/conductor/delegation_report.py
@@ -129,8 +129,9 @@ def build_delegation_report(
             selected = route.get("provider")
             if isinstance(selected, str) and selected:
                 route_selected[selected] += 1
-                if selected != provider:
-                    route_fallbacks[f"{selected}->{provider}"] += 1
+        chain_key = _fallback_chain_key(event, provider=provider)
+        if chain_key is not None:
+            route_fallbacks[chain_key] += 1
 
     provider_rows = sorted(
         (bucket.payload() for bucket in providers.values()),
@@ -155,6 +156,27 @@ def build_delegation_report(
         "providers": provider_rows,
         "models": model_rows,
     }
+
+
+def _fallback_chain_key(event: dict[str, Any], *, provider: str) -> str | None:
+    """Return the full attempted-provider chain as a "a->b->c" key, or None.
+
+    Prefers the structured ``fallback_chain`` list (providers that failed
+    before the completed one) so multi-hop fallback paths are not collapsed
+    to primary→final. Falls back to the legacy ``route.provider`` heuristic
+    when that field is absent (older v1/early-v2 events).
+    """
+    chain = event.get("fallback_chain")
+    if isinstance(chain, list) and chain:
+        attempted = [item for item in chain if isinstance(item, str) and item]
+        if attempted:
+            return "->".join([*attempted, provider])
+    route = event.get("route")
+    if isinstance(route, dict):
+        selected = route.get("provider")
+        if isinstance(selected, str) and selected and selected != provider:
+            return f"{selected}->{provider}"
+    return None
 
 
 def _int_or_none(value: object) -> int | None:

--- a/src/conductor/delegation_report.py
+++ b/src/conductor/delegation_report.py
@@ -98,12 +98,15 @@ def build_delegation_report(
     *,
     since: str | None,
     tag: str | None = None,
+    last: int | None = None,
 ) -> dict[str, Any]:
     filtered = [
         event
         for event in events
         if tag is None or tag in [candidate for candidate in event.get("tags") or []]
     ]
+    if last is not None:
+        filtered = filtered[-last:]
     providers: dict[str, _Bucket] = {}
     models: dict[tuple[str, str], _Bucket] = {}
     commands: Counter[str] = Counter()

--- a/src/conductor/delegation_report.py
+++ b/src/conductor/delegation_report.py
@@ -1,0 +1,177 @@
+"""Internal aggregation for delegation routing and token-efficiency reports."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from statistics import median
+from typing import Any
+
+REPORT_SCHEMA_VERSION = 1
+
+
+@dataclass
+class _Bucket:
+    provider: str
+    model: str | None = None
+    calls: int = 0
+    ok: int = 0
+    non_ok: int = 0
+    durations_ms: list[int] = field(default_factory=list)
+    input_tokens: int = 0
+    output_tokens: int = 0
+    thinking_tokens: int = 0
+    cached_tokens: int = 0
+    cost_usd: float = 0.0
+    cost_seen: bool = False
+    tags: Counter[str] = field(default_factory=Counter)
+    models: Counter[str] = field(default_factory=Counter)
+
+    def add(self, event: dict[str, Any]) -> None:
+        self.calls += 1
+        if event.get("status") == "ok":
+            self.ok += 1
+        else:
+            self.non_ok += 1
+
+        duration = _int_or_none(event.get("duration_ms"))
+        if duration is not None:
+            self.durations_ms.append(duration)
+        self.input_tokens += _int_or_zero(event.get("input_tokens"))
+        self.output_tokens += _int_or_zero(event.get("output_tokens"))
+        self.thinking_tokens += _int_or_zero(event.get("thinking_tokens"))
+        self.cached_tokens += _int_or_zero(event.get("cached_tokens"))
+
+        cost = event.get("cost_usd")
+        if isinstance(cost, (int, float)):
+            self.cost_usd += float(cost)
+            self.cost_seen = True
+
+        model = event.get("model")
+        if isinstance(model, str) and model:
+            self.models[model] += 1
+        for tag in event.get("tags") or []:
+            if isinstance(tag, str) and tag:
+                self.tags[tag] += 1
+
+    def payload(self) -> dict[str, Any]:
+        total_tokens = self.input_tokens + self.output_tokens + self.thinking_tokens
+        median_duration_ms = int(median(self.durations_ms)) if self.durations_ms else None
+        return {
+            "provider": self.provider,
+            "model": self.model,
+            "calls": self.calls,
+            "ok": self.ok,
+            "non_ok": self.non_ok,
+            "success_rate": _ratio(self.ok, self.calls),
+            "median_duration_ms": median_duration_ms,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "thinking_tokens": self.thinking_tokens,
+            "cached_tokens": self.cached_tokens,
+            "total_tokens": total_tokens,
+            "output_tokens_per_1k_input": _per(self.output_tokens, self.input_tokens, 1000),
+            "input_tokens_per_output_token": _per(self.input_tokens, self.output_tokens, 1),
+            "thinking_tokens_per_output_token": _per(
+                self.thinking_tokens, self.output_tokens, 1
+            ),
+            "ms_per_output_token": _per(sum(self.durations_ms), self.output_tokens, 1),
+            "cost_usd": self.cost_usd if self.cost_seen else None,
+            "cost_per_1k_total_tokens": (
+                _per(self.cost_usd, total_tokens, 1000) if self.cost_seen else None
+            ),
+            "cost_per_1k_output_tokens": (
+                _per(self.cost_usd, self.output_tokens, 1000) if self.cost_seen else None
+            ),
+            "models": [
+                {"model": model, "calls": count}
+                for model, count in self.models.most_common()
+            ],
+            "top_tags": [
+                {"tag": tag, "calls": count} for tag, count in self.tags.most_common(8)
+            ],
+        }
+
+
+def build_delegation_report(
+    events: list[dict[str, Any]],
+    *,
+    since: str | None,
+    tag: str | None = None,
+) -> dict[str, Any]:
+    filtered = [
+        event
+        for event in events
+        if tag is None or tag in [candidate for candidate in event.get("tags") or []]
+    ]
+    providers: dict[str, _Bucket] = {}
+    models: dict[tuple[str, str], _Bucket] = {}
+    commands: Counter[str] = Counter()
+    statuses: Counter[str] = Counter()
+    route_selected: Counter[str] = Counter()
+    route_fallbacks: Counter[str] = Counter()
+
+    for event in filtered:
+        provider = str(event.get("provider") or "-")
+        model = event.get("model")
+        provider_bucket = providers.setdefault(provider, _Bucket(provider=provider))
+        provider_bucket.add(event)
+        if isinstance(model, str) and model:
+            model_bucket = models.setdefault(
+                (provider, model),
+                _Bucket(provider=provider, model=model),
+            )
+            model_bucket.add(event)
+        commands[str(event.get("command") or "-")] += 1
+        statuses[str(event.get("status") or "-")] += 1
+        route = event.get("route")
+        if isinstance(route, dict):
+            selected = route.get("provider")
+            if isinstance(selected, str) and selected:
+                route_selected[selected] += 1
+                if selected != provider:
+                    route_fallbacks[f"{selected}->{provider}"] += 1
+
+    provider_rows = sorted(
+        (bucket.payload() for bucket in providers.values()),
+        key=lambda row: (-int(row["calls"]), str(row["provider"])),
+    )
+    model_rows = sorted(
+        (bucket.payload() for bucket in models.values()),
+        key=lambda row: (-int(row["calls"]), str(row["provider"]), str(row["model"])),
+    )
+    return {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "window": {
+            "since": since,
+            "events": len(filtered),
+            "events_before_tag_filter": len(events),
+            "tag_filter": tag,
+        },
+        "commands": dict(sorted(commands.items())),
+        "statuses": dict(sorted(statuses.items())),
+        "route_selected": dict(sorted(route_selected.items())),
+        "route_fallbacks": dict(sorted(route_fallbacks.items())),
+        "providers": provider_rows,
+        "models": model_rows,
+    }
+
+
+def _int_or_none(value: object) -> int | None:
+    return value if isinstance(value, int) else None
+
+
+def _int_or_zero(value: object) -> int:
+    return value if isinstance(value, int) else 0
+
+
+def _ratio(numerator: int | float, denominator: int | float) -> float | None:
+    if denominator == 0:
+        return None
+    return round(float(numerator) / float(denominator), 4)
+
+
+def _per(numerator: int | float, denominator: int | float, multiplier: int) -> float | None:
+    if denominator == 0:
+        return None
+    return round((float(numerator) / float(denominator)) * multiplier, 4)

--- a/src/conductor/internal_config.py
+++ b/src/conductor/internal_config.py
@@ -1,0 +1,94 @@
+"""Internal diagnostic configuration.
+
+This module intentionally keeps internal telemetry opt-in and outside the
+stable consumer contract. The config only controls richer local ledger fields;
+basic delegation accounting remains on for normal Conductor operation.
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from pathlib import Path
+
+INTERNAL_TELEMETRY_ENV = "CONDUCTOR_INTERNAL_TELEMETRY"
+INTERNAL_CONFIG_ENV = "CONDUCTOR_INTERNAL_CONFIG"
+DEFAULT_REPO_INTERNAL_PATH = Path(".conductor") / "internal.toml"
+
+
+class InternalConfigError(ValueError):
+    """Raised when internal diagnostic config is malformed."""
+
+
+def home_internal_config_path() -> Path:
+    override = os.environ.get(INTERNAL_CONFIG_ENV)
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".config" / "conductor" / "internal.toml"
+
+
+def repo_internal_config_path(cwd: Path | None = None) -> Path:
+    root = cwd or Path.cwd()
+    return root / DEFAULT_REPO_INTERNAL_PATH
+
+
+def internal_telemetry_enabled(*, cwd: Path | None = None) -> bool:
+    """Return whether richer internal telemetry capture is enabled.
+
+    Precedence is env override, repo-local config, user config, default off.
+    Config schema:
+
+        [telemetry]
+        capture_route_decisions = true
+    """
+    env = os.environ.get(INTERNAL_TELEMETRY_ENV)
+    if env is not None:
+        return _parse_bool(env, source=INTERNAL_TELEMETRY_ENV)
+
+    for path in (repo_internal_config_path(cwd), home_internal_config_path()):
+        if not path.exists():
+            continue
+        value = _load_capture_route_decisions(path)
+        if value is not None:
+            return value
+    return False
+
+
+def _load_capture_route_decisions(path: Path) -> bool | None:
+    try:
+        with path.open("rb") as fh:
+            data = tomllib.load(fh)
+    except tomllib.TOMLDecodeError as e:
+        raise InternalConfigError(f"internal config {path} is not valid TOML: {e}") from e
+    except OSError as e:
+        raise InternalConfigError(
+            f"could not read internal config {path}: {e.strerror or e}"
+        ) from e
+
+    telemetry = data.get("telemetry")
+    if telemetry is None:
+        return None
+    if not isinstance(telemetry, dict):
+        raise InternalConfigError(f"internal config {path}: `telemetry` must be a table.")
+
+    for key in ("capture_route_decisions", "delegation_report", "enabled"):
+        if key not in telemetry:
+            continue
+        value = telemetry[key]
+        if not isinstance(value, bool):
+            raise InternalConfigError(
+                f"internal config {path}: `telemetry.{key}` must be true or false."
+            )
+        return value
+    return None
+
+
+def _parse_bool(value: str, *, source: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise InternalConfigError(
+        f"{source} must be a boolean value: 1/0, true/false, yes/no, or on/off."
+    )

--- a/src/conductor/internal_config.py
+++ b/src/conductor/internal_config.py
@@ -27,9 +27,19 @@ def home_internal_config_path() -> Path:
     return Path.home() / ".config" / "conductor" / "internal.toml"
 
 
-def repo_internal_config_path(cwd: Path | None = None) -> Path:
-    root = cwd or Path.cwd()
-    return root / DEFAULT_REPO_INTERNAL_PATH
+def repo_internal_config_path(cwd: Path | None = None) -> Path | None:
+    """Locate the nearest ``.conductor/internal.toml`` from ``cwd`` upward.
+
+    Walks parent directories so invoking Conductor from a subdirectory of the
+    repo still finds the project's internal-telemetry config. Returns None when
+    no ancestor contains one.
+    """
+    root = (cwd or Path.cwd()).resolve()
+    for candidate in [root, *root.parents]:
+        path = candidate / DEFAULT_REPO_INTERNAL_PATH
+        if path.exists():
+            return path
+    return None
 
 
 def internal_telemetry_enabled(*, cwd: Path | None = None) -> bool:
@@ -45,7 +55,12 @@ def internal_telemetry_enabled(*, cwd: Path | None = None) -> bool:
     if env is not None:
         return _parse_bool(env, source=INTERNAL_TELEMETRY_ENV)
 
-    for path in (repo_internal_config_path(cwd), home_internal_config_path()):
+    candidates: list[Path] = []
+    repo_path = repo_internal_config_path(cwd)
+    if repo_path is not None:
+        candidates.append(repo_path)
+    candidates.append(home_internal_config_path())
+    for path in candidates:
         if not path.exists():
             continue
         value = _load_capture_route_decisions(path)

--- a/tests/test_cli_delegation_ledger.py
+++ b/tests/test_cli_delegation_ledger.py
@@ -121,6 +121,7 @@ def test_exec_records_ledger_event(monkeypatch):
 
 def test_ask_records_ledger_event(monkeypatch):
     events = []
+    monkeypatch.setenv("CONDUCTOR_INTERNAL_TELEMETRY", "0")
     monkeypatch.setattr("conductor.cli.record_delegation", events.append)
     monkeypatch.setattr("conductor.cli.pick", lambda *args, **kwargs: ("codex", _decision()))
     monkeypatch.setattr(
@@ -145,6 +146,36 @@ def test_ask_records_ledger_event(monkeypatch):
     assert events[0].command == "ask"
     assert events[0].provider == "codex"
     assert events[0].status == "ok"
+    assert events[0].route is None
+
+
+def test_internal_telemetry_records_route_metadata(monkeypatch):
+    events = []
+    monkeypatch.setenv("CONDUCTOR_INTERNAL_TELEMETRY", "1")
+    monkeypatch.setattr("conductor.cli.record_delegation", events.append)
+    monkeypatch.setattr("conductor.cli.pick", lambda *args, **kwargs: ("codex", _decision()))
+    monkeypatch.setattr(
+        "conductor.cli._invoke_with_fallback",
+        lambda *args, **kwargs: (_response(provider="codex", model="gpt-test"), []),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "ask",
+            "--kind",
+            "code",
+            "--task",
+            "this is long enough for semantic exec",
+            "--no-preflight",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(events) == 1
+    assert events[0].route["provider"] == "codex"
+    assert events[0].route["ranked"][0]["name"] == "codex"
+    assert events[0].semantic["kind"] == "code"
 
 
 def test_council_records_parent_and_member_events(monkeypatch):

--- a/tests/test_delegation_ledger.py
+++ b/tests/test_delegation_ledger.py
@@ -281,3 +281,43 @@ def test_delegations_report_tag_filter(monkeypatch, tmp_path):
     payload = json.loads(result.output)
     assert payload["window"]["events"] == 1
     assert [row["provider"] for row in payload["providers"]] == ["gemini"]
+
+
+def test_delegations_report_preserves_multi_hop_fallback_chain(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    now = datetime.now(UTC).isoformat()
+    record_delegation(
+        _event(
+            delegation_id="multi-1",
+            timestamp=now,
+            command="review",
+            provider="gemini",
+            model="gemini-2.5-pro",
+            status="ok",
+            tags=["code-review"],
+            route={"provider": "codex"},
+            fallback_chain=["codex", "claude", "openrouter"],
+        )
+    )
+    record_delegation(
+        _event(
+            delegation_id="single-1",
+            timestamp=now,
+            command="review",
+            provider="gemini",
+            model="gemini-2.5-pro",
+            status="ok",
+            tags=["code-review"],
+            route={"provider": "codex"},
+            fallback_chain=["codex"],
+        )
+    )
+
+    result = CliRunner().invoke(main, ["delegations", "report", "--since", "1h", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["route_fallbacks"] == {
+        "codex->claude->openrouter->gemini": 1,
+        "codex->gemini": 1,
+    }

--- a/tests/test_delegation_ledger.py
+++ b/tests/test_delegation_ledger.py
@@ -283,6 +283,52 @@ def test_delegations_report_tag_filter(monkeypatch, tmp_path):
     assert [row["provider"] for row in payload["providers"]] == ["gemini"]
 
 
+def test_delegations_report_last_applies_after_tag_filter(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    now = datetime.now(UTC)
+    record_delegation(
+        _event(
+            delegation_id="old-tagged",
+            timestamp=(now - timedelta(minutes=30)).isoformat(),
+            provider="codex",
+            tags=["tool-use"],
+            input_tokens=100,
+            output_tokens=10,
+        )
+    )
+    for idx in range(5):
+        record_delegation(
+            _event(
+                delegation_id=f"recent-{idx}",
+                timestamp=(now - timedelta(minutes=10 - idx)).isoformat(),
+                provider="codex",
+                tags=["other"],
+                input_tokens=100,
+                output_tokens=10,
+            )
+        )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "delegations",
+            "report",
+            "--since",
+            "1h",
+            "--last",
+            "2",
+            "--tag",
+            "tool-use",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["window"]["events"] == 1
+    assert payload["window"]["events_before_tag_filter"] == 6
+
+
 def test_delegations_report_preserves_multi_hop_fallback_chain(monkeypatch, tmp_path):
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
     now = datetime.now(UTC).isoformat()

--- a/tests/test_delegation_ledger.py
+++ b/tests/test_delegation_ledger.py
@@ -179,3 +179,105 @@ def test_delegations_list_cli_filters(monkeypatch, tmp_path):
         "id3",
         "id4",
     ]
+
+
+def test_delegations_report_summarizes_token_efficiency(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    now = datetime.now(UTC).isoformat()
+    record_delegation(
+        _event(
+            delegation_id="gemini-1",
+            timestamp=now,
+            command="exec",
+            provider="gemini",
+            model="gemini-2.5-pro",
+            status="ok",
+            duration_ms=20_000,
+            input_tokens=10_000,
+            output_tokens=200,
+            thinking_tokens=1_000,
+            cost_usd=None,
+            tags=["tool-use", "code"],
+            route={"provider": "codex"},
+        )
+    )
+    record_delegation(
+        _event(
+            delegation_id="gemini-2",
+            timestamp=now,
+            command="exec",
+            provider="gemini",
+            model="gemini-2.5-pro",
+            status="error",
+            duration_ms=40_000,
+            input_tokens=20_000,
+            output_tokens=100,
+            thinking_tokens=2_000,
+            tags=["tool-use"],
+        )
+    )
+    record_delegation(
+        _event(
+            delegation_id="codex-1",
+            timestamp=now,
+            command="ask",
+            provider="codex",
+            model="gpt-5.4",
+            status="ok",
+            duration_ms=90_000,
+            input_tokens=30_000,
+            output_tokens=3_000,
+            thinking_tokens=0,
+            cost_usd=0.6,
+            tags=["code"],
+        )
+    )
+
+    result = CliRunner().invoke(main, ["delegations", "report", "--since", "1h", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    rows = {row["provider"]: row for row in payload["providers"]}
+    assert rows["gemini"]["calls"] == 2
+    assert rows["gemini"]["ok"] == 1
+    assert rows["gemini"]["non_ok"] == 1
+    assert rows["gemini"]["output_tokens_per_1k_input"] == 10.0
+    assert rows["gemini"]["input_tokens_per_output_token"] == 100.0
+    assert rows["gemini"]["ms_per_output_token"] == 200.0
+    assert rows["codex"]["cost_per_1k_output_tokens"] == 0.2
+    assert payload["route_fallbacks"] == {"codex->gemini": 1}
+
+
+def test_delegations_report_tag_filter(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    now = datetime.now(UTC).isoformat()
+    record_delegation(
+        _event(
+            delegation_id="a",
+            timestamp=now,
+            provider="gemini",
+            tags=["tool-use"],
+            input_tokens=100,
+            output_tokens=10,
+        )
+    )
+    record_delegation(
+        _event(
+            delegation_id="b",
+            timestamp=now,
+            provider="codex",
+            tags=["research"],
+            input_tokens=100,
+            output_tokens=10,
+        )
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["delegations", "report", "--since", "1h", "--tag", "tool-use", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["window"]["events"] == 1
+    assert [row["provider"] for row in payload["providers"]] == ["gemini"]

--- a/tests/test_internal_config.py
+++ b/tests/test_internal_config.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from conductor.internal_config import (
+    InternalConfigError,
+    internal_telemetry_enabled,
+)
+
+
+def test_internal_telemetry_env_overrides_configs(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    internal = repo / ".conductor" / "internal.toml"
+    internal.parent.mkdir()
+    internal.write_text(
+        "[telemetry]\ncapture_route_decisions = false\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CONDUCTOR_INTERNAL_TELEMETRY", "1")
+
+    assert internal_telemetry_enabled(cwd=repo) is True
+
+
+def test_internal_telemetry_repo_config(monkeypatch, tmp_path):
+    monkeypatch.delenv("CONDUCTOR_INTERNAL_TELEMETRY", raising=False)
+    monkeypatch.setenv("CONDUCTOR_INTERNAL_CONFIG", str(tmp_path / "missing-home.toml"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    internal = repo / ".conductor" / "internal.toml"
+    internal.parent.mkdir()
+    internal.write_text(
+        "[telemetry]\ncapture_route_decisions = true\n",
+        encoding="utf-8",
+    )
+
+    assert internal_telemetry_enabled(cwd=repo) is True
+
+
+def test_internal_telemetry_invalid_bool_raises(monkeypatch):
+    monkeypatch.setenv("CONDUCTOR_INTERNAL_TELEMETRY", "maybe")
+
+    with pytest.raises(InternalConfigError):
+        internal_telemetry_enabled(cwd=Path.cwd())

--- a/tests/test_internal_config.py
+++ b/tests/test_internal_config.py
@@ -44,3 +44,18 @@ def test_internal_telemetry_invalid_bool_raises(monkeypatch):
 
     with pytest.raises(InternalConfigError):
         internal_telemetry_enabled(cwd=Path.cwd())
+
+
+def test_internal_telemetry_found_from_subdirectory(monkeypatch, tmp_path):
+    monkeypatch.delenv("CONDUCTOR_INTERNAL_TELEMETRY", raising=False)
+    monkeypatch.setenv("CONDUCTOR_INTERNAL_CONFIG", str(tmp_path / "missing-home.toml"))
+    repo = tmp_path / "repo"
+    (repo / ".conductor").mkdir(parents=True)
+    (repo / ".conductor" / "internal.toml").write_text(
+        "[telemetry]\ncapture_route_decisions = true\n",
+        encoding="utf-8",
+    )
+    subdir = repo / "src" / "deep" / "nested"
+    subdir.mkdir(parents=True)
+
+    assert internal_telemetry_enabled(cwd=subdir) is True


### PR DESCRIPTION
Capture the router's decision and semantic plan on each delegation
event when internal telemetry is enabled, and add a diagnostic
`conductor delegations report` that aggregates token efficiency,
route selections, and fallback chains from the ledger. Capture is
gated by CONDUCTOR_INTERNAL_TELEMETRY env var, .conductor/internal.toml
(repo), or ~/.config/conductor/internal.toml (home), with env taking
precedence. The schema bumps to v2 with optional `route` and
`semantic` fields so old v1 events remain readable. Output of
`delegations report` is intentionally internal-only — not part of the
stable consumer contract. Repo-local .conductor/internal.toml turns
capture on for this project's own work.

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
