### PR TITLE
fix(review): fail over on codex contract errors

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -1627,6 +1627,49 @@ def _review_excluded_payload(reasons: dict[str, str]) -> list[dict[str, object]]
     ]
 
 
+class _ReviewRouteSelectionError(RuntimeError):
+    def __init__(
+        self,
+        cause: NoConfiguredProvider | InvalidRouterRequest | MutedProvidersError,
+        review_reasons: dict[str, str],
+    ) -> None:
+        self.cause = cause
+        self.review_reasons = review_reasons
+        super().__init__(str(cause))
+
+
+def _build_review_route_decision(
+    *,
+    effort: str | int,
+    tags: tuple[str, ...],
+    prefer: str | None,
+    exclude: frozenset[str],
+    estimated_input_tokens: int | None,
+) -> tuple[RouteDecision, dict[str, str], SemanticPlan]:
+    """Resolve the semantic review route used by review preflight and dispatch.
+
+    Invariant: review route validation and real semantic review dispatch use
+    one provider ordering path, so a no-token preflight cannot report a
+    different selected provider than the gate will try first.
+    """
+    plan = _with_review_semantic_tags(plan_for("review", effort), tags)
+    review_exclude, review_reasons = _review_exclude_set(exclude)
+    exclude_set = _semantic_candidate_exclude_set(plan, review_exclude)
+    try:
+        _provider, decision = pick(
+            list(plan.tags),
+            prefer=prefer or plan.prefer,
+            effort=effort,
+            exclude=exclude_set,
+            priority=_semantic_priority(plan),
+            shadow=True,
+            estimated_input_tokens=estimated_input_tokens,
+        )
+    except (NoConfiguredProvider, InvalidRouterRequest, MutedProvidersError) as e:
+        raise _ReviewRouteSelectionError(e, review_reasons) from e
+    return _apply_semantic_priority_to_decision(decision, plan), review_reasons, plan
+
+
 def _review_no_viable_provider_error(
     review_reasons: dict[str, str],
     cause: Exception,
@@ -4774,8 +4817,6 @@ def ask(
 
     dispatch_started_at = time.monotonic()
     if plan.mode == "review":
-        review_exclude, review_reasons = _review_exclude_set(frozenset())
-        exclude_set = _semantic_candidate_exclude_set(plan, review_exclude)
         review_estimated_input_tokens = _estimate_review_input_tokens(
             body,
             base=base,
@@ -4784,18 +4825,15 @@ def ask(
             cwd=cwd,
         )
         try:
-            _provider, decision = pick(
-                list(plan.tags),
-                prefer=plan.prefer,
+            decision, review_reasons, plan = _build_review_route_decision(
                 effort=effort_value,
-                exclude=exclude_set,
-                priority=_semantic_priority(plan),
-                shadow=True,
+                tags=user_tags,
+                prefer=None,
+                exclude=frozenset(),
                 estimated_input_tokens=review_estimated_input_tokens,
             )
-            decision = _apply_semantic_priority_to_decision(decision, plan)
-        except (NoConfiguredProvider, InvalidRouterRequest, MutedProvidersError) as e:
-            _emit_review_route_failure(review_reasons, e, as_json=as_json)
+        except _ReviewRouteSelectionError as e:
+            _emit_review_route_failure(e.review_reasons, e.cause, as_json=as_json)
             sys.exit(2)
         print_caller_banner(decision.provider, silent=silent_route or as_json)
         _emit_route_log(decision, verbose=verbose_route, silent=silent_route or as_json)
@@ -5743,25 +5781,18 @@ def review(
     decision: RouteDecision | None = None
     fallbacks: list[str] = []
     if auto_route:
-        plan = plan_for("review", effort_value)
         user_tags = tuple(_parse_csv(tags))
-        plan = _with_review_semantic_tags(plan, user_tags)
         user_exclude = frozenset(_parse_csv(exclude))
-        review_exclude, review_reasons = _review_exclude_set(user_exclude)
-        exclude_set = _semantic_candidate_exclude_set(plan, review_exclude)
         try:
-            _provider, decision = pick(
-                list(plan.tags),
-                prefer=prefer_value or plan.prefer,
+            decision, review_reasons, plan = _build_review_route_decision(
                 effort=effort_value,
-                exclude=exclude_set,
-                priority=_semantic_priority(plan),
-                shadow=True,
+                tags=user_tags,
+                prefer=prefer_value,
+                exclude=user_exclude,
                 estimated_input_tokens=estimated_input_tokens,
             )
-            decision = _apply_semantic_priority_to_decision(decision, plan)
-        except (NoConfiguredProvider, InvalidRouterRequest, MutedProvidersError) as e:
-            _emit_review_route_failure(review_reasons, e, as_json=as_json)
+        except _ReviewRouteSelectionError as e:
+            _emit_review_route_failure(e.review_reasons, e.cause, as_json=as_json)
             sys.exit(2)
         print_caller_banner(decision.provider, silent=silent_route or as_json)
         _emit_route_log(decision, verbose=verbose_route, silent=silent_route or as_json)
@@ -11098,7 +11129,7 @@ def _route_validation_payload(
     kind: str,
     provider_id: str | None,
     tags: tuple[str, ...],
-    prefer: str,
+    prefer: str | None,
     effort: str | int,
     tools: frozenset[str],
     sandbox: str,
@@ -11166,19 +11197,36 @@ def _route_validation_payload(
             selected_provider = str(selected["provider"])
             selected_model = str(selected["model"])
             route_mode = str(selected["mode"])
+    elif kind == "review":
+        try:
+            decision, _review_reasons, _plan = _build_review_route_decision(
+                effort=effort,
+                tags=tuple(tags),
+                prefer=prefer,
+                exclude=exclude,
+                estimated_input_tokens=estimated_input_tokens,
+            )
+            selected_provider = decision.provider
+            selected_assessment = next(
+                entry for entry in viable_assessments if entry["provider"] == decision.provider
+            )
+            selected_model = str(selected_assessment["model"])
+            route_mode = str(selected_assessment["mode"])
+            ranked_order = [candidate.name for candidate in decision.ranked]
+            by_name = {str(entry["provider"]): entry for entry in viable_assessments}
+            ordered_candidates = [by_name[name] for name in ranked_order if name in by_name]
+            decision_payload = asdict(decision)
+        except _ReviewRouteSelectionError:
+            selected_provider = None
     else:
-        route_exclude = set(exclude)
-        if kind == "review":
-            review_exclude, _review_reasons = _review_exclude_set(frozenset(exclude))
-            route_exclude.update(review_exclude)
         try:
             _provider, decision = pick(
                 list(requested_tags),
-                prefer=prefer,
+                prefer=prefer or "balanced",
                 effort=effort,
                 tools=tools if kind == "exec" else frozenset(),
                 sandbox=sandbox,
-                exclude=route_exclude,
+                exclude=exclude,
                 shadow=True,
                 estimated_input_tokens=estimated_input_tokens,
                 estimated_output_tokens=estimated_output_tokens,
@@ -11341,7 +11389,7 @@ def route(
             kind=kind,
             provider_id=provider_id,
             tags=tag_values,
-            prefer=_validate_prefer(prefer),
+            prefer=_validate_prefer(prefer) if prefer is not None else None,
             effort=effort_value,
             tools=tools_set,
             sandbox=sandbox_value,

--- a/src/conductor/providers/codex.py
+++ b/src/conductor/providers/codex.py
@@ -90,7 +90,6 @@ CODEX_STALL_KNOWN_NON_PROGRESS_EVENTS = frozenset(
 )
 CODEX_STREAM_POLL_INTERVAL_SEC = 0.05
 CODEX_STREAM_EXIT_READER_JOIN_SEC = 0.2
-CODEX_REVIEW_CONTRACT_RETRY_PREVIEW_CHARS = 4000
 
 # Sentinel distinguishing "caller didn't specify a timeout" from "caller
 # explicitly asked for no timeout (None)". The constructor default applies
@@ -140,13 +139,6 @@ _CODEX_EXEC_RESUME_DROPPED_OPTION_ARITY = {
 }
 
 
-def _remaining_review_timeout(timeout: float | None, start: float) -> float | None:
-    if timeout is None:
-        return None
-    remaining = timeout - (time.monotonic() - start)
-    return max(0.001, remaining)
-
-
 def _extract_review_stdout(result: subprocess.CompletedProcess[str]) -> str:
     if result.returncode != 0:
         raise ProviderHTTPError(
@@ -159,46 +151,6 @@ def _extract_review_stdout(result: subprocess.CompletedProcess[str]) -> str:
             f"codex review produced empty stdout: {result.stderr[:500]!r}"
         )
     return content
-
-
-def _build_review_contract_retry_prompt(
-    task: str,
-    *,
-    reason: str,
-    previous_output: str,
-) -> str:
-    previous = previous_output.strip()
-    if len(previous) > CODEX_REVIEW_CONTRACT_RETRY_PREVIEW_CHARS:
-        previous = previous[-CODEX_REVIEW_CONTRACT_RETRY_PREVIEW_CHARS:]
-
-    return f"""{task.rstrip()}
-
-## Conductor review output contract retry
-
-Your previous Codex review output did not satisfy Conductor's required
-review output contract.
-
-Contract failure: {reason}
-
-Re-run the review for the same target. Return the full review result again.
-The final line must be exactly one standalone sentinel:
-
-- CODEX_REVIEW_CLEAN
-- CODEX_REVIEW_FIXED
-- CODEX_REVIEW_BLOCKED
-
-Rules:
-
-- Emit exactly one standalone CODEX_REVIEW_* line.
-- Do not include any text after the sentinel.
-- If you are not certain the change is clean, use CODEX_REVIEW_BLOCKED.
-
-Previous non-compliant output:
-
-```text
-{previous}
-```
-"""
 
 
 def _codex_output_path(resume_session_id: str | None) -> Path:
@@ -638,22 +590,15 @@ class CodexProvider:
         _ = max_stall_sec
         timeout = self._timeout_sec if timeout_sec is None else timeout_sec
         start = time.monotonic()
-        contract_retry_reason: str | None = None
-        first_stderr: str | None = None
 
-        def run_review_once(
-            prompt: str, *, is_retry: bool = False
-        ) -> subprocess.CompletedProcess[str]:
-            review_timeout = (
-                _remaining_review_timeout(timeout, start) if is_retry else timeout
-            )
+        def run_review_once(prompt: str) -> subprocess.CompletedProcess[str]:
             try:
                 return subprocess.run(
                     args,
                     input=prompt,
                     capture_output=True,
                     text=True,
-                    timeout=review_timeout,
+                    timeout=timeout,
                     cwd=cwd,
                 )
             except subprocess.TimeoutExpired as e:
@@ -670,26 +615,14 @@ class CodexProvider:
                 prompt=review_prompt,
                 text=content,
             )
-        except ReviewOutputContractError as first_error:
-            contract_retry_reason = first_error.reason
-            first_stderr = result.stderr
+        except ReviewOutputContractError as e:
             print(
                 "[conductor] codex review output-contract failure "
-                f"({first_error.reason}); retrying once with stricter "
-                "sentinel instructions",
+                f"({e.reason}); failing this attempt so review fallback can "
+                "try the next provider",
                 file=sys.stderr,
             )
-            retry_prompt = _build_review_contract_retry_prompt(
-                review_prompt,
-                reason=first_error.reason,
-                previous_output=content,
-            )
-            result = run_review_once(retry_prompt, is_retry=True)
-            content = validate_requested_review_sentinel(
-                provider_name=self.name,
-                prompt=retry_prompt,
-                text=_extract_review_stdout(result),
-            )
+            raise
         duration_ms = int((time.monotonic() - start) * 1000)
 
         raw: dict[str, object] = {
@@ -702,11 +635,6 @@ class CodexProvider:
                 "title": title,
             },
         }
-        if contract_retry_reason is not None:
-            raw["contract_retry"] = {
-                "reason": contract_retry_reason,
-                "first_stderr": first_stderr,
-            }
 
         return CallResponse(
             text=content,

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -1682,51 +1682,40 @@ def test_codex_review_encodes_uncommitted_target_in_prompt(mocker):
     assert "Use AGENTS.md rubric." in prompt
 
 
-def test_codex_review_retries_missing_requested_sentinel_once(mocker):
+def test_codex_review_fails_fast_on_missing_requested_sentinel(mocker, capsys):
     mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
     captured = mocker.patch(
         "conductor.providers.codex.subprocess.run",
-        side_effect=[
-            _fake_completed(stdout="No blocking issues were found.\n"),
-            _fake_completed(stdout="No blocking issues were found.\nCODEX_REVIEW_CLEAN\n"),
-        ],
+        return_value=_fake_completed(stdout="No blocking issues were found.\n"),
     )
 
-    response = CodexProvider().review(
-        "Return a final standalone CODEX_REVIEW_CLEAN or CODEX_REVIEW_BLOCKED line.",
-        base="origin/main",
+    with pytest.raises(ReviewOutputContractError, match="missing"):
+        CodexProvider().review(
+            "Return a final standalone CODEX_REVIEW_CLEAN or CODEX_REVIEW_BLOCKED line.",
+            base="origin/main",
+        )
+
+    assert captured.call_count == 1
+    prompt = captured.call_args.kwargs["input"]
+    assert "Review changes against base branch/ref: origin/main" in prompt
+    assert (
+        "failing this attempt so review fallback can try the next provider"
+        in capsys.readouterr().err
     )
 
-    assert captured.call_count == 2
-    first_args = captured.call_args_list[0].args[0]
-    second_args = captured.call_args_list[1].args[0]
-    assert first_args == second_args
-    assert "--base" not in second_args
-    retry_prompt = captured.call_args_list[1].kwargs["input"]
-    assert "Conductor review output contract retry" in retry_prompt
-    assert "Review changes against base branch/ref: origin/main" in retry_prompt
-    assert "Contract failure: missing" in retry_prompt
-    assert "Do not include any text after the sentinel." in retry_prompt
-    assert "No blocking issues were found." in retry_prompt
-    assert response.text == "No blocking issues were found.\nCODEX_REVIEW_CLEAN"
-    assert response.raw["contract_retry"]["reason"] == "missing"
 
-
-def test_codex_review_rejects_missing_requested_sentinel_after_retry(mocker):
+def test_codex_review_rejects_missing_requested_sentinel_without_retry(mocker):
     mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
     captured = mocker.patch(
         "conductor.providers.codex.subprocess.run",
-        side_effect=[
-            _fake_completed(stdout="The changes need operator review.\n"),
-            _fake_completed(stdout="The changes still need operator review.\n"),
-        ],
+        return_value=_fake_completed(stdout="The changes need operator review.\n"),
     )
 
     with pytest.raises(ReviewOutputContractError, match="codex review output"):
         CodexProvider().review(
             "Return a final standalone CODEX_REVIEW_CLEAN or CODEX_REVIEW_BLOCKED line.",
         )
-    assert captured.call_count == 2
+    assert captured.call_count == 1
 
 
 def test_codex_review_accepts_sentinel_with_footer(mocker):

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -4141,6 +4141,28 @@ def test_route_prints_chosen_provider_without_calling(mocker):
     assert not call_mock.called  # router dry-run makes no calls
 
 
+def test_route_kind_review_matches_semantic_review_dispatch(mocker):
+    _stub_all_configured(mocker, {"claude", "codex"})
+    codex_review = mocker.patch.object(CodexProvider, "review")
+    claude_review = mocker.patch.object(ClaudeProvider, "review")
+
+    result = CliRunner().invoke(
+        main,
+        ["route", "--kind", "review", "--effort", "high", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["selected_provider"] == "codex"
+    assert [candidate["provider"] for candidate in payload["candidates"][:2]] == [
+        "codex",
+        "claude",
+    ]
+    assert payload["decision"]["provider"] == "codex"
+    assert not codex_review.called
+    assert not claude_review.called
+
+
 def test_route_json_mode(mocker):
     _stub_all_configured(mocker, {"claude"})
     result = CliRunner().invoke(main, ["route", "--prefer", "best", "--json"])


### PR DESCRIPTION
## Linked Issues

Closes #420

Share semantic review route selection between no-token route validation and live review dispatch, and remove Codex's internal full output-contract retry so malformed review output fails that attempt immediately and lets the review fallback chain continue.

Closes #420

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
