### PR TITLE
chore(release): use shared homebrew-bump workflow again now that v1 is fixed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,86 +75,15 @@ jobs:
     # On the auto-trigger, skip prereleases (RCs, betas) — they shouldn't
     # land in the tap. Manual dispatch always runs so we can re-bump on
     # demand for any tag.
-    #
-    # Inline bump (not the shared workflow @ autumn-garage): the
-    # `mislav/bump-homebrew-formula-action` upstream pin (v4.1 / SHA
-    # ccf2332299a883f6af50a1d2d41e5df7904dd769) has a hard-coded
-    # `if (res.statusCode == 302)` check against GitHub's tarball
-    # redirect. GitHub now returns HTTP 303 for codeload tarball
-    # requests from GitHub Actions runners, so the action errors with
-    # "unexpected HTTP 303 response" and never writes the formula.
-    # See conductor v0.10.27 release run (2026-05-16) for repro.
-    #
-    # This job uses gh + curl directly: download the tagged tarball,
-    # compute SHA256, rewrite the formula's `url` + `sha256` lines, and
-    # PUT the new content via the GitHub Contents API. The shared
-    # workflow at autumn-garage still calls the broken action; a port
-    # of this same fix is in flight there.
     if: github.event_name == 'workflow_dispatch' || !github.event.release.prerelease
     needs: source-validation
-    runs-on: ubuntu-latest
-    env:
-      RELEASE_TAG: ${{ inputs.tag_name || github.event.release.tag_name }}
-      TAP_REPO: autumngarage/homebrew-conductor
-      FORMULA_PATH: Formula/conductor.rb
-      SOURCE_REPO: ${{ github.repository }}
-      GH_TOKEN: ${{ secrets.HOMEBREW_TAP_PAT }}
-    steps:
-      - name: Bump tap formula (curl + gh api)
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          version="${RELEASE_TAG#v}"
-          tarball_url="https://github.com/${SOURCE_REPO}/archive/refs/tags/${RELEASE_TAG}.tar.gz"
-
-          echo "::group::Download tarball and compute SHA256"
-          curl -fL --retry 3 --retry-delay 2 "$tarball_url" -o /tmp/source.tar.gz
-          sha256="$(sha256sum /tmp/source.tar.gz | awk '{print $1}')"
-          echo "version=${version}  sha256=${sha256}"
-          echo "::endgroup::"
-
-          echo "::group::Fetch current formula"
-          gh api "repos/${TAP_REPO}/contents/${FORMULA_PATH}" >/tmp/formula-meta.json
-          jq -r '.content' /tmp/formula-meta.json | base64 -d >/tmp/formula.rb
-          existing_sha="$(jq -r '.sha' /tmp/formula-meta.json)"
-          echo "existing blob sha: ${existing_sha}"
-          echo "::endgroup::"
-
-          echo "::group::Rewrite url + sha256 lines"
-          # `sed -E` with anchors so a stray `url`/`sha256` substring in
-          # the caveats block can't be hit. POSIX `[[:space:]]` instead
-          # of `\s` so the same script runs on BSD sed locally and GNU
-          # sed in the runner.
-          new_url="https://github.com/${SOURCE_REPO}/archive/refs/tags/${RELEASE_TAG}.tar.gz"
-          sed -E -i \
-            -e "s|^([[:space:]]*url )\"[^\"]+\"|\1\"${new_url}\"|" \
-            -e "s|^([[:space:]]*sha256 )\"[0-9a-f]{64}\"|\1\"${sha256}\"|" \
-            /tmp/formula.rb
-
-          if ! grep -q "\"${new_url}\"" /tmp/formula.rb; then
-            echo "::error::sed did not rewrite the url line; formula left unchanged"
-            head -10 /tmp/formula.rb
-            exit 1
-          fi
-          if ! grep -q "\"${sha256}\"" /tmp/formula.rb; then
-            echo "::error::sed did not rewrite the sha256 line; formula left unchanged"
-            head -10 /tmp/formula.rb
-            exit 1
-          fi
-          echo "::endgroup::"
-
-          echo "::group::PUT new formula content"
-          new_content_b64="$(base64 -w0 </tmp/formula.rb)"
-          commit_message="conductor ${version}
-
-          Released by GitHub Actions from ${SOURCE_REPO}@${GITHUB_SHA}."
-          gh api -X PUT "repos/${TAP_REPO}/contents/${FORMULA_PATH}" \
-            -f message="$commit_message" \
-            -f content="$new_content_b64" \
-            -f sha="$existing_sha" \
-            --jq '"committed " + .commit.sha + " — " + .commit.message'
-          echo "::endgroup::"
+    uses: autumngarage/autumn-garage/.github/workflows/homebrew-bump.yml@v1
+    with:
+      formula-name: conductor
+      tap-repo: autumngarage/homebrew-conductor
+      tag-name: ${{ inputs.tag_name || github.event.release.tag_name }}
+    secrets:
+      HOMEBREW_TAP_PAT: ${{ secrets.HOMEBREW_TAP_PAT }}
 
   fresh-install-smoke:
     # This runs only after the reusable workflow has committed the formula


### PR DESCRIPTION
PR #456 inlined the tap bump into this workflow as a fast unblock for
v0.10.27 because the shared workflow at autumn-garage was still
calling the broken `mislav/bump-homebrew-formula-action@v4.1`.

autumngarage/autumn-garage#34 ported the same curl + gh api logic
into the shared workflow and moved `refs/tags/v1` to that commit.
The shared workflow and the inline copy are now byte-identical at
the bump-step level, so the inline copy is pure duplication: a
divergence trap if either is edited later without the other.

Revert to `uses: autumngarage/autumn-garage/.../homebrew-bump.yml@v1`
so the bump-tap path has one canonical implementation again. No
behavior change is expected — same auth (HOMEBREW_TAP_PAT), same
inputs, same effect on the tap.

The next release of any garage tool (conductor included) exercises
the shared workflow for real. If that surfaces a bug, the inline
copy is one git revert away.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
