### PR TITLE
fix: expose repo integration status

### DIFF
--- a/src/conductor/agent_wiring.py
+++ b/src/conductor/agent_wiring.py
@@ -431,13 +431,12 @@ def repo_scope_version_decisions(
 ) -> tuple[RepoScopeVersionDecision, ...]:
     """Scan repo-scope managed files for stale conductor version stamps.
 
-    Startup auto-refresh calls this on eligible CLI commands, so the scan is
-    intentionally bounded to the conventional repo-scope files in ``cwd`` and
-    reads only a small prefix from each existing candidate.
+    The scan is intentionally bounded to the conventional repo-scope files in
+    ``cwd``. Sentinel blocks may live deep in AGENTS.md or CLAUDE.md after
+    project-owned content, so sentinel files are read fully; first-line managed
+    files still use bounded reads.
     """
     root = cwd.resolve()
-    if not _is_inside_git_repo(root):
-        return ()
 
     decisions: list[RepoScopeVersionDecision] = []
     for path, kind in _repo_scope_candidate_sentinel_paths(root).items():
@@ -511,7 +510,8 @@ def _repo_scope_decision(
     reason: str | None,
 ) -> RepoScopeVersionDecision:
     if reason is not None:
-        return RepoScopeVersionDecision(path, kind, version, False, reason)
+        stale = reason.startswith("read-error:")
+        return RepoScopeVersionDecision(path, kind, version, stale, reason)
     if version is None:
         detail = "missing" if not exists else "not conductor-managed"
         return RepoScopeVersionDecision(path, kind, None, False, detail)
@@ -574,7 +574,7 @@ def _read_managed_version_prefix(path: Path) -> str | None:
 
 
 def _read_sentinel_version_prefix(path: Path) -> str | None:
-    text = _read_prefix(path)
+    text = _read_text(path)
     if not text:
         return None
     idx = text.find(SENTINEL_BEGIN_PREFIX)
@@ -588,7 +588,10 @@ def _read_sentinel_version_prefix(path: Path) -> str | None:
 
 
 def _read_repo_sentinel_version_prefix(path: Path) -> tuple[str | None, str | None]:
-    text = _read_prefix(path)
+    try:
+        text = _read_text(path)
+    except OSError as e:
+        return None, f"read-error: {e}"
     if not text:
         return None, None
     idx = text.find(SENTINEL_BEGIN_PREFIX)
@@ -597,11 +600,20 @@ def _read_repo_sentinel_version_prefix(path: Path) -> tuple[str | None, str | No
     marker_end = text.find("-->", idx)
     if marker_end == -1:
         return None, "malformed sentinel"
+    block_end = text.find(SENTINEL_END, marker_end)
+    if block_end == -1:
+        return None, "malformed sentinel"
+    version = text[idx + len(SENTINEL_BEGIN_PREFIX) : marker_end].strip() or None
     body_prefix = text[marker_end + len("-->") :].lstrip()
     if body_prefix.startswith("@"):
-        return None, "import-mode"
-    version = text[idx + len(SENTINEL_BEGIN_PREFIX) : marker_end].strip()
-    return version or None, None
+        return version, "import-mode"
+    return version, None
+
+
+def _read_text(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    return path.read_text(encoding="utf-8")
 
 
 def _is_inside_git_repo(cwd: Path) -> bool:
@@ -638,26 +650,22 @@ def agent_wiring_notice(
     if root is None:
         return None
 
-    detection = detect(cwd=root)
     current_version_key = _canonical_wiring_version(current_version)
     stale: list[str] = []
-    for artifact in detection.managed:
-        if artifact.kind not in _REPO_SCOPED_KINDS:
+    decisions = repo_scope_version_decisions(root, binary_version=current_version)
+    for decision in decisions:
+        if not decision.stale:
             continue
-        if artifact.version and not _wiring_versions_match(
-            artifact.version, current_version
-        ):
-            try:
-                display = artifact.path.relative_to(root)
-            except ValueError:
-                display = artifact.path
-            stale.append(f"{display} has conductor v{artifact.version}")
+        try:
+            display = decision.path.relative_to(root)
+        except ValueError:
+            display = decision.path
+        version = decision.version or "unknown"
+        stale.append(f"{display} has conductor v{version}")
 
     agents_current = any(
-        artifact.kind == "agents-md-import"
-        and artifact.version
-        and _wiring_versions_match(artifact.version, current_version)
-        for artifact in detection.managed
+        decision.kind == "agents-md-import" and decision.reason == "current"
+        for decision in decisions
     )
     agents_missing = not agents_current
 

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -10,7 +10,7 @@ v0.1 surface (unchanged):
   conductor smoke [<id>] [--all] [--json]
   conductor doctor [--json]
   conductor init [--yes]
-  conductor update [--dry-run] [--check]
+  conductor update [--dry-run] [--check] [--json]
   conductor update-all [--paths PATHS] [--config-file FILE]
 
 v0.2 additions:
@@ -4080,6 +4080,9 @@ def _maybe_auto_refresh(ctx: click.Context) -> None:
         from conductor import agent_wiring
 
         cwd = Path.cwd()
+        repo_check = _run_repo_command(cwd, ["git", "rev-parse", "--is-inside-work-tree"])
+        if repo_check.returncode != 0:
+            return
         repo_decisions = agent_wiring.repo_scope_version_decisions(
             cwd,
             binary_version=__version__,
@@ -11385,25 +11388,25 @@ def _diagnostic_payload() -> dict:
 
 def _agent_integration_payload() -> dict:
     """Summarize the state of agent-integration wiring (see agent_wiring.py)."""
-    from conductor.agent_wiring import detect
+    from conductor import agent_wiring
 
-    detection = detect()
+    detection = agent_wiring.detect()
     kinds = {a.kind for a in detection.managed}
     managed_files = [
         {"path": str(a.path), "kind": a.kind, "version": a.version} for a in detection.managed
     ]
-    version_skew_files = _integration_version_skew_files(
-        managed_files,
-        binary_version=__version__,
-    )
     user_version_skew_files = _integration_version_skew_files(
         [f for f in managed_files if f["kind"] not in REPO_INTEGRATION_KINDS],
         binary_version=__version__,
     )
-    repo_version_skew_files = _integration_version_skew_files(
-        [f for f in managed_files if f["kind"] in REPO_INTEGRATION_KINDS],
+    repo_integration_status = _repo_integration_status_payloads(
+        cwd=Path.cwd(),
         binary_version=__version__,
     )
+    repo_version_skew_files = [
+        str(entry["path"]) for entry in repo_integration_status if entry["stale"]
+    ]
+    version_skew_files = [*user_version_skew_files, *repo_version_skew_files]
     return {
         "claude_detected": detection.claude_detected,
         "claude_cli_on_path": detection.claude_cli_on_path,
@@ -11427,6 +11430,65 @@ def _agent_integration_payload() -> dict:
         "version_skew_files": version_skew_files,
         "user_version_skew_files": user_version_skew_files,
         "repo_version_skew_files": repo_version_skew_files,
+        "repo_integration_status": repo_integration_status,
+    }
+
+
+def _repo_integration_status_payloads(
+    *,
+    cwd: Path,
+    binary_version: str,
+) -> list[dict[str, object]]:
+    """Return exact repo integration status for machine consumers.
+
+    Invariant: the same repo-scope decision engine powers human doctor
+    warnings and JSON status, so an import-only CLAUDE.md block cannot be
+    reported stale while `conductor update` says there is nothing to do.
+    """
+    from conductor import agent_wiring
+
+    return [
+        _repo_integration_decision_payload(decision, cwd=cwd, binary_version=binary_version)
+        for decision in agent_wiring.repo_scope_version_decisions(
+            cwd,
+            binary_version=binary_version,
+        )
+    ]
+
+
+def _repo_integration_decision_payload(
+    decision: RepoScopeVersionDecision,
+    *,
+    cwd: Path,
+    binary_version: str,
+) -> dict[str, object]:
+    expected = str(binary_version).split("+", 1)[0]
+    status = decision.reason
+    managed = status not in {"missing", "not conductor-managed"}
+    requires_attention = status == "malformed sentinel" or status.startswith("read-error:")
+    if status.startswith("read-error:"):
+        update_command = "fix file permissions, then conductor update"
+    elif status == "malformed sentinel":
+        update_command = "repair malformed sentinel, then conductor init -y"
+    elif decision.stale:
+        update_command = "conductor update"
+    elif status in {"missing", "not conductor-managed", "malformed sentinel"}:
+        update_command = "conductor init -y"
+    else:
+        update_command = None
+    return {
+        "path": str(decision.path),
+        "display_path": _repo_relative_path(decision.path, cwd=cwd),
+        "kind": decision.kind,
+        "scope": "repo",
+        "exists": decision.path.is_file(),
+        "managed": managed,
+        "status": status,
+        "stale": decision.stale,
+        "requires_attention": requires_attention,
+        "installed_version": decision.version,
+        "expected_version": expected,
+        "update_command": update_command,
     }
 
 
@@ -11925,10 +11987,9 @@ def doctor(as_json: bool) -> None:
         click.echo(f"⚠ Integration files behind binary (v{payload['version']}). Refresh with:")
         click.echo("    conductor init -y --remaining")
     if ai["repo_version_skew_files"]:
-        repo_skew_entries = _integration_version_skew_entries(
-            [f for f in ai["managed_files"] if f["kind"] in REPO_INTEGRATION_KINDS],
-            binary_version=payload["version"],
-        )
+        repo_skew_entries = [
+            entry for entry in ai["repo_integration_status"] if entry["stale"]
+        ]
         click.echo("")
         click.echo(f"⚠ Repo integration files behind binary (v{payload['version']}):")
         for entry in repo_skew_entries:
@@ -11937,7 +11998,11 @@ def doctor(as_json: bool) -> None:
                 display = path.relative_to(Path.cwd())
             except ValueError:
                 display = path
-            version_note = f" (v{entry['version']})" if entry["version"] else ""
+            version_note = (
+                f" (v{entry['installed_version']})"
+                if entry["installed_version"]
+                else ""
+            )
             click.echo(f"    {display}{version_note}")
         click.echo("  Auto refresh paths:")
         click.echo("    brew upgrade conductor       # CLAUDE.md @-import self-heals on upgrade")
@@ -12268,12 +12333,19 @@ def refresh_on_commit() -> None:
     default=False,
     help="Exit 1 if repo integrations are stale; do not write files.",
 )
-def update(dry_run: bool, check: bool) -> None:
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit machine-readable repo integration status as JSON.",
+)
+def update(dry_run: bool, check: bool, as_json: bool) -> None:
     """Refresh stale embedded Conductor repo integrations in this repo."""
-    sys.exit(_run_update_current_repo(dry_run=dry_run, check=check))
+    sys.exit(_run_update_current_repo(dry_run=dry_run, check=check, as_json=as_json))
 
 
-def _run_update_current_repo(*, dry_run: bool, check: bool) -> int:
+def _run_update_current_repo(*, dry_run: bool, check: bool, as_json: bool = False) -> int:
     cwd = Path.cwd()
     repo_check = _run_repo_command(cwd, ["git", "rev-parse", "--is-inside-work-tree"])
     if repo_check.returncode != 0:
@@ -12282,6 +12354,25 @@ def _run_update_current_repo(*, dry_run: bool, check: bool) -> int:
         raise click.ClickException(f"not a git repository{suffix}")
 
     stale = _stale_repo_integration_decisions(cwd)
+    attention = _repo_attention_integration_decisions(cwd)
+    if as_json:
+        status = _repo_update_status_payload(cwd, refreshed=())
+        if attention:
+            click.echo(json.dumps(status, indent=2))
+            return 0 if dry_run else 1
+        if not stale and not attention:
+            click.echo(json.dumps(status, indent=2))
+            return 0
+        if dry_run or check:
+            click.echo(json.dumps(status, indent=2))
+            return 1 if check else 0
+
+    if attention:
+        click.echo("Conductor repo integrations need manual repair:")
+        _echo_repo_attention_plan(attention, cwd=cwd)
+        click.echo("Repair the files above, then run `conductor init -y`.")
+        return 0 if dry_run else 1
+
     if not stale:
         click.echo("Conductor repo integrations are current.")
         return 0
@@ -12307,6 +12398,9 @@ def _run_update_current_repo(*, dry_run: bool, check: bool) -> int:
         raise click.ClickException(f"internal refresh error: {e}") from e
 
     if not touched:
+        if as_json:
+            click.echo(json.dumps(_repo_update_status_payload(cwd, refreshed=()), indent=2))
+            return 0
         click.echo("Conductor repo integrations are current.")
         return 0
 
@@ -12316,6 +12410,10 @@ def _run_update_current_repo(*, dry_run: bool, check: bool) -> int:
     )
     if add.returncode != 0:
         raise click.ClickException(_command_failure_detail(add, "git add"))
+
+    if as_json:
+        click.echo(json.dumps(_repo_update_status_payload(cwd, refreshed=touched), indent=2))
+        return 0
 
     click.echo("Refreshed Conductor repo integrations:")
     for path in touched:
@@ -12337,6 +12435,40 @@ def _stale_repo_integration_decisions(cwd: Path) -> tuple[RepoScopeVersionDecisi
     )
 
 
+def _repo_attention_integration_decisions(cwd: Path) -> tuple[RepoScopeVersionDecision, ...]:
+    from conductor import agent_wiring
+
+    return tuple(
+        decision
+        for decision in agent_wiring.repo_scope_version_decisions(
+            cwd,
+            binary_version=__version__,
+        )
+        if decision.reason == "malformed sentinel"
+        or decision.reason.startswith("read-error:")
+    )
+
+
+def _repo_update_status_payload(
+    cwd: Path,
+    *,
+    refreshed: tuple[Path, ...],
+) -> dict[str, object]:
+    integrations = _repo_integration_status_payloads(cwd=cwd, binary_version=__version__)
+    stale = [entry for entry in integrations if entry["stale"]]
+    needs_attention = [entry for entry in integrations if entry["requires_attention"]]
+    return {
+        "version": __version__.split("+", 1)[0],
+        "repo": str(cwd.resolve()),
+        "current": not stale and not needs_attention,
+        "stale": bool(stale),
+        "needs_attention": bool(needs_attention),
+        "update_command": "conductor update" if stale else None,
+        "refreshed": [_repo_relative_path(path, cwd=cwd) for path in refreshed],
+        "integrations": integrations,
+    }
+
+
 def _echo_repo_update_plan(
     decisions: tuple[RepoScopeVersionDecision, ...],
     *,
@@ -12348,6 +12480,18 @@ def _echo_repo_update_plan(
         click.echo(
             f"  {_repo_relative_path(decision.path, cwd=cwd)} "
             f"(v{version} -> v{target_version})"
+        )
+
+
+def _echo_repo_attention_plan(
+    decisions: tuple[RepoScopeVersionDecision, ...],
+    *,
+    cwd: Path,
+) -> None:
+    for decision in decisions:
+        click.echo(
+            f"  {_repo_relative_path(decision.path, cwd=cwd)} "
+            f"({decision.reason})"
         )
 
 

--- a/tests/test_agent_wiring.py
+++ b/tests/test_agent_wiring.py
@@ -496,6 +496,13 @@ def test_agent_wiring_notice_omits_fresh_repo_wiring():
     assert aw.agent_wiring_notice(current_version="0.8.1") is None
 
 
+def test_agent_wiring_notice_omits_stale_repo_claude_import_mode():
+    aw.wire_agents_md(version="0.9.0")
+    aw.wire_claude_md_repo(version="0.8.1")
+
+    assert aw.agent_wiring_notice(current_version="0.9.0") is None
+
+
 def test_agent_wiring_notice_treats_local_build_metadata_as_current():
     aw.wire_agents_md(version="0.8.1")
     aw.wire_gemini_md(version="0.8.1")

--- a/tests/test_cli_phase5.py
+++ b/tests/test_cli_phase5.py
@@ -865,6 +865,38 @@ def test_doctor_json_includes_agent_integration_version_skew(
     assert ai["version_skew"] is True
     assert ai["version_skew_files"] == [str(tmp_path / "repo" / "AGENTS.md")]
     assert ai["repo_version_skew_files"] == [str(tmp_path / "repo" / "AGENTS.md")]
+    status = {
+        entry["kind"]: entry
+        for entry in ai["repo_integration_status"]
+    }
+    assert status["agents-md-import"]["stale"] is True
+    assert status["agents-md-import"]["installed_version"] == "0.8.10"
+    assert status["agents-md-import"]["expected_version"] == "0.9.0"
+    assert status["agents-md-import"]["update_command"] == "conductor update"
+
+
+def test_doctor_json_treats_repo_claude_import_mode_as_current(
+    mocker, monkeypatch, tmp_path
+):
+    _stub_all_unconfigured(mocker)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+
+    from conductor import agent_wiring
+
+    agent_wiring.wire_claude_md_repo(version="0.8.10")
+
+    result = CliRunner().invoke(main, ["doctor", "--json"])
+    assert result.exit_code == 0, result.output
+    ai = json.loads(result.output)["agent_integration"]
+    assert ai["repo_version_skew_files"] == []
+    status = {
+        entry["kind"]: entry
+        for entry in ai["repo_integration_status"]
+    }
+    assert status["claude-md-repo-import"]["status"] == "import-mode"
+    assert status["claude-md-repo-import"]["installed_version"] == "0.8.10"
+    assert status["claude-md-repo-import"]["stale"] is False
+    assert status["claude-md-repo-import"]["update_command"] is None
 
 
 def test_doctor_reports_agents_md_when_present(mocker, monkeypatch, tmp_path):

--- a/tests/test_migration_flow.py
+++ b/tests/test_migration_flow.py
@@ -182,6 +182,10 @@ def test_brew_upgrade_then_consumer_commit_refresh(tmp_path, monkeypatch):
     doctor = _invoke(["doctor", "--json"])
     agent_integration = json.loads(doctor.output)["agent_integration"]
     assert agent_integration["user_version_skew_files"] == []
-    assert set(agent_integration["repo_version_skew_files"]) == {
-        str(consumer / "CLAUDE.md")
+    assert agent_integration["repo_version_skew_files"] == []
+    status = {
+        entry["kind"]: entry
+        for entry in agent_integration["repo_integration_status"]
     }
+    assert status["claude-md-repo-import"]["status"] == "import-mode"
+    assert status["claude-md-repo-import"]["installed_version"] == "0.10.0"

--- a/tests/test_refresh_on_commit.py
+++ b/tests/test_refresh_on_commit.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import json
 import subprocess
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
@@ -9,9 +10,6 @@ from click.testing import CliRunner
 from conductor import agent_wiring
 from conductor import cli as cli_mod
 from conductor.cli import main
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 @pytest.fixture(autouse=True)
@@ -147,6 +145,151 @@ def test_update_check_exits_one_for_stale_without_writing(tmp_path, monkeypatch)
         repo / "AGENTS.md"
     ).read_text(encoding="utf-8")
     assert _staged_paths(repo) == []
+
+
+def test_update_check_json_reports_exact_stale_repo_integrations(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+    agent_wiring.wire_agents_md(cwd=repo, version="0.8.9")
+
+    result = CliRunner().invoke(main, ["update", "--check", "--json"])
+
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.output)
+    assert payload["current"] is False
+    assert payload["stale"] is True
+    assert payload["update_command"] == "conductor update"
+    integrations = {entry["kind"]: entry for entry in payload["integrations"]}
+    assert integrations["agents-md-import"]["status"] == "stale"
+    assert integrations["agents-md-import"]["installed_version"] == "0.8.9"
+    assert integrations["agents-md-import"]["expected_version"] == "0.9.0"
+    assert integrations["agents-md-import"]["update_command"] == "conductor update"
+    assert _staged_paths(repo) == []
+
+
+def test_update_check_json_treats_repo_claude_import_mode_as_current(
+    tmp_path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+    agent_wiring.wire_claude_md_repo(cwd=repo, version="0.8.9")
+
+    result = CliRunner().invoke(main, ["update", "--check", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["current"] is True
+    assert payload["stale"] is False
+    integrations = {entry["kind"]: entry for entry in payload["integrations"]}
+    assert integrations["claude-md-repo-import"]["status"] == "import-mode"
+    assert integrations["claude-md-repo-import"]["installed_version"] == "0.8.9"
+    assert integrations["claude-md-repo-import"]["stale"] is False
+    assert integrations["claude-md-repo-import"]["update_command"] is None
+    assert _staged_paths(repo) == []
+
+
+def test_update_check_json_reports_unreadable_repo_integration(
+    tmp_path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+    agent_wiring.wire_agents_md(cwd=repo, version="0.8.9")
+    original_read_text = Path.read_text
+
+    def read_text(path, *args, **kwargs):
+        if path == repo / "AGENTS.md":
+            raise OSError("permission denied")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", read_text)
+
+    result = CliRunner().invoke(main, ["update", "--check", "--json"])
+
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.output)
+    assert payload["current"] is False
+    assert payload["needs_attention"] is True
+    integrations = {entry["kind"]: entry for entry in payload["integrations"]}
+    assert integrations["agents-md-import"]["stale"] is True
+    assert integrations["agents-md-import"]["requires_attention"] is True
+    assert integrations["agents-md-import"]["status"].startswith("read-error:")
+    assert (
+        integrations["agents-md-import"]["update_command"]
+        == "fix file permissions, then conductor update"
+    )
+
+
+def test_update_plain_reports_unreadable_repo_integration(
+    tmp_path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+    agent_wiring.wire_agents_md(cwd=repo, version="0.8.9")
+    original_read_text = Path.read_text
+
+    def read_text(path, *args, **kwargs):
+        if path == repo / "AGENTS.md":
+            raise OSError("permission denied")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", read_text)
+
+    result = CliRunner().invoke(main, ["update"])
+
+    assert result.exit_code == 1, result.output
+    assert "need manual repair" in result.output
+    assert "permission denied" in result.output
+    assert "Conductor repo integrations are current." not in result.output
+
+
+def test_update_check_json_reports_malformed_sentinel_as_manual_repair(
+    tmp_path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+    (repo / "AGENTS.md").write_text(
+        "<!-- conductor:begin v0.8.9 -->\nmissing end marker\n",
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(main, ["update", "--check", "--json"])
+
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.output)
+    assert payload["current"] is False
+    assert payload["stale"] is False
+    assert payload["needs_attention"] is True
+    integrations = {entry["kind"]: entry for entry in payload["integrations"]}
+    assert integrations["agents-md-import"]["status"] == "malformed sentinel"
+    assert integrations["agents-md-import"]["stale"] is False
+    assert integrations["agents-md-import"]["requires_attention"] is True
+    assert (
+        integrations["agents-md-import"]["update_command"]
+        == "repair malformed sentinel, then conductor init -y"
+    )
+
+
+def test_update_json_reports_malformed_sentinel_as_json(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    monkeypatch.setattr(cli_mod, "__version__", "0.9.0")
+    (repo / "AGENTS.md").write_text(
+        "<!-- conductor:begin v0.8.9 -->\nmissing end marker\n",
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(main, ["update", "--json"])
+
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.output)
+    assert payload["current"] is False
+    assert payload["needs_attention"] is True
+    assert "Conductor repo integrations need manual repair" not in result.output
 
 
 def test_update_check_exits_zero_when_current(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- Add machine-readable repo integration status to `conductor doctor --json`.
- Add `conductor update --check --json` / `conductor update --json` output for no-write diagnostics and refresh results.
- Align stale detection so repo `CLAUDE.md` import-mode blocks are treated as self-updating instead of stale while still reporting their installed marker version.
- Read sentinel blocks fully so long AGENTS.md/CLAUDE.md files do not hide stale markers beyond the first prefix window.

Closes #413

## Validation

- `.venv/bin/python -m pytest tests/test_cli_phase5.py::test_doctor_json_includes_agent_integration_version_skew tests/test_cli_phase5.py::test_doctor_json_treats_repo_claude_import_mode_as_current tests/test_agent_wiring.py::test_agent_wiring_notice_omits_stale_repo_claude_import_mode tests/test_refresh_on_commit.py::test_update_check_json_reports_exact_stale_repo_integrations tests/test_refresh_on_commit.py::test_update_check_json_treats_repo_claude_import_mode_as_current tests/test_cli_auto_refresh.py::test_auto_refresh_repo_scope_non_git_noops tests/test_migration_flow.py::test_brew_upgrade_then_consumer_commit_refresh`
- `.venv/bin/python -m pytest tests/test_agent_wiring.py tests/test_cli_phase5.py tests/test_refresh_on_commit.py tests/test_cli_auto_refresh.py tests/test_migration_flow.py`
- `.venv/bin/ruff check src/conductor/agent_wiring.py src/conductor/cli.py tests/test_agent_wiring.py tests/test_cli_phase5.py tests/test_refresh_on_commit.py tests/test_migration_flow.py`
- `.venv/bin/conductor update --check --json`
- `bash scripts/touchstone-run.sh validate` (`1254 passed, 15 skipped`)