### PR TITLE
[codex] Harden OpenRouter exec delivery diagnostics

### DIFF
--- a/.cortex/state.md
+++ b/.cortex/state.md
@@ -1,15 +1,15 @@
 ---
-Generated: 2026-05-11T12:05:22-04:00
-Generator: cortex refresh-state v1.6.2
+Generated: 2026-05-13T09:13:16-04:00
+Generator: cortex refresh-state v1.6.3
 Sources:
-  - HEAD sha: 3c21713865fd55dbab3c9e51efaa999946ae78f8
+  - HEAD sha: 029862ccc1821cd399dd1c292448987aec15cc7b
   - .cortex/plans/*.md (1 files)
   - .cortex/journal/*.md (24 entries, 2026-04-24..2026-05-11)
   - .cortex/doctrine/*.md (6 entries)
   - .cortex/templates/**/*.md (12 templates)
   - docs/case-studies/*.md (0 case studies)
   - SPEC version: 0.5.0
-  - pyproject.toml: conductor + cortex package version: 1.6.2
+  - pyproject.toml: conductor + cortex package version: 1.6.3
 Sources-hash:
   .cortex/doctrine/0001-readme.md: 6ba51021185ac81b252780f755f85f6afe388518f9c90009a0b14c1e60b54153
   .cortex/doctrine/0002-audit-weak-points.md: 9d0dbf91fd4af7b42c1e16ecefae6ab228f369bf83d70ca2019de59c60947d55

--- a/.cursor/rules/conductor-delegation.mdc
+++ b/.cursor/rules/conductor-delegation.mdc
@@ -2,7 +2,7 @@
 description: Use when delegating or routing tasks to a different LLM via the conductor CLI — e.g., cheap second opinions, long-context reads, web search, or offline runs.
 globs: ""
 alwaysApply: false
-managed-by: conductor v0.10.19
+managed-by: conductor v0.10.20
 ---
 
 # Conductor delegation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ If there are zero blocking issues, the review is just: "LGTM."
 
 @.cortex/protocol.md
 
-<!-- conductor:begin v0.10.19 -->
+<!-- conductor:begin v0.10.20 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
 
-<!-- conductor:begin v0.10.19 -->
+<!-- conductor:begin v0.10.20 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ expected output, and validation. Conductor only sees the brief you pass
 plus any files the delegated provider can inspect; it does not inherit
 the caller's conversation context. Existing `--task` / `--task-file`
 flags remain supported as compatibility aliases.
+Headless orchestrators can run repo-changing work with
+`conductor exec --brief-file /tmp/brief.md`.
 
 ## v0.1 scope
 

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -5712,6 +5712,13 @@ SWARM_SUCCESS_STATUSES = frozenset({"shipped", "no-changes"})
 SWARM_PROVIDER_FAILED_STATUS = "provider-failed"
 SWARM_CONFLICT_STATUS = "needs-human-conflict-resolution"
 SWARM_VALIDATION_FAILED_STATUS = "validation-failed"
+SWARM_DELIVERY_CONTRACT = """
+Conductor swarm delivery contract:
+- Commit all intended changes before your final answer.
+- Leave the worktree clean.
+- Do not open a pull request; conductor swarm opens and merges PRs after exec succeeds.
+- If no code changes are needed, say that explicitly in the final answer.
+""".strip()
 SWARM_BRANCH_PREFIX = "feat/swarm"
 SWARM_WORKTREE_LOCK = threading.Lock()
 SWARM_MANIFEST_LOCK = threading.Lock()
@@ -5723,6 +5730,14 @@ SWARM_METRICS_SCHEMA_VERSION = 1
 SWARM_PREFLIGHT_SCHEMA_VERSION = 1
 SWARM_MERGE_PLAN_SCHEMA_VERSION = 1
 SWARM_CORTEX_BOOKKEEPING_SCHEMA_VERSION = 1
+
+
+def _with_swarm_delivery_contract(body: str) -> str:
+    if "Conductor swarm delivery contract:" in body:
+        return body
+    return f"{body.rstrip()}\n\n{SWARM_DELIVERY_CONTRACT}"
+
+
 SWARM_PREFLIGHT_SUBSYSTEMS = frozenset(
     {
         "swarm",
@@ -8729,6 +8744,7 @@ def _run_swarm_task(
         brief_path=brief,
         repo_slug=_swarm_github_repo_slug(repo_root),
     )
+    dispatch_body = _with_swarm_delivery_contract(body)
 
     created_worktree = False
     status = "failed"
@@ -8800,9 +8816,9 @@ def _run_swarm_task(
                     strict_stall=False,
                     start_timeout_sec=None,
                     max_iterations=max_iterations,
-                    allow_completion_stretch=False,
+                    allow_completion_stretch=True,
                     retry_on_stall=1,
-                    body=body,
+                    body=dispatch_body,
                     attachments=(),
                     model=None,
                     log_file=None,

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -4524,6 +4524,18 @@ def ask(
 
     tools_set = plan.tools
     sandbox_value = plan.sandbox
+    if plan.mode == "exec" and brief_declares_read_only_text_output(body):
+        read_only_tools = EXEC_PERMISSION_PROFILES["read-only"]
+        narrowed = tools_set & read_only_tools
+        if narrowed:
+            tools_set = narrowed
+            sandbox_value = "read-only"
+            if not (silent_route or as_json):
+                click.echo(
+                    "[conductor] read-only brief detected; restricting exec "
+                    f"tools to {_ordered_tools_csv(tools_set)}",
+                    err=True,
+                )
     exclude_set = _semantic_candidate_exclude_set(plan, frozenset())
     try:
         provider, decision = pick(

--- a/src/conductor/exec_completion.py
+++ b/src/conductor/exec_completion.py
@@ -126,7 +126,8 @@ def detect_missing_deliverables(
 
     missing: list[MissingDeliverable] = []
     changed = tuple(changed_paths)
-    tool_calls = list(recent_tool_calls)[-RECENT_TOOL_CALL_LIMIT:]
+    all_tool_calls = list(recent_tool_calls)
+    tool_calls = all_tool_calls[-RECENT_TOOL_CALL_LIMIT:]
     if (
         _brief_requests_tests(brief)
         and not brief_declares_read_only_text_output(brief)
@@ -163,6 +164,16 @@ def detect_missing_deliverables(
                 "shipping",
                 "Brief asks to ship via `bash scripts/open-pr.sh --auto-merge`; "
                 "push/PR shipping command not invoked in this session.",
+            )
+        )
+
+    if _brief_requests_committed_work(brief) and not _recent_git_commit_invoked(
+        all_tool_calls
+    ):
+        missing.append(
+            MissingDeliverable(
+                "commit",
+                "Brief asks for committed work; `git commit` not invoked in this session.",
             )
         )
 
@@ -306,6 +317,15 @@ def _brief_requests_open_pr_ship(brief: str) -> bool:
     )
 
 
+def _brief_requests_committed_work(brief: str) -> bool:
+    patterns = (
+        r"(?i)\bcommit\s+all\s+intended\s+changes\b",
+        r"(?i)\bcommit\s+(?:your|the|all)\s+(?:changes|work)\b",
+        r"(?i)\bleave\s+the\s+worktree\s+clean\b",
+    )
+    return any(re.search(pattern, brief) for pattern in patterns)
+
+
 def _recent_bash_invoked(tool_calls: Iterable[dict[str, object]], command: str) -> bool:
     needle = _normalize_command(command)
     for call in tool_calls:
@@ -327,6 +347,16 @@ def _recent_shipping_invoked(tool_calls: Iterable[dict[str, object]]) -> bool:
         saw_push = saw_push or "git push" in command
         saw_pr = saw_pr or "gh pr" in command or "scripts/open-pr.sh --auto-merge" in command
     return saw_push and saw_pr
+
+
+def _recent_git_commit_invoked(tool_calls: Iterable[dict[str, object]]) -> bool:
+    for call in tool_calls:
+        if call.get("name") != "Bash":
+            continue
+        command = _normalize_command(_tool_call_command(call))
+        if re.search(r"\bgit\b.*\bcommit\b", command):
+            return True
+    return False
 
 
 def _tool_call_command(call: dict[str, object]) -> str:

--- a/src/conductor/exec_completion.py
+++ b/src/conductor/exec_completion.py
@@ -33,18 +33,37 @@ class MissingDeliverable:
     message: str
 
 
+@dataclass(frozen=True)
+class CapDiagnostics:
+    """Operator-facing state captured when a managed exec loop hits its cap."""
+
+    tool_usage: dict[str, int]
+    git_state: dict[str, object]
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "tool_usage": dict(self.tool_usage),
+            "git_state": dict(self.git_state),
+        }
+
+
 def changed_paths_for_completion_scan(cwd: Path) -> tuple[str, ...]:
     """Return changed paths relative to ``cwd`` for completion heuristics.
 
     Git failures are logged and degrade to no changed paths so the original cap
     behavior can still surface. Untracked files are included because agents
-    often create new tests before staging them.
+    often create new tests before staging them. Committed branch changes are
+    included when a default branch can be resolved so a clean worktree with
+    commits is not misread as no progress.
     """
 
-    commands = (
+    commands: list[list[str]] = [
         ["git", "diff", "--name-only", "HEAD"],
         ["git", "ls-files", "--others", "--exclude-standard"],
-    )
+    ]
+    base_ref = _default_branch_ref(cwd)
+    if base_ref is not None:
+        commands.append(["git", "diff", "--name-only", f"{base_ref}...HEAD"])
     paths: list[str] = []
     for command in commands:
         try:
@@ -76,6 +95,24 @@ def changed_paths_for_completion_scan(cwd: Path) -> tuple[str, ...]:
     return tuple(dict.fromkeys(paths))
 
 
+def cap_diagnostics_for_completion_scan(
+    cwd: Path,
+    *,
+    recent_tool_calls: Iterable[dict[str, object]],
+) -> CapDiagnostics:
+    """Return cap-time tool and git state diagnostics.
+
+    Invariant: diagnostic collection must never mask the original iteration-cap
+    failure; every failed git probe is logged and represented in the returned
+    payload.
+    """
+
+    return CapDiagnostics(
+        tool_usage=_tool_usage_counts(recent_tool_calls),
+        git_state=_git_state_at_cap(cwd),
+    )
+
+
 def detect_missing_deliverables(
     brief: str,
     *,
@@ -88,18 +125,27 @@ def detect_missing_deliverables(
     """
 
     missing: list[MissingDeliverable] = []
+    changed = tuple(changed_paths)
     tool_calls = list(recent_tool_calls)[-RECENT_TOOL_CALL_LIMIT:]
     if (
         _brief_requests_tests(brief)
         and not brief_declares_read_only_text_output(brief)
-        and not _has_test_path_change(changed_paths)
+        and not _has_test_path_change(changed)
     ):
-        missing.append(
-            MissingDeliverable(
-                "tests",
-                "Tests requested in brief; diff did not add to tests/.",
+        if changed:
+            missing.append(
+                MissingDeliverable(
+                    "tests",
+                    "Tests requested in brief; diff did not add to tests/.",
+                )
             )
-        )
+        else:
+            missing.append(
+                MissingDeliverable(
+                    "changes",
+                    "Agent made no changes before the iteration cap.",
+                )
+            )
 
     if not _review_preflight_already_passed(brief):
         for command in _requested_validation_commands(brief):
@@ -126,11 +172,15 @@ def detect_missing_deliverables(
 def format_missing_deliverables_cap_message(
     iteration_cap: int,
     missing: Iterable[MissingDeliverable],
+    diagnostics: CapDiagnostics | dict[str, object] | None = None,
 ) -> str:
     message = (
         f"[conductor] Reached --max-iterations cap ({iteration_cap}). "
         "Re-run with --max-iterations <larger> or split the brief."
     )
+    diagnostic_text = _format_cap_diagnostics(iteration_cap, diagnostics)
+    if diagnostic_text:
+        message = f"{message}\n{diagnostic_text}"
     items = list(missing)
     if not items:
         return message
@@ -285,6 +335,162 @@ def _tool_call_command(call: dict[str, object]) -> str:
         value = args.get("command")
         return value if isinstance(value, str) else ""
     return ""
+
+
+def _tool_usage_counts(tool_calls: Iterable[dict[str, object]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for call in tool_calls:
+        name = call.get("name")
+        if not isinstance(name, str) or not name:
+            name = "<unknown>"
+        counts[name] = counts.get(name, 0) + 1
+
+    preferred = ("Read", "Grep", "Glob", "Edit", "Write", "Bash")
+    ordered: dict[str, int] = {}
+    for name in preferred:
+        if name in counts:
+            ordered[name] = counts.pop(name)
+    for name in sorted(counts):
+        ordered[name] = counts[name]
+    return ordered
+
+
+def _git_state_at_cap(cwd: Path) -> dict[str, object]:
+    status = _run_git(["status", "--porcelain"], cwd)
+    if status is None:
+        return {
+            "available": False,
+            "error": "git status failed",
+        }
+
+    tracked_changes = 0
+    untracked = 0
+    for line in status.splitlines():
+        if line.startswith("?? "):
+            untracked += 1
+        elif line.strip():
+            tracked_changes += 1
+
+    base_ref = _default_branch_ref(cwd)
+    commits_on_branch: int | None = None
+    commit_error: str | None = None
+    if base_ref is None:
+        commit_error = "default branch unavailable"
+    else:
+        raw_count = _run_git(["rev-list", "--count", f"{base_ref}..HEAD"], cwd)
+        if raw_count is None:
+            commit_error = f"git rev-list failed for {base_ref}..HEAD"
+        else:
+            try:
+                commits_on_branch = int(raw_count.strip())
+            except ValueError:
+                commit_error = f"unexpected git rev-list output: {raw_count!r}"
+                _LOG.warning(
+                    "cap diagnostic git rev-list returned unexpected output: cwd=%s output=%r",
+                    cwd,
+                    raw_count,
+                )
+
+    state: dict[str, object] = {
+        "available": True,
+        "base_ref": base_ref,
+        "commits_on_branch": commits_on_branch,
+        "modified_files": tracked_changes,
+        "untracked_files": untracked,
+    }
+    if commit_error is not None:
+        state["commit_error"] = commit_error
+    return state
+
+
+def _default_branch_ref(cwd: Path) -> str | None:
+    origin_head = _run_git(
+        ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+        cwd,
+        log_failure=False,
+    )
+    if origin_head:
+        return origin_head.strip()
+
+    for ref in ("origin/main", "origin/master", "main", "master"):
+        if _run_git(["rev-parse", "--verify", "--quiet", ref], cwd, log_failure=False):
+            return ref
+    _LOG.info("completion scan could not resolve default branch in %s", cwd)
+    return None
+
+
+def _run_git(
+    args: list[str],
+    cwd: Path,
+    *,
+    log_failure: bool = True,
+) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        _LOG.warning(
+            "completion scan could not run git %s in %s: %r",
+            " ".join(args),
+            cwd,
+            e,
+        )
+        return None
+    if result.returncode != 0:
+        if log_failure:
+            _LOG.warning(
+                "completion scan git command failed: command=git %s cwd=%s stderr=%s",
+                " ".join(args),
+                cwd,
+                result.stderr.strip()[:500],
+            )
+        return None
+    return result.stdout
+
+
+def _format_cap_diagnostics(
+    iteration_cap: int,
+    diagnostics: CapDiagnostics | dict[str, object] | None,
+) -> str:
+    if diagnostics is None:
+        return ""
+    raw = diagnostics.as_dict() if isinstance(diagnostics, CapDiagnostics) else diagnostics
+
+    tool_usage = raw.get("tool_usage")
+    if isinstance(tool_usage, dict) and tool_usage:
+        tool_text = " ".join(f"{name}={count}" for name, count in tool_usage.items())
+    else:
+        tool_text = "none"
+
+    lines = [
+        f"[conductor] iteration cap hit at {iteration_cap}. Tool usage: {tool_text}"
+    ]
+    git_state = raw.get("git_state")
+    if isinstance(git_state, dict):
+        if git_state.get("available") is True:
+            line = (
+                "[conductor] git state at cap-fire: "
+                f"commits-on-branch={git_state.get('commits_on_branch')}, "
+                f"modified-files={git_state.get('modified_files')}, "
+                f"untracked-files={git_state.get('untracked_files')}"
+            )
+            base_ref = git_state.get("base_ref")
+            if base_ref:
+                line += f", base={base_ref}"
+            commit_error = git_state.get("commit_error")
+            if commit_error:
+                line += f", commit-count={commit_error}"
+            lines.append(line)
+        else:
+            error = git_state.get("error") or "unknown"
+            lines.append(f"[conductor] git state at cap-fire: unavailable ({error})")
+    return "\n".join(lines)
 
 
 def _normalize_command(command: str) -> str:

--- a/src/conductor/providers/ollama.py
+++ b/src/conductor/providers/ollama.py
@@ -23,7 +23,9 @@ from typing import TYPE_CHECKING
 import httpx
 
 from conductor.exec_completion import (
+    CapDiagnostics,
     MissingDeliverable,
+    cap_diagnostics_for_completion_scan,
     changed_paths_for_completion_scan,
     completion_stretch_prompt,
     detect_missing_deliverables,
@@ -550,6 +552,7 @@ class OllamaProvider:
         hit_context_budget = False
         recent_tool_calls: list[dict[str, object]] = []
         missing_deliverables: list[MissingDeliverable] = []
+        cap_diagnostics: CapDiagnostics | None = None
         completion_stretched = False
         prompt_tokens = 0
         context_ceiling = int(
@@ -741,10 +744,15 @@ class OllamaProvider:
             hit_cap = True
 
         if hit_cap:
+            cap_diagnostics = cap_diagnostics_for_completion_scan(
+                workdir,
+                recent_tool_calls=recent_tool_calls,
+            )
             final_text = (final_text or "(no content)") + "\n\n" + (
                 format_missing_deliverables_cap_message(
                     original_iteration_cap,
                     missing_deliverables,
+                    cap_diagnostics,
                 )
             )
         if hit_context_budget:
@@ -776,6 +784,9 @@ class OllamaProvider:
                 "missing_deliverables": [
                     item.__dict__ for item in missing_deliverables
                 ],
+                "cap_diagnostics": (
+                    cap_diagnostics.as_dict() if cap_diagnostics is not None else None
+                ),
                 "hit_context_budget": hit_context_budget,
                 "iterations": iterations_log,
             },

--- a/src/conductor/providers/openrouter.py
+++ b/src/conductor/providers/openrouter.py
@@ -20,7 +20,9 @@ import httpx
 
 from conductor import credentials
 from conductor.exec_completion import (
+    CapDiagnostics,
     MissingDeliverable,
+    cap_diagnostics_for_completion_scan,
     changed_paths_for_completion_scan,
     completion_stretch_prompt,
     detect_missing_deliverables,
@@ -500,6 +502,7 @@ class OpenRouterProvider:
         validation_failures: list[dict[str, object]] = []
         recent_tool_calls: list[dict[str, object]] = []
         missing_deliverables: list[MissingDeliverable] = []
+        cap_diagnostics: CapDiagnostics | None = None
         empty_response_retries: list[dict[str, object]] = []
         completion_stretched = False
         terminal_answer_stretched = False
@@ -756,10 +759,15 @@ class OpenRouterProvider:
             hit_cap = True
 
         if hit_cap:
+            cap_diagnostics = cap_diagnostics_for_completion_scan(
+                workdir,
+                recent_tool_calls=recent_tool_calls,
+            )
             final_text = (final_text or "(no content)") + "\n\n" + (
                 format_missing_deliverables_cap_message(
                     original_iteration_cap,
                     missing_deliverables,
+                    cap_diagnostics,
                 )
             )
 
@@ -776,6 +784,7 @@ class OpenRouterProvider:
             git_status_before=git_status_before,
             git_status_after=git_status_after,
             missing_deliverables=missing_deliverables,
+            cap_diagnostics=cap_diagnostics,
         )
         duration_ms = int((time.monotonic() - start) * 1000)
         execution_status["duration_ms"] = duration_ms
@@ -813,6 +822,9 @@ class OpenRouterProvider:
                 "missing_deliverables": [
                     item.__dict__ for item in missing_deliverables
                 ],
+                "cap_diagnostics": (
+                    cap_diagnostics.as_dict() if cap_diagnostics is not None else None
+                ),
                 "tool_call_count": tool_call_count,
                 "write_success_count": write_success_count,
                 "tool_error_count": len(tool_errors),
@@ -1012,6 +1024,7 @@ def _execution_status(
     git_status_before: dict[str, object] | None,
     git_status_after: dict[str, object] | None,
     missing_deliverables: list[MissingDeliverable],
+    cap_diagnostics: CapDiagnostics | None,
 ) -> dict[str, object]:
     state = "completed"
     after_clean = (
@@ -1042,6 +1055,9 @@ def _execution_status(
         "hit_iteration_cap": hit_cap,
         "iteration_cap": iteration_cap,
         "missing_deliverables": [item.__dict__ for item in missing_deliverables],
+        "cap_diagnostics": (
+            cap_diagnostics.as_dict() if cap_diagnostics is not None else None
+        ),
         "git_status_before": git_status_before,
         "git_status_after": git_status_after,
     }
@@ -1064,6 +1080,7 @@ def _execution_failure_message(status: dict[str, object]) -> str | None:
         return format_missing_deliverables_cap_message(
             int(cap) if isinstance(cap, int) else 0,
             missing,
+            status.get("cap_diagnostics"),
         )
     if state == "tool-call-leak":
         return (

--- a/src/conductor/providers/openrouter.py
+++ b/src/conductor/providers/openrouter.py
@@ -521,6 +521,8 @@ class OpenRouterProvider:
                 "tools": tool_specs,
                 "tool_choice": "auto",
             }
+            if tools & {"Bash", "Edit", "Write"}:
+                payload["parallel_tool_calls"] = False
             body = self._post_chat(
                 payload,
                 timeout_sec=_remaining_timeout_sec(

--- a/src/conductor/providers/openrouter.py
+++ b/src/conductor/providers/openrouter.py
@@ -14,7 +14,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import httpx
 
@@ -1079,10 +1079,16 @@ def _execution_failure_message(status: dict[str, object]) -> str | None:
             for item in missing_items
             if isinstance(item, dict)
         ]
+        raw_cap_diagnostics = status.get("cap_diagnostics")
+        cap_diagnostics = (
+            cast("dict[str, object]", raw_cap_diagnostics)
+            if isinstance(raw_cap_diagnostics, dict)
+            else None
+        )
         return format_missing_deliverables_cap_message(
             int(cap) if isinstance(cap, int) else 0,
             missing,
-            status.get("cap_diagnostics"),
+            cap_diagnostics,
         )
     if state == "tool-call-leak":
         return (

--- a/tests/test_cli_swarm.py
+++ b/tests/test_cli_swarm.py
@@ -114,13 +114,17 @@ def _commit_change(worktree: Path, filename: str, message: str) -> None:
     _git(worktree, "commit", "-m", message)
 
 
+def _swarm_original_body(body: str) -> str:
+    return body.split(f"\n\n{cli.SWARM_DELIVERY_CONTRACT}", 1)[0]
+
+
 def _fake_exec_factory(*, fail_on: set[str] | None = None, no_change_on: set[str] | None = None):
     fail_on = fail_on or set()
     no_change_on = no_change_on or set()
 
     def fake_exec(**kwargs):
         worktree = Path(kwargs["cwd"])
-        body = kwargs["body"]
+        body = _swarm_original_body(kwargs["body"])
         if body in fail_on:
             raise cli._ExecPhaseError(
                 exit_code=1,
@@ -538,7 +542,19 @@ def test_swarm_one_brief_succeeds_as_shipped(monkeypatch, tmp_path: Path) -> Non
     repo = _repo(tmp_path)
     brief = _brief(repo, "foo.md")
     monkeypatch.chdir(repo)
-    monkeypatch.setattr(cli, "_run_exec_phase_dispatch", _fake_exec_factory())
+    seen: dict[str, object] = {}
+
+    def fake_exec(**kwargs):
+        seen.update(kwargs)
+        worktree = Path(kwargs["cwd"])
+        _commit_change(worktree, "foo.txt", "foo")
+        return (
+            CallResponse(text="done", provider=kwargs["provider_id"], model="test", duration_ms=1),
+            None,
+            None,
+        )
+
+    monkeypatch.setattr(cli, "_run_exec_phase_dispatch", fake_exec)
     monkeypatch.setattr(cli, "_ship_swarm_pr", _fake_merged_ship(repo))
 
     result = CliRunner().invoke(
@@ -552,6 +568,9 @@ def test_swarm_one_brief_succeeds_as_shipped(monkeypatch, tmp_path: Path) -> Non
     assert payload["shipped_count"] == 1
     assert payload["tasks"][0]["status"] == "shipped"
     assert payload["tasks"][0]["commits"] == 1
+    assert seen["allow_completion_stretch"] is True
+    assert "Conductor swarm delivery contract:" in str(seen["body"])
+    assert "Commit all intended changes" in str(seen["body"])
     assert not Path(payload["tasks"][0]["worktree"]).exists()
     assert (
         _git_returncode(repo, "show-ref", "--verify", "--quiet", "refs/heads/feat/swarm/foo")
@@ -2247,7 +2266,7 @@ def test_swarm_auto_merge_marks_rebase_conflict_for_human_recovery(
 
     def fake_exec(**kwargs):
         worktree = Path(kwargs["cwd"])
-        body = kwargs["body"]
+        body = _swarm_original_body(kwargs["body"])
         value = "first\n" if body.startswith("first lane") else "second\n"
         (worktree / "conflict.txt").write_text(value, encoding="utf-8")
         _git(worktree, "add", "conflict.txt")
@@ -2584,7 +2603,7 @@ def test_swarm_max_parallel_runs_tasks_concurrently(monkeypatch, tmp_path: Path)
 
     def fake_exec(**kwargs):
         worktree = Path(kwargs["cwd"])
-        body = kwargs["body"]
+        body = _swarm_original_body(kwargs["body"])
         with started_lock:
             started.add(body)
             if len(started) == 2:

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -648,6 +648,34 @@ def test_ask_code_high_routes_to_codex_exec_with_default_tools(mocker):
     assert exec_mock.call_args.kwargs["sandbox"] == "none"
 
 
+def test_ask_code_high_read_only_brief_restricts_exec_tools(mocker):
+    _stub_all_configured(mocker, {"codex"})
+    exec_mock = mocker.patch.object(CodexProvider, "exec", return_value=_fake_response("codex"))
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "ask",
+            "--kind",
+            "code",
+            "--effort",
+            "high",
+            "--allow-short-brief",
+            "--brief",
+            (
+                "Read-only advisory task. Do not modify files. "
+                "Inspect the repo and recommend the schema/stage approach."
+            ),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert exec_mock.called
+    assert exec_mock.call_args.kwargs["tools"] == frozenset({"Read", "Grep", "Glob"})
+    assert exec_mock.call_args.kwargs["sandbox"] == "read-only"
+    assert "read-only brief detected; restricting exec tools to Read,Grep,Glob" in result.stderr
+
+
 def test_ask_code_high_falls_back_immediately_to_openrouter_on_quota(mocker):
     from conductor.providers.interface import ProviderHTTPError
 

--- a/tests/test_exec_completion.py
+++ b/tests/test_exec_completion.py
@@ -81,6 +81,35 @@ def test_cap_diagnostics_format_tool_usage_and_git_state(tmp_path: Path) -> None
     assert "untracked-files=1" in text
 
 
+def test_committed_work_request_without_git_commit_is_flagged() -> None:
+    missing = detect_missing_deliverables(
+        (
+            "Conductor swarm delivery contract:\n"
+            "- Commit all intended changes before your final answer.\n"
+            "- Leave the worktree clean."
+        ),
+        changed_paths=("src/conductor/foo.py",),
+        recent_tool_calls=[{"name": "Write", "args": {"path": "src/conductor/foo.py"}}],
+    )
+
+    assert [item.kind for item in missing] == ["commit"]
+    assert "`git commit` not invoked" in missing[0].message
+
+
+def test_committed_work_request_accepts_git_commit_from_any_prior_turn() -> None:
+    older_calls = [{"name": "Read", "args": {"path": f"file-{idx}.py"}} for idx in range(25)]
+    missing = detect_missing_deliverables(
+        "Commit all intended changes before your final answer.",
+        changed_paths=("src/conductor/foo.py",),
+        recent_tool_calls=[
+            {"name": "Bash", "args": {"command": "git add . && git commit -m fix"}},
+            *older_calls,
+        ],
+    )
+
+    assert missing == []
+
+
 def test_read_only_test_recommendations_do_not_require_test_path_change() -> None:
     missing = detect_missing_deliverables(
         (

--- a/tests/test_exec_completion.py
+++ b/tests/test_exec_completion.py
@@ -97,7 +97,9 @@ def test_committed_work_request_without_git_commit_is_flagged() -> None:
 
 
 def test_committed_work_request_accepts_git_commit_from_any_prior_turn() -> None:
-    older_calls = [{"name": "Read", "args": {"path": f"file-{idx}.py"}} for idx in range(25)]
+    older_calls: list[dict[str, object]] = [
+        {"name": "Read", "args": {"path": f"file-{idx}.py"}} for idx in range(25)
+    ]
     missing = detect_missing_deliverables(
         "Commit all intended changes before your final answer.",
         changed_paths=("src/conductor/foo.py",),

--- a/tests/test_exec_completion.py
+++ b/tests/test_exec_completion.py
@@ -23,6 +23,13 @@ def _init_git(path: Path) -> None:
         "GIT_COMMITTER_EMAIL": "tester@example.com",
     }
     subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, env=env, check=True)
+    subprocess.run(["git", "config", "user.name", "Tester"], cwd=path, env=env, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "tester@example.com"],
+        cwd=path,
+        env=env,
+        check=True,
+    )
     subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=path, env=env, check=True)
     (path / "README.md").write_text("base\n", encoding="utf-8")
     subprocess.run(["git", "add", "README.md"], cwd=path, env=env, check=True)

--- a/tests/test_exec_completion.py
+++ b/tests/test_exec_completion.py
@@ -1,9 +1,32 @@
 from __future__ import annotations
 
+import subprocess
+from typing import TYPE_CHECKING
+
 from conductor.exec_completion import (
     brief_declares_read_only_text_output,
+    cap_diagnostics_for_completion_scan,
+    changed_paths_for_completion_scan,
     detect_missing_deliverables,
+    format_missing_deliverables_cap_message,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _init_git(path: Path) -> None:
+    env = {
+        "GIT_AUTHOR_NAME": "Tester",
+        "GIT_AUTHOR_EMAIL": "tester@example.com",
+        "GIT_COMMITTER_NAME": "Tester",
+        "GIT_COMMITTER_EMAIL": "tester@example.com",
+    }
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, env=env, check=True)
+    subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=path, env=env, check=True)
+    (path / "README.md").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=path, env=env, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "base"], cwd=path, env=env, check=True)
 
 
 def test_tests_requested_without_test_path_change_is_flagged() -> None:
@@ -15,6 +38,47 @@ def test_tests_requested_without_test_path_change_is_flagged() -> None:
 
     assert [item.kind for item in missing] == ["tests"]
     assert "diff did not add to tests/" in missing[0].message
+
+
+def test_tests_requested_with_empty_diff_reports_no_changes() -> None:
+    missing = detect_missing_deliverables(
+        "Implement it.\n\n## Tests\nAdd regression coverage.",
+        changed_paths=(),
+        recent_tool_calls=[],
+    )
+
+    assert [item.kind for item in missing] == ["changes"]
+    assert missing[0].message == "Agent made no changes before the iteration cap."
+
+
+def test_changed_paths_include_committed_branch_changes(tmp_path: Path) -> None:
+    _init_git(tmp_path)
+    subprocess.run(["git", "switch", "-q", "-c", "feature"], cwd=tmp_path, check=True)
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_feature.py").write_text("def test_it():\n    pass\n")
+    subprocess.run(["git", "add", "tests/test_feature.py"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "add test"], cwd=tmp_path, check=True)
+
+    assert changed_paths_for_completion_scan(tmp_path) == ("tests/test_feature.py",)
+
+
+def test_cap_diagnostics_format_tool_usage_and_git_state(tmp_path: Path) -> None:
+    _init_git(tmp_path)
+    (tmp_path / "scratch.txt").write_text("wip\n", encoding="utf-8")
+    diagnostics = cap_diagnostics_for_completion_scan(
+        tmp_path,
+        recent_tool_calls=[
+            {"name": "Read", "args": {"path": "README.md"}},
+            {"name": "Bash", "args": {"command": "pytest"}},
+            {"name": "Read", "args": {"path": "README.md"}},
+        ],
+    )
+
+    text = format_missing_deliverables_cap_message(60, [], diagnostics)
+
+    assert "Tool usage: Read=2 Bash=1" in text
+    assert "git state at cap-fire: commits-on-branch=0" in text
+    assert "untracked-files=1" in text
 
 
 def test_read_only_test_recommendations_do_not_require_test_path_change() -> None:

--- a/tests/test_openrouter.py
+++ b/tests/test_openrouter.py
@@ -1419,6 +1419,64 @@ def test_exec_iteration_cap_reports_missing_tests(configured, tmp_path):
     assert "Detected unfinished items" in str(exc.value)
 
 
+def test_exec_iteration_cap_reports_no_changes_and_cap_diagnostics(
+    configured, tmp_path
+):
+    _init_clean_git_repo(tmp_path)
+    response = {
+        "model": "openai/gpt-5.5",
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_read",
+                            "type": "function",
+                            "function": {
+                                "name": "Read",
+                                "arguments": json.dumps({"path": "README.md"}),
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 2},
+    }
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.post("/chat/completions").mock(
+            return_value=httpx.Response(200, json=response)
+        )
+        with pytest.raises(ProviderExecutionError) as exc:
+            OpenRouterProvider().exec(
+                "Implement it.\n\n## Tests\nAdd tests.",
+                model="openai/gpt-5.5",
+                tools=frozenset({"Read"}),
+                task_tags=("code", "tool-use"),
+                sandbox="none",
+                cwd=str(tmp_path),
+                max_iterations=1,
+            )
+
+    status = exc.value.status
+    assert status["missing_deliverables"] == [
+        {
+            "kind": "changes",
+            "message": "Agent made no changes before the iteration cap.",
+        }
+    ]
+    assert status["cap_diagnostics"]["tool_usage"] == {"Read": 1}
+    assert status["cap_diagnostics"]["git_state"]["modified_files"] == 0
+    assert status["cap_diagnostics"]["git_state"]["untracked_files"] == 0
+    assert "Tool usage: Read=1" in str(exc.value)
+    assert "Agent made no changes" in str(exc.value)
+    assert "diff did not add to tests/" not in str(exc.value)
+
+
 def test_exec_iteration_cap_does_not_require_tests_for_read_only_recommendations(
     configured, tmp_path
 ):

--- a/tests/test_openrouter.py
+++ b/tests/test_openrouter.py
@@ -662,6 +662,7 @@ def test_exec_with_tools_runs_openai_tool_loop(configured, tmp_path):
     assert response.usage["iterations"][1]["cost_usd"] == pytest.approx(0.002)
     assert response.cost_usd == pytest.approx(0.003)
     assert requests[0]["tools"][0]["function"]["name"] == "Read"
+    assert "parallel_tool_calls" not in requests[0]
     assert requests[1]["messages"][1]["tool_calls"][0]["id"] == "call_read"
     assert requests[1]["messages"][2] == {
         "role": "tool",
@@ -669,6 +670,67 @@ def test_exec_with_tools_runs_openai_tool_loop(configured, tmp_path):
         "name": "Read",
         "content": "tool loop works",
     }
+
+
+def test_exec_with_write_tools_disables_parallel_tool_calls(configured, tmp_path):
+    (tmp_path / "README.md").write_text("base\n", encoding="utf-8")
+    requests: list[dict] = []
+    responses = [
+        {
+            "model": "openai/gpt-5.5",
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call_write",
+                                "type": "function",
+                                "function": {
+                                    "name": "Write",
+                                    "arguments": json.dumps(
+                                        {"path": "README.md", "content": "updated\n"}
+                                    ),
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 2},
+        },
+        {
+            "model": "openai/gpt-5.5",
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "done"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 20, "completion_tokens": 3},
+        },
+    ]
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content))
+        return httpx.Response(200, json=responses[len(requests) - 1])
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.post("/chat/completions").mock(side_effect=_record)
+        response = OpenRouterProvider().exec(
+            "Update README.md.",
+            model="openai/gpt-5.5",
+            tools=frozenset({"Read", "Write"}),
+            sandbox="none",
+            cwd=str(tmp_path),
+            max_iterations=2,
+        )
+
+    assert response.text == "done"
+    assert requests[0]["parallel_tool_calls"] is False
+    assert requests[1]["parallel_tool_calls"] is False
 
 
 def test_exec_without_tools_passes_timeout_to_call(configured, mocker):


### PR DESCRIPTION
## Summary

This fixes the OpenRouter/swarm failure mode as a delivery-boundary problem, not just a larger iteration cap.

Root causes addressed:

- OpenRouter managed exec loops hit the iteration cap without enough operator-visible state to distinguish no progress, dirty progress, and committed work.
- Semantic read-only code briefs could fall through to write-capable exec fallback, which made read-only diagnosis look like implementation work.
- Swarm delegated the commit/clean-worktree delivery requirement to a stateless chat tool loop without putting that contract in the delegated brief or completion heuristic.
- OpenRouter write-capable tool use left parallel tool calls provider/model-defaulted, which is unsafe for local filesystem mutation.

Changes:

- Adds cap diagnostics for tool usage and git state when managed loops hit the cap.
- Scans committed branch changes so clean worktrees with commits are not misread as no progress.
- Adds explicit read-only routing for high-effort semantic code briefs that ask for text-only/no-edit output.
- Injects a swarm delivery contract requiring committed intended changes and a clean worktree.
- Allows one completion stretch for swarm tasks when commit delivery is missing.
- Disables `parallel_tool_calls` for OpenRouter write-capable exec tools.
- Documents headless `conductor exec --brief-file` usage for orchestrators and refreshes generated integration/state metadata.

Refs #394
Closes #395
Refs #403

## Validation

- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest -q` (`1245 passed, 15 skipped`)
- pre-push hooks: branch naming, AI default-branch push review, Touchstone project validation