### PR TITLE
[codex] Let swarm commit dirty task worktrees

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -6627,6 +6627,47 @@ def _swarm_dirty_paths(worktree: Path) -> list[str]:
     return [line for line in output.splitlines() if line.strip()]
 
 
+def _swarm_commit_dirty_worktree(
+    worktree: Path,
+    *,
+    brief_path: str,
+    body: str,
+) -> bool:
+    _run_swarm_git(["add", "-A"], cwd=worktree)
+    staged = _run_swarm_git(["diff", "--cached", "--quiet"], cwd=worktree, check=False)
+    if staged.returncode == 0:
+        return False
+    if staged.returncode != 1:
+        detail = (staged.stderr or staged.stdout or "").strip()
+        suffix = f": {detail}" if detail else ""
+        raise RuntimeError(f"`git diff --cached --quiet` failed in {worktree}{suffix}")
+    _run_swarm_git(
+        [
+            "commit",
+            "-m",
+            _swarm_owned_commit_subject(brief_path),
+            "-m",
+            _swarm_owned_commit_body(brief_path, body),
+        ],
+        cwd=worktree,
+    )
+    return True
+
+
+def _swarm_owned_commit_subject(brief_path: str) -> str:
+    stem = Path(brief_path).stem or "task"
+    cleaned = re.sub(r"[^A-Za-z0-9._ -]+", "-", stem).strip(" ._-") or "task"
+    return f"swarm: {cleaned}"[:72]
+
+
+def _swarm_owned_commit_body(brief_path: str, body: str) -> str:
+    brief = body.strip()
+    max_body_chars = 2_000
+    if len(brief) > max_body_chars:
+        brief = f"{brief[:max_body_chars].rstrip()}\n\n[brief truncated]"
+    return f"Conductor swarm task: {brief_path}\n\n{brief}"
+
+
 def _swarm_changed_files(worktree: Path, base_ref: str) -> list[str]:
     output = _run_swarm_git(
         ["diff", "--name-only", f"{base_ref}...HEAD"],
@@ -8893,41 +8934,45 @@ def _run_swarm_task(
                 fallback_provider = provider_used
             mark_phase("testing")
             dirty_paths = _swarm_dirty_paths(worktree)
+            committing_marked = False
             if dirty_paths:
-                status = "failed"
-                failure_reason = (
-                    "task left uncommitted changes in worktree: "
-                    + ", ".join(path[:200] for path in dirty_paths[:10])
+                mark_phase("committing")
+                committing_marked = True
+                _swarm_commit_dirty_worktree(
+                    worktree,
+                    brief_path=brief_path,
+                    body=body,
                 )
+            commits = _swarm_commit_count(worktree, base_ref)
+            if commits == 0:
+                status = "no-changes"
+            elif defer_ship:
+                if not committing_marked:
+                    mark_phase("committing")
+                _append_swarm_closing_refs_to_head_commit(worktree, closing_refs)
+                status = "ready-to-ship"
             else:
-                commits = _swarm_commit_count(worktree, base_ref)
-                if commits == 0:
-                    status = "no-changes"
-                elif defer_ship:
+                if not committing_marked:
                     mark_phase("committing")
-                    _append_swarm_closing_refs_to_head_commit(worktree, closing_refs)
-                    status = "ready-to-ship"
-                else:
-                    mark_phase("committing")
-                    _append_swarm_closing_refs_to_head_commit(worktree, closing_refs)
-                    mark_phase("shipping")
-                    ship_outcome = _coerce_swarm_ship_outcome(
-                        _ship_swarm_pr(
-                            worktree,
-                            base_branch=base_branch,
-                            branch=branch,
-                            auto_merge=auto_merge,
-                        )
+                _append_swarm_closing_refs_to_head_commit(worktree, closing_refs)
+                mark_phase("shipping")
+                ship_outcome = _coerce_swarm_ship_outcome(
+                    _ship_swarm_pr(
+                        worktree,
+                        base_branch=base_branch,
+                        branch=branch,
+                        auto_merge=auto_merge,
                     )
-                    status = ship_outcome.status
-                    pr_url = ship_outcome.pr_url
-                    merge_status = ship_outcome.merge_status
-                    inspection_warning = ship_outcome.inspection_warning
-                    validation_failure = ship_outcome.validation_failure
-                    if status == "shipped":
-                        merge_sha = ship_outcome.detail
-                    elif status in {"failed", "review-blocked", SWARM_VALIDATION_FAILED_STATUS}:
-                        failure_reason = ship_outcome.detail
+                )
+                status = ship_outcome.status
+                pr_url = ship_outcome.pr_url
+                merge_status = ship_outcome.merge_status
+                inspection_warning = ship_outcome.inspection_warning
+                validation_failure = ship_outcome.validation_failure
+                if status == "shipped":
+                    merge_sha = ship_outcome.detail
+                elif status in {"failed", "review-blocked", SWARM_VALIDATION_FAILED_STATUS}:
+                    failure_reason = ship_outcome.detail
         elif status == "failed":
             failure_reason = failure_reason or "provider dispatch did not complete"
     except _ExecPhaseError as e:

--- a/tests/test_cli_swarm.py
+++ b/tests/test_cli_swarm.py
@@ -2400,6 +2400,57 @@ def test_swarm_ship_does_not_add_closing_ref_without_explicit_issue(
     assert result.exit_code == 0, result.output
 
 
+def test_swarm_commits_dirty_worktree_before_shipping(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    brief = _brief(repo, "foo.md", "make a focused change")
+    monkeypatch.chdir(repo)
+    merged_ship = _fake_merged_ship(repo)
+
+    def fake_exec(**kwargs):
+        worktree = Path(kwargs["cwd"])
+        (worktree / "feature.txt").write_text("feature\n", encoding="utf-8")
+        return (
+            CallResponse(
+                text="done",
+                provider="codex",
+                model="codex",
+                duration_ms=1,
+            ),
+            None,
+            None,
+        )
+
+    def fake_ship(worktree: Path, *, base_branch: str, branch: str, auto_merge: bool):
+        assert _git(worktree, "status", "--porcelain").stdout == ""
+        assert _git(worktree, "log", "-1", "--format=%s").stdout.strip() == "swarm: foo"
+        body = _git(worktree, "log", "-1", "--format=%b").stdout
+        assert "Conductor swarm task:" in body
+        assert "make a focused change" in body
+        assert _git(worktree, "rev-list", "--count", f"{base_branch}..HEAD").stdout.strip() == "1"
+        return merged_ship(
+            worktree,
+            base_branch=base_branch,
+            branch=branch,
+            auto_merge=auto_merge,
+        )
+
+    monkeypatch.setattr(cli, "_run_exec_phase_dispatch", fake_exec)
+    monkeypatch.setattr(cli, "_ship_swarm_pr", fake_ship)
+
+    result = CliRunner().invoke(
+        main,
+        ["swarm", "--provider", "codex", "--brief", str(brief), "--auto-merge", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["tasks"][0]["status"] == "shipped"
+    assert payload["tasks"][0]["commits"] == 1
+
+
 def test_swarm_two_briefs_both_succeed(monkeypatch, tmp_path: Path) -> None:
     repo = _repo(tmp_path)
     first = _brief(repo, "foo.md", "first change")


### PR DESCRIPTION
## Summary

This moves swarm one step closer to the right ownership boundary: successful provider execution may leave file edits in the isolated task worktree, and Conductor now commits those edits before shipping instead of failing the task for uncommitted changes.

Root cause: swarm owns the task worktree and PR shipping path, but previously required the delegated provider/model to also remember the final `git commit` delivery step. That made stateless chat/tool-loop providers such as OpenRouter brittle even when they produced a usable patch.

Changes:

- Stage and commit dirty successful swarm task worktrees with a deterministic `swarm: <brief>` subject.
- Include the brief identity and body in the generated commit body.
- Continue through the existing closing-ref append, ready-to-ship, and ship paths after Conductor creates the commit.
- Preserve `no-changes` behavior when the provider makes no file changes.
- Add a regression test where the provider writes a file but never invokes `git commit`; swarm still ships one commit.

Closes #406
Refs #394
Refs #403
Refs #405

## Validation

- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest -q` (`1246 passed, 15 skipped`)
- `cortex update --check`
- pre-push hooks: branch naming, AI default-branch push review, Touchstone project validation