### PR TITLE
fix(cli): foreground --kind/--effort cost shape; hard-break --sandbox

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -172,11 +172,16 @@ EXEC_PERMISSION_PROFILES: dict[str, frozenset[str]] = {
     "patch": frozenset({"Read", "Grep", "Glob", "Edit", "Write"}),
     "full": frozenset(VALID_TOOLS),
 }
-SANDBOX_DEPRECATION_WARNING = (
-    "[conductor] --sandbox is deprecated and ignored; conductor exec runs "
-    "unsandboxed. Use --permission-profile for an enforceable Conductor "
-    "tool whitelist."
+SANDBOX_REMOVED_MESSAGE = (
+    "--sandbox is removed; conductor exec runs unsandboxed. "
+    "Use --permission-profile for an enforceable tool whitelist "
+    "(read-only | patch | full). "
+    "Drop the --sandbox flag and the call will succeed."
 )
+# Back-compat alias for downstream consumers that imported the old name.
+# Both names point at the same string; the message itself describes the
+# new (hard-break) behavior, not the previous (silently-ignored) one.
+SANDBOX_DEPRECATION_WARNING = SANDBOX_REMOVED_MESSAGE
 VALID_EFFORT_LEVELS = ("minimal", "low", "medium", "high", "max")
 PROFILE_PRECEDENCE_TEXT = (
     "Resolution order: profile defaults < CONDUCTOR_* env vars < explicit CLI flags."
@@ -1083,9 +1088,16 @@ def _ensure_permission_profile_supported(
 def _validate_sandbox(raw: str | None, *, warn: bool = False) -> str:
     if raw is None:
         return "none"
-    if warn:
-        click.echo(SANDBOX_DEPRECATION_WARNING, err=True)
-    return "none"
+    # Hard-break per agent-first surface design: a silently-ignored flag is
+    # a hallucination trap (council feedback on the surface-simplification
+    # proposal). Agents reading old logs or training data will retry
+    # --sandbox and silently get default behavior with no signal that the
+    # flag did nothing. Raise instead so the call fails loudly and the
+    # agent rewrites the command. (The CLI flag is the only path here;
+    # profile.sandbox and CONDUCTOR_SANDBOX env get stripped before
+    # reaching this validator — see _resolve_layered_value sandbox
+    # callsite.)
+    raise click.UsageError(SANDBOX_REMOVED_MESSAGE)
 
 
 def _validate_prefer(raw: str | None) -> str:
@@ -4597,14 +4609,26 @@ def main(ctx: click.Context) -> None:
     required=True,
     type=click.Choice(SEMANTIC_KINDS),
     help=(
-        "Semantic work category. research/code are cheap single-model defaults; "
-        "council is capped OpenRouter multi-model fan-out."
+        "What kind of work this is. Picks the provider stack and physical "
+        "execution shape:\n"
+        "  research = cheap single-model lookup / synthesis\n"
+        "  code     = coding-optimized stack; --effort high switches to a "
+        "multi-turn agent loop\n"
+        "  review   = code review cascade (codex → claude → openrouter)\n"
+        "  council  = multi-model fan-out, cost-capped"
     ),
 )
 @click.option(
     "--effort",
     default=None,
-    help=f"Thinking depth: {' | '.join(VALID_EFFORT_LEVELS)} or integer budget.",
+    help=(
+        "How hard the task is. Higher levels cost more:\n"
+        "  minimal / low = single-shot, cheap models, ~$0.001-0.01/call typical\n"
+        "  medium        = balanced default, ~$0.01-0.10/call typical\n"
+        "  high / max    = curated quality stack; for --kind code this switches "
+        "to a multi-turn agent loop (10-30x cost, $0.30-1.50/session typical)\n"
+        "Or pass an integer for an explicit thinking-token budget."
+    ),
 )
 @click.option(
     "--tags",
@@ -10240,7 +10264,10 @@ def _run_exec_phase_dispatch(
 @click.option(
     "--sandbox",
     default=None,
-    help="Deprecated and ignored; exec always runs unsandboxed.",
+    help=(
+        "Removed. Pass --permission-profile {read-only|patch|full} for an "
+        "enforceable tool whitelist."
+    ),
 )
 @click.option(
     "--exclude",
@@ -10512,11 +10539,14 @@ def exec_cmd(
         permission_profile,
         env_key="CONDUCTOR_PERMISSION_PROFILE",
     )
-    sandbox = _resolve_layered_value(
-        sandbox,
-        env_key="CONDUCTOR_SANDBOX",
-        profile_value=profile_spec.sandbox if profile_spec else None,
-    )
+    # `--sandbox` is removed (raised on explicit use by _validate_sandbox).
+    # Don't consult env or profile — existing user profiles and
+    # CONDUCTOR_SANDBOX env vars shouldn't break every invocation; only
+    # the explicit CLI flag should fail loudly. This is the "hard-break
+    # the surface, soft-break the stored config" trade-off from the
+    # agent-first design discussion.
+    # sandbox stays exactly as the CLI flag passed it (None unless
+    # explicit), which routes into _validate_sandbox below.
     exclude = _resolve_layered_value(exclude, env_key="CONDUCTOR_EXCLUDE")
     provider_id, auto = _apply_offline_flag(offline=offline, provider_id=provider_id, auto=auto)
     if offline is True and provider_id == "ollama":

--- a/tests/test_cli_log_file.py
+++ b/tests/test_cli_log_file.py
@@ -181,8 +181,6 @@ def test_exec_log_file_writes_structured_ndjson_for_auto_route(
             "best",
             "--tools",
             "Read",
-            "--sandbox",
-            "read-only",
             "--task",
             "review the diff",
             "--log-file",

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -26,7 +26,6 @@ from click.testing import CliRunner
 
 from conductor import offline_mode
 from conductor.cli import (
-    SANDBOX_DEPRECATION_WARNING,
     _estimate_review_input_tokens,
     _estimate_text_tokens,
     _resolve_exec_max_iterations,
@@ -2438,8 +2437,6 @@ def test_exec_auto_routes_to_tool_capable_provider(mocker):
             "best",
             "--tools",
             "Read,Grep,Edit",
-            "--sandbox",
-            "read-only",
             "--task",
             "review the diff",
         ],
@@ -2447,7 +2444,6 @@ def test_exec_auto_routes_to_tool_capable_provider(mocker):
 
     assert result.exit_code == 0
     assert exec_mock.called
-    assert SANDBOX_DEPRECATION_WARNING in result.stderr
     # kimi would be skipped by the tools filter (supported_tools=frozenset()).
     assert "→ claude" in result.stderr
 
@@ -2494,7 +2490,10 @@ def test_exec_no_write_validation_passes_through_to_http_tool_provider(mocker):
 
 
 @pytest.mark.parametrize("sandbox", ["workspace-write", "read-only", "strict", "none", "surprise"])
-def test_exec_sandbox_values_warn_once_and_are_ignored(mocker, sandbox):
+def test_exec_sandbox_flag_is_hard_break(mocker, sandbox):
+    """--sandbox is removed; passing it errors loudly with a migration hint.
+    Hard-break beats silent compat for agent consumers (agents may retry
+    --sandbox from training data; silent ignore would mislead them)."""
     _stub_all_configured(mocker, {"codex"})
     exec_mock = mocker.patch.object(CodexProvider, "exec", return_value=_fake_response("codex"))
 
@@ -2503,12 +2502,13 @@ def test_exec_sandbox_values_warn_once_and_are_ignored(mocker, sandbox):
         ["exec", "--auto", "--sandbox", sandbox, "--no-preflight", "--task", "hi"],
     )
 
-    assert result.exit_code == 0, result.output
-    assert result.stderr.count(SANDBOX_DEPRECATION_WARNING) == 1
-    assert exec_mock.call_args.kwargs["sandbox"] == "none"
+    assert result.exit_code != 0
+    assert "--sandbox is removed" in result.output
+    assert "--permission-profile" in result.output
+    assert not exec_mock.called
 
 
-def test_exec_without_sandbox_does_not_warn(mocker):
+def test_exec_without_sandbox_succeeds_without_warning(mocker):
     _stub_all_configured(mocker, {"codex"})
     mocker.patch.object(CodexProvider, "exec", return_value=_fake_response("codex"))
 
@@ -2518,7 +2518,7 @@ def test_exec_without_sandbox_does_not_warn(mocker):
     )
 
     assert result.exit_code == 0, result.output
-    assert SANDBOX_DEPRECATION_WARNING not in result.stderr
+    assert "--sandbox is removed" not in result.stderr
 
 
 def test_exec_auto_cheapest_code_review_online_excludes_ollama_primary(mocker):

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -99,6 +99,9 @@ def test_exec_profile_uses_builtin_defaults_without_sandbox(mocker):
 
 
 def test_user_profile_overrides_builtin(mocker, monkeypatch, tmp_path):
+    """Existing profiles with a `sandbox` field continue to load (silently
+    stripped) — the hard-break is only for the explicit CLI flag, not for
+    stored user config that may have been written months ago."""
     profiles_file = tmp_path / "profiles.toml"
     profiles_file.write_text(
         '[profiles.coding]\n'
@@ -139,7 +142,6 @@ def test_user_profile_overrides_builtin(mocker, monkeypatch, tmp_path):
     assert pick_mock.call_args.kwargs["prefer"] == "balanced"
     assert pick_mock.call_args.kwargs["effort"] == "low"
     assert pick_mock.call_args.kwargs["sandbox"] == "none"
-    assert result.stderr.count(SANDBOX_DEPRECATION_WARNING) == 1
 
 
 def test_unknown_profile_raises_usage_error():
@@ -175,8 +177,6 @@ def test_explicit_flags_override_profile_defaults(mocker):
             "high",
             "--tags",
             "coding,tool-use",
-            "--sandbox",
-            "workspace-write",
             "--tools",
             "Read",
             "--no-preflight",
@@ -190,10 +190,12 @@ def test_explicit_flags_override_profile_defaults(mocker):
     assert pick_mock.call_args.kwargs["prefer"] == "best"
     assert pick_mock.call_args.kwargs["effort"] == "high"
     assert pick_mock.call_args.kwargs["sandbox"] == "none"
-    assert result.stderr.count(SANDBOX_DEPRECATION_WARNING) == 1
 
 
 def test_profile_env_cli_precedence(mocker, monkeypatch):
+    """CONDUCTOR_SANDBOX env var is silently dropped (the hard-break is
+    only on the explicit --sandbox CLI flag, not on stored config that the
+    user may have set months ago and forgotten about)."""
     monkeypatch.setenv("CONDUCTOR_PREFER", "fastest")
     monkeypatch.setenv("CONDUCTOR_EFFORT", "low")
     monkeypatch.setenv("CONDUCTOR_TAGS", "cheap")
@@ -232,7 +234,6 @@ def test_profile_env_cli_precedence(mocker, monkeypatch):
     assert pick_mock.call_args.kwargs["prefer"] == "fastest"
     assert pick_mock.call_args.kwargs["effort"] == "high"
     assert pick_mock.call_args.kwargs["sandbox"] == "none"
-    assert result.stderr.count(SANDBOX_DEPRECATION_WARNING) == 1
 
 
 def test_profiles_list_and_show_smoke(monkeypatch, tmp_path):


### PR DESCRIPTION
Two surface changes from the agent-first design discussion (a council
review of the surface-simplification proposal pushed back against
silently-ignored deprecated flags as a hallucination trap for LLM
consumers of the CLI).

1. Beef up --kind and --effort help text with cost-shape annotations
   so the price tier is visible at decision time. The cost cliff
   between `--effort medium` and `--effort high` for `--kind code`
   (the latter switches mode=call → mode=exec and routes to a
   curated coding stack ~10-30x more expensive) was previously
   invisible from `--help` and only discoverable by reading source.

2. Hard-break the deprecated --sandbox CLI flag. Previously the flag
   was silently ignored with a stderr warning. Council finding from
   the surface review: silently-ignored flags are a hallucination
   trap — agents reading old training data or logs will retry
   --sandbox, see no error, assume their input was honored. Better
   to fail loudly with a migration message so the agent rewrites
   the call.

   Scope choice: hard-break only the explicit CLI flag, not the
   stored config paths (CONDUCTOR_SANDBOX env, profile.sandbox key
   in TOML). Users with months-old profile files shouldn't see
   every invocation break — only fresh explicit input fails.

   _validate_sandbox now raises click.UsageError for any non-None
   input; env/profile values are stripped before reaching it.

   Backwards-compat: SANDBOX_DEPRECATION_WARNING is kept as an alias
   for SANDBOX_REMOVED_MESSAGE so downstream consumers that imported
   the old constant continue to import successfully.

Tests: updated five tests that previously asserted on the silently-
ignored sandbox behavior. The deprecation-warning tests become
hard-break-error tests; the profile/env tests verify silent-strip
of stored config.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
