### PR TITLE
fix(tests): isolate XDG_CACHE_HOME in test_adapters_subprocess.py

### DIFF
--- a/.cortex/journal/2026-05-15-alchemist-447.md
+++ b/.cortex/journal/2026-05-15-alchemist-447.md
@@ -1,0 +1,44 @@
+---
+title: alchemist transmuted issue #447
+date: 2026-05-15T19:18:29.028081+00:00
+type: alchemist-cycle
+trigger: T1.6-alchemist
+issue: https://github.com/autumngarage/conductor/issues/447
+branch: alchemist/issue-447-tests-write-stall-fixtures-to-real-user-
+provider: openrouter
+brief_template: 2
+---
+
+# Alchemist transmuted issue #447
+
+## Issue
+
+> Tests write stall fixtures to real user cache (~3,660 files accumulated)
+
+Source: https://github.com/autumngarage/conductor/issues/447
+
+## Cycle
+
+- Branch: `alchemist/issue-447-tests-write-stall-fixtures-to-real-user-`
+- Provider: `openrouter`
+- Brief template: v2
+
+## Agent summary
+
+```
+cache (`~/.cache/conductor`), preventing future stall-envelope pollution.
+
+---
+
+### Verification
+
+I ran the issue-relevant codex tests directly, and they pass:
+
+- `test_codex_exec_explicit_timeout_is_honored`
+- `test_codex_exec_stall_watchdog_ignores_subagent_message_heartbeats`
+- `test_codex_exec_heartbeat_falls_back_when_session_log_missing`
+
+Result: **3 passed**.
+
+I also ran the whole file once; two pre-existing claude tests fail in this container environment (one depends on `USER` being set for ps probe, one on POSIX process-group behavior), unrelated to this codex cache isolation change.
+```

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -55,6 +55,11 @@ from conductor.session_log import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _isolate_xdg_cache_home(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+
+
 def _strip_gemini_auth_env(monkeypatch) -> None:
     """Clear any GEMINI/GOOGLE auth env vars inherited from the host shell.
 


### PR DESCRIPTION
Closes #447

Re-lands the diff from #449 (originally authored by @autumn-alchemist) on a properly-named branch.

## Why

`tests/test_adapters_subprocess.py` has 59 tests that mock `shutil.which` to return `/usr/bin/codex`. 17 of them already isolate `XDG_CACHE_HOME` to a tmp dir, but the remaining tests trigger code paths that write stall envelopes into the user's real `~/.cache/conductor/`. Empirically that produced ~3,660 synthetic `codex-*.json` stall files on my machine. Three specific tests are the active polluters (`sess-slow`, `sess-subagent-heartbeats`, `sess-heartbeat-fallback` fixtures), but the right structural fix is a module-level guardrail rather than fixing each test individually.

## Fix

One autouse fixture at module scope:

\`\`\`python
@pytest.fixture(autouse=True)
def _isolate_xdg_cache_home(monkeypatch, tmp_path) -> None:
    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
\`\`\`

This catches the next instance of the pattern automatically — exactly the guardrail discipline from `principles/audit-weak-points.md`.

## Cleanup of accumulated pollution

After this merges, a one-off `rm ~/.cache/conductor/codex-*.json` clears the existing ~3,660 stale files. Not part of this PR — manual operator step.

## Why not merging #449 directly

PR #449 was opened by `autumn-alchemist` on the `alchemist/...` branch namespace. The pre-push hook in this repo rejects branches that don't match `feat/`, `fix/`, `chore/`, `refactor/`, or `docs/` prefixes, so I couldn't rebase #449's branch directly after #451 landed and made it out of date. Re-shipping on `fix/issue-447-test-cache-isolation` is the clean path; closed #449 with an explanation.