### PR TITLE
fix(gemini): surface internal tool failures + stop mislabeling them as rate limits

### DIFF
--- a/src/conductor/providers/gemini.py
+++ b/src/conductor/providers/gemini.py
@@ -626,6 +626,14 @@ class GeminiProvider:
                 auth_prompts=tracker.prompts or None,
             )
 
+        # Gemini's CLI exits 0 even when its internal tools (replace,
+        # write_file, etc.) error mid-session. Without inspecting the JSON
+        # tool stats we silently return success and the caller doesn't
+        # learn that gemini left partial edits behind. See issue #443.
+        tool_failures = _gemini_tool_failures(data)
+        if tool_failures:
+            raise ProviderHTTPError(_gemini_tool_failure_message(tool_failures))
+
         input_tokens, output_tokens = self._sum_usage(data)
         # Gemini's JSON output may carry a session identifier under one of
         # several keys depending on CLI version (`session_id` is the
@@ -708,3 +716,39 @@ def _gemini_used_write_file(data: dict) -> bool:
         if isinstance(count, int) and count > 0:
             return True
     return False
+
+
+def _gemini_tool_failures(data: dict) -> list[tuple[str, int]]:
+    """Return (tool_name, fail_count) pairs from Gemini's per-tool stats.
+
+    Gemini CLI's JSON output records fails per tool under
+    ``stats.tools.byName.<name>.fail`` (camelCase ``byName`` since 0.36+,
+    ``by_name`` in older builds). A non-zero fail count means a tool
+    invocation errored at runtime — for ``replace`` / ``write_file`` /
+    ``Edit`` this typically leaves a partially-applied edit on disk.
+    """
+    stats = data.get("stats") or {}
+    tools = stats.get("tools") or {}
+    by_name = tools.get("byName") or tools.get("by_name") or {}
+    if not isinstance(by_name, dict):
+        return []
+    failures: list[tuple[str, int]] = []
+    for name, entry in by_name.items():
+        if not isinstance(entry, dict):
+            continue
+        fail = entry.get("fail")
+        if isinstance(fail, int) and fail > 0 and isinstance(name, str):
+            failures.append((name, fail))
+    failures.sort(key=lambda pair: (-pair[1], pair[0]))
+    return failures
+
+
+def _gemini_tool_failure_message(failures: list[tuple[str, int]]) -> str:
+    summary = ", ".join(
+        f"{name}={count}" if count != 1 else name for name, count in failures
+    )
+    return (
+        f"gemini agent reported tool failures ({summary}); "
+        "the agent may have left partially-applied edits in the working tree. "
+        "Inspect `git status --short` and revert as needed."
+    )

--- a/src/conductor/providers/terminal_signals.py
+++ b/src/conductor/providers/terminal_signals.py
@@ -14,7 +14,7 @@ import re
 from dataclasses import dataclass
 from typing import Any, Literal
 
-FailureCategory = Literal["rate-limit", "5xx", "network", "provider-error"]
+FailureCategory = Literal["rate-limit", "5xx", "network", "tool-error", "provider-error"]
 
 RECENT_TEXT_LIMIT = 4_000
 
@@ -65,6 +65,21 @@ _NETWORK_SIGNALS = (
     "getaddrinfo failed",
 )
 
+# Patterns the agent CLI prints when its OWN internal tool call errored at
+# runtime (not an upstream rate-limit / network issue). Detecting these
+# explicitly prevents misclassifying tool failures as rate-limit when the
+# stderr buffer happens to contain rate-limit-shaped text further downstream.
+_TOOL_ERROR_SIGNALS = (
+    "error executing tool",
+    "tool execution failed",
+    "tool execution error",
+)
+
+_TOOL_ERROR_RE = re.compile(
+    r"error executing tool\s+(\S+)|tool execution (?:failed|error)[:\s]+(\S+)",
+    re.IGNORECASE,
+)
+
 _UPSTREAM_DOWN_SIGNALS = (
     "service unavailable",
     "bad gateway",
@@ -102,6 +117,7 @@ class ProviderFailureSignal:
             "rate-limit": "rate limit",
             "5xx": "upstream unavailable",
             "network": "network failure",
+            "tool-error": "tool execution error",
             "provider-error": "provider error",
         }[self.category]
         status = f" HTTP {self.status_code}" if self.status_code is not None else ""
@@ -141,6 +157,19 @@ def detect_retriable_provider_failure(
     status_codes = _status_codes(payload) if payload is not None else []
     searchable = _searchable_text(raw, payload)
     lowered = searchable.lower()
+
+    # Agent-side tool-execution errors take precedence over rate-limit
+    # detection. The agent CLI's own tool surface ("Error executing tool
+    # replace: ...") is the actionable cause; downstream rate-limit phrases
+    # in the same buffer (often unrelated noise) would otherwise mislabel
+    # the failure as a quota issue. See conductor issue #443.
+    if any(sig in lowered for sig in _TOOL_ERROR_SIGNALS):
+        return ProviderFailureSignal(
+            category="tool-error",
+            status_code=_first_status(status_codes),
+            source=source,
+            detail=_compact_tool_error_detail(raw),
+        )
 
     if (
         429 in status_codes
@@ -272,3 +301,21 @@ def _compact_detail(raw: str) -> str:
     if len(one_line) <= 500:
         return one_line
     return one_line[:497] + "..."
+
+
+def _compact_tool_error_detail(raw: str) -> str:
+    """Like _compact_detail but anchored to the tool-error message itself.
+
+    Prevents the displayed detail from being dominated by upstream noise
+    (deprecation warnings, ripgrep fallback messages) when the actionable
+    signal — "Error executing tool <name>: ..." — is what the operator
+    needs to see.
+    """
+    one_line = " ".join(raw.split())
+    match = _TOOL_ERROR_RE.search(one_line)
+    if match is None:
+        return _compact_detail(raw)
+    snippet = one_line[match.start():]
+    if len(snippet) <= 500:
+        return snippet
+    return snippet[:497] + "..."

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -3080,6 +3080,26 @@ GEMINI_SAVED_JSON = """{
     }
 }"""
 
+# Gemini CLI exits 0 even when its internal `replace` tool errored mid-edit.
+# The failure is recorded in stats.tools.byName.<tool>.fail. Conductor must
+# detect this so the caller doesn't silently inherit a half-edited worktree
+# (issue #443).
+GEMINI_TOOL_FAILURE_JSON = """{
+    "response": "I started editing but ran into an error.",
+    "session_id": "tool-fail-xyz",
+    "stats": {
+        "models": {
+            "gemini-2.5-pro": {"tokens": {"input": 50, "candidates": 20}}
+        },
+        "tools": {
+            "byName": {
+                "replace": {"count": 1, "success": 0, "fail": 1, "durationMs": 12},
+                "Edit":    {"count": 2, "success": 1, "fail": 1, "durationMs": 30}
+            }
+        }
+    }
+}"""
+
 
 def test_gemini_configured_when_cli_present_and_env_authed(mocker, monkeypatch):
     mocker.patch("conductor.providers.gemini.shutil.which", return_value="/usr/bin/gemini")
@@ -3238,6 +3258,52 @@ def test_gemini_exec_allows_saved_write_file_response(mocker):
     response = GeminiProvider().exec("write a file", sandbox="workspace-write")
 
     assert "has been saved" in response.text
+
+
+def test_gemini_exec_raises_when_internal_tool_failed(mocker):
+    """Regression for #443: gemini CLI exits 0 even when its `replace` (or
+    `Edit`) tool errored mid-session, leaving partial edits on disk.
+    Conductor must surface that as a ProviderHTTPError so the caller —
+    typically a parent orchestrator dispatching `conductor exec` as a
+    background task — can detect the failure instead of inheriting a
+    silently-corrupted worktree.
+    """
+    mocker.patch("conductor.providers.gemini.shutil.which", return_value="/usr/bin/gemini")
+    fake = _FakePopen(stdout_schedule=[(0, GEMINI_TOOL_FAILURE_JSON)])
+
+    def factory(args, **kwargs):
+        fake.args = args
+        return fake
+
+    mocker.patch("conductor.providers.gemini.subprocess.Popen", side_effect=factory)
+
+    with pytest.raises(ProviderHTTPError) as exc:
+        GeminiProvider().exec("edit two files")
+
+    message = str(exc.value)
+    assert "tool failures" in message
+    assert "replace" in message
+    assert "Edit" in message
+    assert "partially-applied" in message
+    assert "git status" in message
+
+
+def test_gemini_exec_succeeds_when_no_tool_failures(mocker):
+    """The tool-failure check is only triggered by actual fail counts —
+    a clean run with success-only counts must still parse normally.
+    """
+    mocker.patch("conductor.providers.gemini.shutil.which", return_value="/usr/bin/gemini")
+    fake = _FakePopen(stdout_schedule=[(0, GEMINI_SAVED_JSON)])
+
+    def factory(args, **kwargs):
+        fake.args = args
+        return fake
+
+    mocker.patch("conductor.providers.gemini.subprocess.Popen", side_effect=factory)
+
+    response = GeminiProvider().exec("write something")
+
+    assert response.text  # success path
 
 
 def test_gemini_exec_sets_headless_workspace_trust_env(mocker, monkeypatch):

--- a/tests/test_terminal_signals.py
+++ b/tests/test_terminal_signals.py
@@ -1,0 +1,63 @@
+"""Direct coverage for the provider-stream classifier.
+
+Most of the classifier's behavior is exercised indirectly through the
+adapter integration tests. The tool-error category — added to fix #443
+where a Gemini tool failure was reported as "rate limit on stderr" —
+deserves dedicated coverage so the ranking against rate-limit signals
+in the same buffer doesn't silently regress.
+"""
+
+from __future__ import annotations
+
+from conductor.providers.terminal_signals import (
+    detect_retriable_provider_failure,
+)
+
+
+def test_tool_error_takes_precedence_over_rate_limit_in_same_buffer():
+    """Mixed buffer: a Gemini tool failure followed by rate-limit-shaped
+    noise (deprecation warnings, downstream messages) used to be tagged
+    as `rate-limit`. The actionable signal is the tool error.
+    """
+    text = (
+        "YOLO mode is enabled. All tool calls will be automatically approved. "
+        "Ripgrep is not available. Falling back to GrepTool. "
+        "Error executing tool replace: Error: Failed to apply edit. "
+        "You have hit your limit on retries."
+    )
+    signal = detect_retriable_provider_failure(text, source="stderr")
+
+    assert signal is not None
+    assert signal.category == "tool-error"
+    # Detail should anchor to the tool-error message, not the noise prefix.
+    assert signal.detail.startswith("Error executing tool replace")
+
+
+def test_tool_error_label_is_tool_execution_error():
+    text = "Error executing tool write_file: permission denied"
+    signal = detect_retriable_provider_failure(text, source="stderr")
+
+    assert signal is not None
+    assert signal.error_message("gemini").startswith(
+        "gemini reported tool execution error on stderr:"
+    )
+
+
+def test_pure_rate_limit_still_classified_as_rate_limit():
+    """No tool-error pattern present — classification must stay rate-limit
+    so existing rate-limit handling (cascade fallback, retry budget) keeps
+    working.
+    """
+    text = "You have hit your limit. HTTP 429 Too Many Requests"
+    signal = detect_retriable_provider_failure(text, source="stderr")
+
+    assert signal is not None
+    assert signal.category == "rate-limit"
+
+
+def test_tool_execution_failed_variant_is_recognized():
+    text = "Tool execution failed: replace returned non-zero"
+    signal = detect_retriable_provider_failure(text, source="stderr")
+
+    assert signal is not None
+    assert signal.category == "tool-error"


### PR DESCRIPTION
## Linked Issues

Closes #443

Closes #443

Two related defects in `conductor exec --with gemini`:

1. Exit 0 on agent crash. Gemini CLI exits cleanly even when its own
   `replace` / `Edit` / `write_file` tool errors mid-session, leaving
   partial edits on disk. The failure is recorded under
   `stats.tools.byName.<tool>.fail` in the JSON output, which Conductor
   was ignoring. Parent orchestrators dispatching `conductor exec` as a
   background task could not distinguish "agent finished cleanly" from
   "agent crashed and corrupted the worktree" without diffing the
   working tree by hand.

   Fix: after parsing Gemini's JSON, walk the per-tool fail counts and
   raise `ProviderHTTPError` naming the failed tool(s) and pointing the
   operator at `git status --short`.

2. Tool failures reported as "rate limit on stderr". `terminal_signals`
   classified the running stderr buffer by substring match; if any
   rate-limit-shaped phrase appeared anywhere in the tail (often
   downstream noise), a tool-execution error got tagged as `rate-limit`
   even when the actionable signal was the tool failure itself.

   Fix: add a `tool-error` classification that fires on
   "Error executing tool" / "Tool execution failed" patterns and takes
   precedence over rate-limit detection in the same buffer. The error
   detail anchors to the tool-error message rather than the noise prefix
   so the operator sees what actually broke.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
