### PR TITLE
fix(openrouter): opt in to usage.cost reporting

### DIFF
--- a/src/conductor/providers/openrouter.py
+++ b/src/conductor/providers/openrouter.py
@@ -208,6 +208,11 @@ class OpenRouterProvider:
         return True, None
 
     def _post_chat(self, payload: dict, *, timeout_sec: float | None = None) -> dict:
+        # OpenRouter only populates `usage.cost` (and other usage details) in
+        # the response when the request opts in via `usage: {include: true}`.
+        # Without it, multi-turn exec/review sessions log per-iteration cost
+        # as None and the aggregated delegation cost under-reports by ~10x.
+        payload = {**payload, "usage": {"include": True}}
         try:
             timeout = self._timeout_sec if timeout_sec is None else timeout_sec
             with provider_http_client(timeout=timeout) as client:

--- a/tests/test_deepseek_migration.py
+++ b/tests/test_deepseek_migration.py
@@ -102,6 +102,7 @@ def test_deepseek_chat_call_uses_preset_openrouter_model(monkeypatch):
     assert captured["payload"] == {
         "model": DEEPSEEK_CHAT_MODEL,
         "messages": [{"role": "user", "content": "hi"}],
+        "usage": {"include": True},
     }
 
 

--- a/tests/test_kimi_migration.py
+++ b/tests/test_kimi_migration.py
@@ -88,6 +88,7 @@ def test_kimi_call_uses_preset_openrouter_model(monkeypatch):
         "model": KIMI_DEFAULT_MODEL,
         "messages": [{"role": "user", "content": "hi"}],
         "reasoning": {"effort": "medium"},
+        "usage": {"include": True},
     }
 
 

--- a/tests/test_openrouter.py
+++ b/tests/test_openrouter.py
@@ -427,7 +427,37 @@ def test_call_sends_reasoning_effort_and_openrouter_headers(configured):
         "model": "anthropic/claude-sonnet-4",
         "messages": [{"role": "user", "content": "hi"}],
         "reasoning": {"effort": "xhigh"},
+        "usage": {"include": True},
     }
+
+
+def test_call_opts_in_to_usage_cost_reporting(configured):
+    """OpenRouter only populates usage.cost in the response when the request
+    includes usage:{include:true}. Without it, multi-turn exec sessions log
+    per-iteration cost as None and the aggregated delegation cost
+    under-reports by ~10x. Lock the request side so future refactors don't
+    silently drop the opt-in. (Regression for #446.)"""
+    captured: dict[str, object] = {}
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        captured["payload"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "model": OPENROUTER_DEFAULT_MODEL,
+                "choices": [{"message": {"content": "ok"}}],
+                "usage": {},
+            },
+        )
+
+    with respx.mock(
+        base_url="https://openrouter.ai/api/v1",
+        assert_all_called=False,
+    ) as router:
+        router.post("/chat/completions").mock(side_effect=_record)
+        OpenRouterProvider().call("hi", model="openai/gpt-5.5")
+
+    assert captured["payload"]["usage"] == {"include": True}
 
 
 def test_call_sends_ordered_models_stack(configured):
@@ -465,6 +495,7 @@ def test_call_sends_ordered_models_stack(configured):
         ],
         "messages": [{"role": "user", "content": "hi"}],
         "reasoning": {"effort": "low"},
+        "usage": {"include": True},
     }
     assert len(captured["payload"]["models"]) <= OPENROUTER_MODELS_ARRAY_MAX
 
@@ -513,6 +544,7 @@ def test_call_without_model_invokes_selector_and_builds_payload(configured, mock
         "model": OPENROUTER_DEFAULT_MODEL,
         "messages": [{"role": "user", "content": "hi"}],
         "reasoning": {"effort": "medium"},
+        "usage": {"include": True},
     }
     assert response.model == "google/gemini-flash-1.5"
 


### PR DESCRIPTION
## Linked Issues

Closes #446

OpenRouter only populates `usage.cost` in chat-completion responses when
the request includes `usage: {include: true}`. Without that opt-in the
field is missing, `_usage_cost_usd` returns None, and multi-turn exec
sessions log per-iteration cost as None — so the aggregated delegation
cost in `~/.cache/conductor/delegations.ndjson` under-reports by ~10x.

Empirical evidence (2026-05-14 → 2026-05-15, 36h window):
- delegations.ndjson:  $3.05 across 91 openrouter delegations
- OpenRouter billing: $31.21 across 1305 underlying API calls
- Call-count ratio matches expected ~14 iterations/exec session
  (cap=10 + up to 3 stretches + retries), so call accounting is
  correct — only cost attribution was broken.

Add `usage: {include: true}` to every chat-completion request in
`_post_chat`, plus a dedicated regression test that captures the
outbound request and asserts the opt-in flag is present. Update three
existing payload-equality tests in test_openrouter / test_kimi_migration
/ test_deepseek_migration that locked in the prior payload shape.

Closes #446

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
