### PR TITLE
chore(tests): drop per-file XDG_CACHE_HOME fixture superseded by conftest

### DIFF
--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -55,11 +55,6 @@ from conductor.session_log import (
 )
 
 
-@pytest.fixture(autouse=True)
-def _isolate_xdg_cache_home(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
-
-
 def _strip_gemini_auth_env(monkeypatch) -> None:
     """Clear any GEMINI/GOOGLE auth env vars inherited from the host shell.
 


### PR DESCRIPTION
PR #456 moved `_isolate_xdg_cache_home` to tests/conftest.py so every
test in the repo runs against a tmp XDG_CACHE_HOME. The per-file copy
in test_adapters_subprocess.py is now redundant — both fire on every
test in this module and the conftest one runs first, with the file-
local one overriding to the same shape. Removing the duplicate.

149 tests still pass after the removal; isolation comes from the
conftest-level fixture.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
