### PR TITLE
fix(exec): raise --effort high/max iteration defaults (60→100, 80→140)

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -193,12 +193,12 @@ EXEC_MAX_ITERATION_MULTIPLIERS = {
     "minimal": 1.0,
     "low": 1.5,
     "medium": 2.0,
-    "high": 6.0,
-    "max": 8.0,
+    "high": 10.0,
+    "max": 14.0,
 }
 EXEC_MAX_ITERATIONS_HELP = (
     "Maximum Conductor-managed tool-use loop iterations. Default scales with "
-    "--effort from base 10: minimal=10, low=15, medium=20, high=60, max=80. "
+    "--effort from base 10: minimal=10, low=15, medium=20, high=100, max=140. "
     "If --effort is unset, preserves the legacy cap of 10."
 )
 EXEC_MAX_ITERATION_PROVIDER_IDS = frozenset({"codex", "openrouter", "ollama"})

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -3432,11 +3432,12 @@ def test_exec_cli_max_stall_seconds_zero_disables_watchdog(mocker):
         ("minimal", 10),
         ("low", 15),
         ("medium", 20),
-        ("high", 60),
-        ("max", 80),
+        ("high", 100),
+        ("max", 140),
     ],
 )
 def test_exec_max_iterations_default_scales_by_effort(effort, expected):
+    # Regression for #459: keep high/max defaults high enough for real refactor loops.
     assert _resolve_exec_max_iterations(None, raw_effort=effort) == expected
 
 


### PR DESCRIPTION
## Linked Issues

Closes #459

## Summary

Issue #459 reported a dogfood refactor run that hit the `--effort high` default iteration cap (`60`) exactly and only finished with completion stretch. This PR raises the default `--max-iterations` budgets for `high`/`max` so realistic refactor loops have more headroom.

## Changes

- Updated `EXEC_MAX_ITERATION_MULTIPLIERS` in `src/conductor/cli.py`:
  - `high`: `6.0` → `10.0` (default `60` → `100`)
  - `max`: `8.0` → `14.0` (default `80` → `140`)
- Updated `EXEC_MAX_ITERATIONS_HELP` to reflect the new defaults:
  - `"--effort from base 10: minimal=10, low=15, medium=20, high=100, max=140."`
- Updated/extended regression coverage in `tests/test_cli_v02.py` for `_resolve_exec_max_iterations` across all effort levels, with a `#459` regression comment.

> Note: the max-iteration resolution algorithm is unchanged; only multiplier values and user-facing help text were updated.

## Testing

- `uv run ruff check src/ tests/`
- `uv run pytest tests/ -q`

## Risk

- Low risk: constants + help text + matching tests.

## Rollback

- Clean revert of commit `da1a4f0`.

Closes-issue: #459
