### PR TITLE
[codex] Add provider runtime categories

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -99,6 +99,10 @@ from conductor.openrouter_stack_audit import (
 )
 from conductor.profiles import ProfileError, ProfileSpec, get_profile, load_profiles
 from conductor.providers import (
+    PROVIDER_RUNTIME_KINDS,
+    PROVIDER_RUNTIME_STATEFUL_AGENT,
+    PROVIDER_RUNTIME_STATELESS_TOOL_LOOP,
+    PROVIDER_RUNTIME_TEXT_ONLY,
     QUALITY_TIERS,
     TIER_RANK,
     TOOL_NAMES,
@@ -934,6 +938,20 @@ def _resolve_exec_tools(
 
 def _provider_enforces_exec_tool_permissions(provider_obj: object) -> bool:
     return bool(getattr(provider_obj, "enforces_exec_tool_permissions", False))
+
+
+def _provider_runtime_kind(provider_obj: object) -> str:
+    runtime_kind = getattr(provider_obj, "runtime_kind", PROVIDER_RUNTIME_TEXT_ONLY)
+    if isinstance(runtime_kind, str) and runtime_kind in PROVIDER_RUNTIME_KINDS:
+        return runtime_kind
+    return PROVIDER_RUNTIME_TEXT_ONLY
+
+
+def _provider_runtime_kind_by_name(provider_id: str) -> str:
+    try:
+        return _provider_runtime_kind(get_provider(provider_id))
+    except KeyError:
+        return PROVIDER_RUNTIME_TEXT_ONLY
 
 
 def _permission_profile_excludes(
@@ -8892,7 +8910,11 @@ def _run_swarm_task(
                         fallback_provider = provider_candidates[index + 1]
                         click.echo(
                             "[conductor] swarm provider fallback: "
-                            f"{candidate_provider} -> {fallback_provider}; reason: {e.message}",
+                            f"{candidate_provider} "
+                            f"({_provider_runtime_kind_by_name(candidate_provider)}) -> "
+                            f"{fallback_provider} "
+                            f"({_provider_runtime_kind_by_name(fallback_provider)}); "
+                            f"reason: {e.message}",
                             err=True,
                         )
                         continue
@@ -8921,7 +8943,11 @@ def _run_swarm_task(
                         fallback_provider = provider_candidates[index + 1]
                         click.echo(
                             "[conductor] swarm provider fallback: "
-                            f"{candidate_provider} -> {fallback_provider}; reason: {e}",
+                            f"{candidate_provider} "
+                            f"({_provider_runtime_kind_by_name(candidate_provider)}) -> "
+                            f"{fallback_provider} "
+                            f"({_provider_runtime_kind_by_name(fallback_provider)}); "
+                            f"reason: {e}",
                             err=True,
                         )
                         continue
@@ -9099,6 +9125,27 @@ def _swarm_task_tags(raw_tags: str | None) -> list[str]:
     return tags
 
 
+_SWARM_RUNTIME_PRIORITY = {
+    PROVIDER_RUNTIME_STATEFUL_AGENT: 0,
+    PROVIDER_RUNTIME_STATELESS_TOOL_LOOP: 1,
+    PROVIDER_RUNTIME_TEXT_ONLY: 2,
+}
+
+
+def _swarm_runtime_ordered_candidates(candidates: list[str]) -> list[str]:
+    original_index = {name: index for index, name in enumerate(candidates)}
+    return sorted(
+        candidates,
+        key=lambda name: (
+            _SWARM_RUNTIME_PRIORITY.get(
+                _provider_runtime_kind_by_name(name),
+                _SWARM_RUNTIME_PRIORITY[PROVIDER_RUNTIME_TEXT_ONLY],
+            ),
+            original_index[name],
+        ),
+    )
+
+
 def _swarm_provider_candidates(
     *,
     provider_id: str | None,
@@ -9134,7 +9181,7 @@ def _swarm_provider_candidates(
                 "--max-iterations only applies to Conductor-managed tool-use "
                 "providers; no routed swarm candidate can honor it."
             )
-    return candidates, decision
+    return _swarm_runtime_ordered_candidates(candidates), decision
 
 
 def _swarm_can_fallback_after_provider_failure(
@@ -10927,6 +10974,7 @@ def _provider_rows() -> list[dict]:
                 "default_model": _provider_default_model(provider),
                 "tags": list(provider.tags),
                 "tier": provider.quality_tier,
+                "runtime": _provider_runtime_kind(provider),
                 "muted": name in muted,
                 "tools": _tools_label(provider),
             }
@@ -10955,11 +11003,13 @@ def list_cmd(as_json: bool) -> None:
     name_w = max(len("PROVIDER"), max(len(r["provider"]) for r in rows))
     model_w = max(len("DEFAULT MODEL"), max(len(r["default_model"]) for r in rows))
     tier_w = max(len("TIER"), max(len(r["tier"]) for r in rows))
+    runtime_w = max(len("RUNTIME"), max(len(r["runtime"]) for r in rows))
     tags_w = max(len("TAGS"), max(len(",".join(r["tags"])) for r in rows))
     header = (
         f"{'PROVIDER':<{name_w}}  "
         f"{'READY':<5}  "
         f"{'TIER':<{tier_w}}  "
+        f"{'RUNTIME':<{runtime_w}}  "
         f"{'DEFAULT MODEL':<{model_w}}  "
         f"{'TAGS':<{tags_w}}  TOOLS"
     )
@@ -10972,6 +11022,7 @@ def list_cmd(as_json: bool) -> None:
             f"{r['provider']:<{name_w}}  "
             f"{ready:<5}  "
             f"{r['tier']:<{tier_w}}  "
+            f"{r['runtime']:<{runtime_w}}  "
             f"{r['default_model']:<{model_w}}  "
             f"{tags:<{tags_w}}  "
             f"{r['tools']}"
@@ -11249,6 +11300,7 @@ def _diagnostic_payload() -> dict:
                 "default_model": _provider_default_model(provider),
                 "tags": list(provider.tags),
                 "quality_tier": provider.quality_tier,
+                "runtime": _provider_runtime_kind(provider),
                 "supports_effort": provider.supports_effort,
                 "warnings": provider_warnings,
                 "muted": name in muted,
@@ -14019,6 +14071,7 @@ def providers_list(as_json: bool) -> None:
                 "accepts": s.accepts,
                 "tags": list(s.tags),
                 "tier": s.quality_tier,
+                "runtime": PROVIDER_RUNTIME_TEXT_ONLY,
                 "cost_per_1k_in": s.cost_per_1k_in,
                 "cost_per_1k_out": s.cost_per_1k_out,
                 "typical_p50_ms": s.typical_p50_ms,
@@ -14048,6 +14101,7 @@ def providers_list(as_json: bool) -> None:
         click.echo(f"    shell:    {s.shell}")
         click.echo(f"    accepts:  {s.accepts}")
         click.echo(f"    tier:     {s.quality_tier}")
+        click.echo(f"    runtime:  {PROVIDER_RUNTIME_TEXT_ONLY}")
         if s.tags:
             click.echo(f"    tags:     {', '.join(s.tags)}")
         if s.cost_per_1k_in or s.cost_per_1k_out:

--- a/src/conductor/providers/__init__.py
+++ b/src/conductor/providers/__init__.py
@@ -4,6 +4,10 @@ from conductor.providers.deepseek import DeepSeekChatProvider, DeepSeekReasonerP
 from conductor.providers.gemini import GeminiProvider
 from conductor.providers.interface import (
     EFFORT_LEVELS,
+    PROVIDER_RUNTIME_KINDS,
+    PROVIDER_RUNTIME_STATEFUL_AGENT,
+    PROVIDER_RUNTIME_STATELESS_TOOL_LOOP,
+    PROVIDER_RUNTIME_TEXT_ONLY,
     QUALITY_TIERS,
     TIER_RANK,
     TOOL_NAMES,
@@ -25,6 +29,10 @@ from conductor.providers.shell import ShellProvider, ShellProviderSpec
 
 __all__ = [
     "EFFORT_LEVELS",
+    "PROVIDER_RUNTIME_KINDS",
+    "PROVIDER_RUNTIME_STATEFUL_AGENT",
+    "PROVIDER_RUNTIME_STATELESS_TOOL_LOOP",
+    "PROVIDER_RUNTIME_TEXT_ONLY",
     "QUALITY_TIERS",
     "TIER_RANK",
     "TOOL_NAMES",

--- a/src/conductor/providers/claude.py
+++ b/src/conductor/providers/claude.py
@@ -27,6 +27,7 @@ from conductor.providers.cli_auth import (
     run_subprocess_with_live_stderr,
 )
 from conductor.providers.interface import (
+    PROVIDER_RUNTIME_STATEFUL_AGENT,
     CallResponse,
     ProviderConfigError,
     ProviderError,
@@ -187,6 +188,7 @@ class ClaudeProvider:
 
     # Capability declarations (see interface.py)
     quality_tier = "frontier"
+    runtime_kind = PROVIDER_RUNTIME_STATEFUL_AGENT
     supported_tools = frozenset({"Read", "Grep", "Glob", "Edit", "Write", "Bash"})
     enforces_exec_tool_permissions = True
     supports_effort = True

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -35,6 +35,7 @@ from conductor.providers._startup_lock import codex_startup_lock, release_startu
 from conductor.providers._tool_weights import ToolBudgetCounter
 from conductor.providers.cli_auth import STARTUP_LOCK_MAX_HOLD_SEC, AuthPromptTracker
 from conductor.providers.interface import (
+    PROVIDER_RUNTIME_STATEFUL_AGENT,
     CallResponse,
     ProviderConfigError,
     ProviderError,
@@ -348,6 +349,7 @@ class CodexProvider:
 
     # Capability declarations (see interface.py)
     quality_tier = "frontier"
+    runtime_kind = PROVIDER_RUNTIME_STATEFUL_AGENT
     supported_tools = frozenset({"Read", "Grep", "Glob", "Edit", "Write", "Bash"})
     enforces_exec_tool_permissions = False
     supports_effort = True

--- a/src/conductor/providers/deepseek.py
+++ b/src/conductor/providers/deepseek.py
@@ -8,6 +8,7 @@ now share OpenRouter's credential + transport layer.
 from __future__ import annotations
 
 import conductor.providers.openrouter_catalog as openrouter_catalog
+from conductor.providers.interface import PROVIDER_RUNTIME_TEXT_ONLY
 from conductor.providers.openrouter import OpenRouterProvider
 
 DEEPSEEK_CHAT_MODEL = "deepseek/deepseek-chat"
@@ -38,6 +39,7 @@ class DeepSeekChatProvider(OpenRouterProvider):
     fix_command = "conductor init --only openrouter"
 
     quality_tier = "strong"
+    runtime_kind = PROVIDER_RUNTIME_TEXT_ONLY
     supported_tools: frozenset[str] = frozenset()
     supports_effort = False
     effort_to_thinking: dict[str, int] = {}
@@ -73,6 +75,7 @@ class DeepSeekReasonerProvider(OpenRouterProvider):
     fix_command = "conductor init --only openrouter"
 
     quality_tier = "strong"
+    runtime_kind = PROVIDER_RUNTIME_TEXT_ONLY
     supported_tools: frozenset[str] = frozenset()
     supports_effort = True
     effort_to_thinking = {

--- a/src/conductor/providers/gemini.py
+++ b/src/conductor/providers/gemini.py
@@ -28,6 +28,7 @@ from conductor.providers.cli_auth import (
     run_subprocess_with_live_stderr,
 )
 from conductor.providers.interface import (
+    PROVIDER_RUNTIME_STATEFUL_AGENT,
     CallResponse,
     ProviderConfigError,
     ProviderError,
@@ -104,6 +105,7 @@ class GeminiProvider:
 
     # Capability declarations (see interface.py)
     quality_tier = "strong"
+    runtime_kind = PROVIDER_RUNTIME_STATEFUL_AGENT
     supported_tools = frozenset({"Read", "Grep", "Glob", "Edit", "Write", "Bash"})
     enforces_exec_tool_permissions = False
     supports_effort = True

--- a/src/conductor/providers/interface.py
+++ b/src/conductor/providers/interface.py
@@ -15,6 +15,7 @@ and the error hierarchy below.
 
 Capability declarations (v0.2):
   - quality_tier            — "frontier" | "strong" | "standard" | "local"
+  - runtime_kind            — "stateful-agent" | "stateless-tool-loop" | "text-only"
   - supported_tools         — frozenset of tool names ({Read, Grep, Glob, Edit, Write, Bash})
   - enforces_exec_tool_permissions — whether exec() honors Conductor's requested tool whitelist
   - supports_effort         — whether the provider has a thinking/reasoning dial
@@ -57,6 +58,16 @@ TIER_RANK = {name: len(QUALITY_TIERS) - i for i, name in enumerate(QUALITY_TIERS
 # which of these they can drive; the router filters unsupported combinations.
 # --------------------------------------------------------------------------- #
 TOOL_NAMES = frozenset({"Read", "Grep", "Glob", "Edit", "Write", "Bash"})
+PROVIDER_RUNTIME_STATEFUL_AGENT = "stateful-agent"
+PROVIDER_RUNTIME_STATELESS_TOOL_LOOP = "stateless-tool-loop"
+PROVIDER_RUNTIME_TEXT_ONLY = "text-only"
+PROVIDER_RUNTIME_KINDS = frozenset(
+    {
+        PROVIDER_RUNTIME_STATEFUL_AGENT,
+        PROVIDER_RUNTIME_STATELESS_TOOL_LOOP,
+        PROVIDER_RUNTIME_TEXT_ONLY,
+    }
+)
 
 
 class ProviderError(Exception):
@@ -212,6 +223,7 @@ class Provider(Protocol):
 
     # --- capability declarations (hard filters + scoring dimensions) ------- #
     quality_tier: ClassVar[str]
+    runtime_kind: ClassVar[str]
     supported_tools: ClassVar[frozenset[str]]
     enforces_exec_tool_permissions: ClassVar[bool]
     supports_effort: ClassVar[bool]

--- a/src/conductor/providers/kimi.py
+++ b/src/conductor/providers/kimi.py
@@ -7,6 +7,7 @@ transport now flow through the shared OpenRouter adapter.
 from __future__ import annotations
 
 import conductor.providers.openrouter_catalog as openrouter_catalog
+from conductor.providers.interface import PROVIDER_RUNTIME_TEXT_ONLY
 from conductor.providers.openrouter import OpenRouterProvider
 
 KIMI_DEFAULT_MODEL = "moonshotai/kimi-k2.6"
@@ -25,6 +26,7 @@ class KimiProvider(OpenRouterProvider):
     fix_command = "conductor init --only openrouter"
 
     quality_tier = "strong"
+    runtime_kind = PROVIDER_RUNTIME_TEXT_ONLY
     supported_tools: frozenset[str] = frozenset()
     supports_effort = True
     effort_to_thinking = {

--- a/src/conductor/providers/ollama.py
+++ b/src/conductor/providers/ollama.py
@@ -32,6 +32,7 @@ from conductor.exec_completion import (
     format_missing_deliverables_cap_message,
 )
 from conductor.providers.interface import (
+    PROVIDER_RUNTIME_STATELESS_TOOL_LOOP,
     CallResponse,
     ProviderConfigError,
     ProviderHTTPError,
@@ -212,6 +213,7 @@ class OllamaProvider:
 
     # Capability declarations (see interface.py)
     quality_tier = "local"
+    runtime_kind = PROVIDER_RUNTIME_STATELESS_TOOL_LOOP
     # Tool-use runs through Conductor's HTTP tool-use loop.
     supported_tools: frozenset[str] = frozenset(
         {"Read", "Grep", "Glob", "Edit", "Write", "Bash"}

--- a/src/conductor/providers/openrouter.py
+++ b/src/conductor/providers/openrouter.py
@@ -30,6 +30,7 @@ from conductor.exec_completion import (
 )
 from conductor.openrouter_model_stacks import openrouter_coding_stack
 from conductor.providers.interface import (
+    PROVIDER_RUNTIME_STATELESS_TOOL_LOOP,
     CallResponse,
     ProviderConfigError,
     ProviderError,
@@ -96,6 +97,7 @@ class OpenRouterProvider:
     fix_command = "conductor init --only openrouter"
 
     quality_tier = "frontier"
+    runtime_kind = PROVIDER_RUNTIME_STATELESS_TOOL_LOOP
     supported_tools: frozenset[str] = frozenset(
         {"Read", "Grep", "Glob", "Edit", "Write", "Bash"}
     )

--- a/src/conductor/providers/shell.py
+++ b/src/conductor/providers/shell.py
@@ -40,6 +40,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
 from conductor.providers.interface import (
+    PROVIDER_RUNTIME_TEXT_ONLY,
     CallResponse,
     ProviderConfigError,
     ProviderError,
@@ -86,6 +87,7 @@ class ShellProvider:
     """
 
     # Capability declarations that are the same for every shell provider.
+    runtime_kind: str = PROVIDER_RUNTIME_TEXT_ONLY
     supported_tools: frozenset[str] = frozenset()
     enforces_exec_tool_permissions: bool = False
     supports_effort: bool = False

--- a/src/conductor/router.py
+++ b/src/conductor/router.py
@@ -37,6 +37,7 @@ from typing import Literal
 
 from conductor.muted_providers import load_muted_provider_ids
 from conductor.providers import (
+    PROVIDER_RUNTIME_TEXT_ONLY,
     TIER_RANK,
     Provider,
     ProviderError,
@@ -164,6 +165,7 @@ class RankedCandidate:
     latency_ms: int
     health_penalty: float
     combined_score: float       # the key used by the current prefer mode (higher=better)
+    runtime_kind: str = PROVIDER_RUNTIME_TEXT_ONLY
     unconfigured_reason: str | None = None
     estimated_input_tokens: int = DEFAULT_ESTIMATED_INPUT_TOKENS
     estimated_output_tokens: int = DEFAULT_ESTIMATED_OUTPUT_TOKENS
@@ -270,6 +272,7 @@ def _score_one(
         latency_ms=provider.typical_p50_ms,
         health_penalty=penalty,
         combined_score=combined,
+        runtime_kind=getattr(provider, "runtime_kind", PROVIDER_RUNTIME_TEXT_ONLY),
         unconfigured_reason=unconfigured_reason,
         estimated_input_tokens=estimated_input_tokens,
         estimated_output_tokens=estimated_output_tokens,

--- a/tests/test_cli_phase5.py
+++ b/tests/test_cli_phase5.py
@@ -236,12 +236,27 @@ def test_list_json_includes_tools_field(mocker):
         assert rows[name]["tools"] == "none", f"{name}: expected tools=none"
 
 
+def test_list_json_includes_runtime_field(mocker):
+    """Provider runtime kind is a contract, not a soft routing tag."""
+    _stub_all_unconfigured(mocker)
+    result = CliRunner().invoke(main, ["list", "--json"])
+    assert result.exit_code == 0
+    rows = {r["provider"]: r for r in json.loads(result.output)}
+    for name in ("claude", "codex", "gemini"):
+        assert rows[name]["runtime"] == "stateful-agent"
+    for name in ("openrouter", "ollama"):
+        assert rows[name]["runtime"] == "stateless-tool-loop"
+    for name in ("kimi", "deepseek-chat", "deepseek-reasoner"):
+        assert rows[name]["runtime"] == "text-only"
+
+
 def test_list_text_output_shows_tools_column(mocker):
     """conductor list text output includes a TOOLS column (#143)."""
     _stub_all_unconfigured(mocker)
     result = CliRunner().invoke(main, ["list"])
     assert result.exit_code == 0
     assert "TOOLS" in result.output
+    assert "RUNTIME" in result.output
     # At least one provider shows "all" and at least one shows "none".
     assert "all" in result.output
     assert "none" in result.output

--- a/tests/test_cli_swarm.py
+++ b/tests/test_cli_swarm.py
@@ -782,6 +782,45 @@ def test_swarm_auto_routes_lane_with_task_tags(monkeypatch, tmp_path: Path) -> N
     assert manifest["tasks"][0]["fallback_reason"] is None
 
 
+def test_swarm_auto_prefers_stateful_runtime_candidates(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    brief = _brief(repo, "foo.md")
+    monkeypatch.chdir(repo)
+    calls: list[str] = []
+
+    def fake_pick(task_tags, **kwargs):
+        _ = (task_tags, kwargs)
+        decision = _route_decision("openrouter", "codex")
+        return object(), decision
+
+    def fake_exec(**kwargs):
+        calls.append(kwargs["provider_id"])
+        worktree = Path(kwargs["cwd"])
+        _commit_change(worktree, "auto.txt", "auto")
+        return (
+            CallResponse(text="done", provider=kwargs["provider_id"], model="test", duration_ms=1),
+            None,
+            None,
+        )
+
+    monkeypatch.setattr(cli, "pick", fake_pick)
+    monkeypatch.setattr(cli, "_run_exec_phase_dispatch", fake_exec)
+    monkeypatch.setattr(cli, "_ship_swarm_pr", _fake_merged_ship(repo))
+
+    result = CliRunner().invoke(
+        main,
+        ["swarm", "--provider", "auto", "--brief", str(brief), "--auto-merge", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == ["codex"]
+    manifest = json.loads(_swarm_manifests(repo)[0].read_text(encoding="utf-8"))
+    assert manifest["tasks"][0]["selected_provider"] == "codex"
+
+
 def test_swarm_auto_falls_back_and_records_provider_details(
     monkeypatch,
     tmp_path: Path,
@@ -839,6 +878,7 @@ def test_swarm_auto_falls_back_and_records_provider_details(
     assert "fallback_reason=codex websocket disconnected during model refresh" in (
         status_result.output
     )
+    assert "codex (stateful-agent) -> gemini (stateful-agent)" in result.stderr
 
 
 def test_swarm_pinned_provider_does_not_fallback(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import pytest
 
 from conductor.providers import (
+    PROVIDER_RUNTIME_KINDS,
+    PROVIDER_RUNTIME_STATEFUL_AGENT,
+    PROVIDER_RUNTIME_STATELESS_TOOL_LOOP,
+    PROVIDER_RUNTIME_TEXT_ONLY,
     ClaudeProvider,
     CodexProvider,
     DeepSeekChatProvider,
@@ -58,9 +62,25 @@ def test_every_provider_implements_protocol_surface():
             isinstance(t, str) for t in provider.tags
         )
         assert isinstance(provider.default_model, str)
+        assert provider.runtime_kind in PROVIDER_RUNTIME_KINDS
         assert callable(provider.configured)
         assert callable(provider.smoke)
         assert callable(provider.call)
+
+
+def test_builtin_provider_runtime_kinds_are_explicit():
+    assert {
+        name: get_provider(name).runtime_kind for name in known_providers()
+    } == {
+        "claude": PROVIDER_RUNTIME_STATEFUL_AGENT,
+        "codex": PROVIDER_RUNTIME_STATEFUL_AGENT,
+        "deepseek-chat": PROVIDER_RUNTIME_TEXT_ONLY,
+        "deepseek-reasoner": PROVIDER_RUNTIME_TEXT_ONLY,
+        "gemini": PROVIDER_RUNTIME_STATEFUL_AGENT,
+        "kimi": PROVIDER_RUNTIME_TEXT_ONLY,
+        "ollama": PROVIDER_RUNTIME_STATELESS_TOOL_LOOP,
+        "openrouter": PROVIDER_RUNTIME_STATELESS_TOOL_LOOP,
+    }
 
 
 def test_provider_identifiers_match_class_name():

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -85,6 +85,14 @@ def test_pick_returns_only_configured_provider(mocker):
     assert decision.provider == "ollama"
 
 
+def test_pick_records_provider_runtime_kind(mocker):
+    _stub_configured(mocker, {"codex": True, "openrouter": True})
+    _provider, decision = pick(["tool-use"], tools={"Read"})
+    runtimes = {candidate.name: candidate.runtime_kind for candidate in decision.ranked}
+    assert runtimes["codex"] == "stateful-agent"
+    assert runtimes["openrouter"] == "stateless-tool-loop"
+
+
 def test_pick_scores_by_tag_overlap(mocker):
     _stub_configured(mocker, {"kimi": True, "claude": True, "ollama": True})
     # "local" is only on ollama; it should win even though priority says kimi first.


### PR DESCRIPTION
## Summary

This fixes the remaining provider-architecture issue by making runtime class an explicit provider capability instead of inferring it from `supported_tools` or tags.

Root cause: Conductor knew whether a provider could expose tools, but not what kind of runtime sat behind those tools. That made stateless chat/tool-loop providers look equivalent to stateful coding-agent subprocesses even though their delivery semantics differ.

Changes:

- Add provider runtime kinds: `stateful-agent`, `stateless-tool-loop`, and `text-only`.
- Declare runtime kind on every built-in provider and shell custom providers.
- Include runtime kind in router ranked candidates, `conductor list --json`, list text output, custom provider list output, and doctor diagnostics.
- Teach swarm auto/pool provider selection to prefer `stateful-agent` candidates before stateless tool loops for repo-changing tasks unless the user pins a provider.
- Include runtime kinds in swarm fallback messages so cross-runtime fallback behavior is visible in logs.

Closes #407
Refs #394
Refs #399
Refs #403
Refs #405

## Validation

- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest -q` (`1250 passed, 15 skipped`)
- `cortex update --check`
- pre-push hooks: branch naming, AI default-branch push review, Touchstone project validation