### PR TITLE
feat: expose provider capability readiness

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -10872,6 +10872,35 @@ def _emit_route_validation_text(payload: dict[str, object]) -> None:
         )
 
 
+def _provider_capability_matrix(name: str) -> dict[str, object]:
+    return {
+        "call": _route_provider_assessment(
+            name,
+            kind="call",
+            tools=frozenset(),
+            excluded=frozenset(),
+        ),
+        "review": _route_provider_assessment(
+            name,
+            kind="review",
+            tools=frozenset(),
+            excluded=frozenset(),
+        ),
+        "exec_read_only": _route_provider_assessment(
+            name,
+            kind="exec",
+            tools=EXEC_PERMISSION_PROFILES["read-only"],
+            excluded=frozenset(),
+        ),
+        "exec_full": _route_provider_assessment(
+            name,
+            kind="exec",
+            tools=EXEC_PERMISSION_PROFILES["full"],
+            excluded=frozenset(),
+        ),
+    }
+
+
 @main.command()
 @click.option(
     "--kind",
@@ -11252,6 +11281,7 @@ def _provider_rows() -> list[dict]:
                 "runtime": _provider_runtime_kind(provider),
                 "muted": name in muted,
                 "tools": _tools_label(provider),
+                "capabilities": _provider_capability_matrix(name),
             }
         )
     return rows
@@ -11577,6 +11607,8 @@ def _diagnostic_payload() -> dict:
                 "quality_tier": provider.quality_tier,
                 "runtime": _provider_runtime_kind(provider),
                 "supports_effort": provider.supports_effort,
+                "supported_tools": sorted(getattr(provider, "supported_tools", frozenset())),
+                "capabilities": _provider_capability_matrix(name),
                 "warnings": provider_warnings,
                 "muted": name in muted,
             }

--- a/tests/test_cli_phase5.py
+++ b/tests/test_cli_phase5.py
@@ -463,6 +463,49 @@ def test_doctor_json_shape(mocker, monkeypatch):
         assert "source" in row
     for row in payload["providers"]:
         assert "muted" in row
+        assert "capabilities" in row
+
+
+def test_list_json_includes_capability_matrix(mocker, monkeypatch):
+    from conductor.providers import KimiProvider
+
+    _stub_all_unconfigured(mocker)
+    mocker.patch.object(KimiProvider, "configured", lambda self: (True, None))
+    monkeypatch.setattr(KimiProvider, "supported_tools", frozenset())
+
+    result = CliRunner().invoke(main, ["list", "--json"])
+
+    assert result.exit_code == 0, result.output
+    rows = {row["provider"]: row for row in json.loads(result.output)}
+    kimi = rows["kimi"]["capabilities"]
+    assert kimi["call"]["viable"] is True
+    assert kimi["exec_read_only"]["viable"] is False
+    assert kimi["exec_read_only"]["reason_code"] == "provider_lacks_tools"
+    assert kimi["exec_full"]["reason_code"] == "provider_lacks_tools"
+
+
+def test_doctor_json_reports_gemini_review_extension_readiness(mocker):
+    from conductor.providers import GeminiProvider
+
+    _stub_all_unconfigured(mocker)
+    mocker.patch.object(GeminiProvider, "configured", lambda self: (True, None))
+    mocker.patch.object(
+        GeminiProvider,
+        "review_configured",
+        lambda self: (
+            False,
+            "Gemini native review requires the Gemini CLI Code Review extension.",
+        ),
+    )
+
+    result = CliRunner().invoke(main, ["doctor", "--json"])
+
+    assert result.exit_code == 0, result.output
+    rows = {row["provider"]: row for row in json.loads(result.output)["providers"]}
+    review = rows["gemini"]["capabilities"]["review"]
+    assert review["viable"] is False
+    assert review["reason_code"] == "missing_native_review_extension"
+    assert rows["gemini"]["capabilities"]["call"]["viable"] is True
 
 
 def test_doctor_mute_unmute_shifts_counts_and_hides_fix_lines(mocker, monkeypatch):


### PR DESCRIPTION
## Summary

- Add a per-provider `capabilities` matrix to `conductor list --json` and `conductor doctor --json`.
- Reuse the no-token route assessment logic from #411 so readiness by mode has the same reason codes as route validation.
- Surface `call`, `review`, `exec_read_only`, and `exec_full` viability, including missing Gemini native review extension and tool capability failures.

Closes #410

## Validation

- `.venv/bin/python -m pytest tests/test_cli_phase5.py::test_list_json_includes_capability_matrix tests/test_cli_phase5.py::test_doctor_json_reports_gemini_review_extension_readiness tests/test_cli_phase5.py::test_doctor_json_shape tests/test_cli_v02.py::test_route_review_json_reports_missing_gemini_extension tests/test_cli_v02.py::test_route_exec_json_reports_provider_lacks_tools`
- `.venv/bin/python -m pytest tests/test_cli_phase5.py tests/test_cli_v02.py`
- `.venv/bin/ruff check src/conductor/cli.py tests/test_cli_phase5.py tests/test_cli_v02.py`
- `.venv/bin/conductor list --json | jq '.[] | select(.provider=="kimi") | {provider, configured, tools, capabilities: {call: .capabilities.call.viable, exec_read_only: .capabilities.exec_read_only.reason_code, exec_full: .capabilities.exec_full.reason_code}}'`
- `.venv/bin/conductor doctor --json | jq '.providers[] | select(.provider=="gemini") | {provider, configured, review: .capabilities.review}'`
- `bash scripts/touchstone-run.sh validate` (`1264 passed, 15 skipped`)