### PR TITLE
feat(openrouter): family-aware model ordering on fallback after stall

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -2454,6 +2454,7 @@ def _invoke_with_fallback(
             )
 
     prompted_offline = False
+    previous_provider: str | None = None
     brief_tokens = _estimate_brief_tokens(task)
     idx = 0
     while idx < len(candidates):
@@ -2543,6 +2544,7 @@ def _invoke_with_fallback(
                         effort=effort,
                         task_tags=list(decision.task_tags),
                         prefer=decision.prefer,
+                        previous_provider=previous_provider,
                         log_selection=not silent,
                         tools=tools,
                         sandbox=sandbox,
@@ -2628,6 +2630,7 @@ def _invoke_with_fallback(
                         effort=effort,
                         task_tags=list(decision.task_tags),
                         prefer=decision.prefer,
+                        previous_provider=previous_provider,
                         log_selection=not silent,
                         timeout_sec=attempt_timeout_sec,
                         max_stall_sec=attempt_max_stall_sec,
@@ -2731,6 +2734,7 @@ def _invoke_with_fallback(
                         f"falling through to {next_name} (falling back → {next_name})",
                         err=True,
                     )
+            previous_provider = candidate.name
             idx += 1
             continue
 
@@ -2816,6 +2820,7 @@ def _invoke_review_with_fallback(
                     effort=effort,
                     task_tags=list(decision.task_tags),
                     prefer=decision.prefer,
+                    previous_provider=(candidates[idx - 1].name if idx > 0 else None),
                     log_selection=not silent,
                     timeout_sec=attempt_timeout_sec,
                     max_stall_sec=attempt_max_stall_sec,

--- a/src/conductor/openrouter_model_stacks.py
+++ b/src/conductor/openrouter_model_stacks.py
@@ -46,6 +46,40 @@ OPENROUTER_CODING_MAX: tuple[str, ...] = (
 )
 
 
+def model_family(model: str) -> str:
+    """Return the lowercased provider family prefix for a model slug."""
+    head, sep, _tail = model.partition("/")
+    if not sep or not head:
+        return ""
+    return head.lower()
+
+
+def bump_family_to_end(models: tuple[str, ...], family: str) -> tuple[str, ...]:
+    """Move the named model family to the end while preserving order."""
+    normalized = family.strip().lower()
+    if not normalized:
+        return models
+
+    keep: list[str] = []
+    bumped: list[str] = []
+    for model in models:
+        if model_family(model) == normalized:
+            bumped.append(model)
+        else:
+            keep.append(model)
+    return tuple([*keep, *bumped])
+
+
+def provider_family_hint(provider_id: str) -> str | None:
+    """Return a model-family hint for a provider id when known."""
+    mapping = {
+        "codex": "openai",
+        "claude": "anthropic",
+        "gemini": "google",
+    }
+    return mapping.get(provider_id.strip().lower())
+
+
 def openrouter_coding_stack(effort: str | int) -> tuple[str, ...]:
     """Return the OpenRouter model stack for tool-using coding work."""
     if effort == "max":

--- a/src/conductor/providers/openrouter.py
+++ b/src/conductor/providers/openrouter.py
@@ -29,7 +29,11 @@ from conductor.exec_completion import (
     detect_missing_deliverables,
     format_missing_deliverables_cap_message,
 )
-from conductor.openrouter_model_stacks import openrouter_coding_stack
+from conductor.openrouter_model_stacks import (
+    bump_family_to_end,
+    openrouter_coding_stack,
+    provider_family_hint,
+)
 from conductor.providers.interface import (
     PROVIDER_RUNTIME_STATELESS_TOOL_LOOP,
     CallResponse,
@@ -260,6 +264,7 @@ class OpenRouterProvider:
         task_tags: list[str] | tuple[str, ...] | None,
         prefer: str,
         exclude: set[str] | frozenset[str] | None,
+        previous_provider: str | None,
         log_selection: bool,
     ) -> tuple[dict, str]:
         if model is not None and models:
@@ -294,6 +299,7 @@ class OpenRouterProvider:
                 prefer=prefer,
                 effort=effort,
                 exclude=exclude,
+                previous_provider=previous_provider,
             )
             payload.update(selector_payload)
             if "models" in payload:
@@ -308,6 +314,7 @@ class OpenRouterProvider:
                     task_tags=task_tags,
                     prefer=prefer,
                     payload=payload,
+                    previous_provider=previous_provider,
                 )
         else:
             payload["model"] = selected_model
@@ -327,6 +334,7 @@ class OpenRouterProvider:
         task_tags: list[str] | tuple[str, ...] | None = None,
         prefer: str = "balanced",
         exclude: set[str] | frozenset[str] | None = None,
+        previous_provider: str | None = None,
         log_selection: bool = True,
         max_tokens: int | None = None,
         timeout_sec: int | None = None,
@@ -352,6 +360,7 @@ class OpenRouterProvider:
             task_tags=task_tags,
             prefer=prefer,
             exclude=exclude,
+            previous_provider=previous_provider,
             log_selection=log_selection,
         )
         payload: dict = {
@@ -433,6 +442,7 @@ class OpenRouterProvider:
         task_tags: list[str] | tuple[str, ...] | None = None,
         prefer: str = "balanced",
         exclude: set[str] | frozenset[str] | None = None,
+        previous_provider: str | None = None,
         log_selection: bool = True,
         tools: frozenset[str] = frozenset(),
         sandbox: str = "none",
@@ -459,6 +469,7 @@ class OpenRouterProvider:
                 task_tags=task_tags,
                 prefer=prefer,
                 exclude=exclude,
+                previous_provider=previous_provider,
                 log_selection=log_selection,
                 timeout_sec=timeout_sec,
                 max_stall_sec=max_stall_sec,
@@ -482,6 +493,7 @@ class OpenRouterProvider:
             task_tags=effective_task_tags,
             prefer=prefer,
             exclude=exclude,
+            previous_provider=previous_provider,
             log_selection=log_selection,
         )
         empty_response_retry_base = (
@@ -1179,6 +1191,7 @@ def select_model_for_task(
     prefer: str,
     effort: str | int,
     exclude: set[str] | frozenset[str] | None = None,
+    previous_provider: str | None = None,
 ) -> dict[str, object]:
     """Select an OpenRouter completion target.
 
@@ -1199,6 +1212,7 @@ def select_model_for_task(
 
     task_tag_set = set(task_tags or [])
     exclude_set = set(exclude or ())
+    family_hint = provider_family_hint(previous_provider or "")
 
     if prefer in {"best", "balanced"}:
         if "tool-use" in task_tag_set:
@@ -1207,6 +1221,8 @@ def select_model_for_task(
                 for model in openrouter_coding_stack(effort)
                 if model not in exclude_set
             )
+            if family_hint is not None:
+                coding_stack = bump_family_to_end(coding_stack, family_hint)
             if not coding_stack:
                 raise ProviderError(
                     "OpenRouter coding stack was fully excluded. "
@@ -1323,6 +1339,7 @@ def _log_selector_choice(
     task_tags: list[str] | tuple[str, ...] | None,
     prefer: str,
     payload: dict[str, object],
+    previous_provider: str | None,
 ) -> None:
     tags_text = ",".join(task_tags or []) or "none"
     if "models" in payload:
@@ -1337,8 +1354,16 @@ def _log_selector_choice(
         target = f"auto shortlist={shortlist}" if shortlist else "auto unrestricted"
     else:
         target = f"model={payload['model']}"
+    annotation = ""
+    family_hint = provider_family_hint(previous_provider or "")
+    if family_hint is not None and "models" in payload:
+        annotation = (
+            f" (recovering from {previous_provider} stall — "
+            f"bumping {family_hint}/* down)"
+        )
     sys.stderr.write(
-        f"[conductor] openrouter selector: tags={tags_text} prefer={prefer} -> {target}\n"
+        "[conductor] openrouter selector: "
+        f"tags={tags_text} prefer={prefer}{annotation} -> {target}\n"
     )
     sys.stderr.flush()
 

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -759,6 +759,7 @@ def test_ask_code_high_falls_back_immediately_to_openrouter_on_quota(mocker):
     assert codex_exec.called
     assert openrouter_exec.called
     assert openrouter_exec.call_args.kwargs["models"] == OPENROUTER_CODING_HIGH
+    assert openrouter_exec.call_args.kwargs["previous_provider"] == "codex"
     assert "codex failed (rate-limit)" in result.stderr
     assert "falling back" in result.stderr
     assert "→ openrouter" in result.stderr

--- a/tests/test_openrouter.py
+++ b/tests/test_openrouter.py
@@ -539,6 +539,7 @@ def test_call_without_model_invokes_selector_and_builds_payload(configured, mock
         prefer="balanced",
         effort="medium",
         exclude=None,
+        previous_provider=None,
     )
     assert captured["payload"] == {
         "model": OPENROUTER_DEFAULT_MODEL,

--- a/tests/test_openrouter_selector.py
+++ b/tests/test_openrouter_selector.py
@@ -8,6 +8,8 @@ import conductor.providers.openrouter_catalog as openrouter_catalog
 from conductor.openrouter_model_stacks import (
     OPENROUTER_CODING_HIGH,
     OPENROUTER_CODING_MAX,
+    bump_family_to_end,
+    model_family,
 )
 from conductor.providers.interface import ProviderError
 from conductor.providers.openrouter import (
@@ -283,3 +285,27 @@ def test_empty_filtered_result_raises_clear_error(mocker, fixture_catalog):
 
     with pytest.raises(ProviderError, match="tags filtered to empty"):
         select_model_for_task(["vision", "thinking"], "cheapest", "medium")
+
+
+def test_model_family_detects_prefix() -> None:
+    assert model_family("openai/gpt-5.3-codex") == "openai"
+    assert model_family("anthropic/claude-sonnet-4.6") == "anthropic"
+
+
+def test_bump_family_to_end_preserves_relative_order() -> None:
+    assert bump_family_to_end(
+        ("openai/x", "anthropic/y", "openai/z", "google/w"),
+        "openai",
+    ) == ("anthropic/y", "google/w", "openai/x", "openai/z")
+
+
+def test_tool_use_selector_bumps_previous_provider_family_to_end() -> None:
+    payload = select_model_for_task(
+        ["tool-use"],
+        "best",
+        "high",
+        previous_provider="codex",
+    )
+
+    assert payload["models"]
+    assert not str(payload["models"][0]).startswith("openai/")


### PR DESCRIPTION
## Linked Issues

Closes #461

Address #461 by making OpenRouter's curated coding selector aware of the provider that just failed during fallback. When recovering from codex stalls/errors, the selector now demotes openai/* entries (for example openai/gpt-5.3-codex) to the end of that one attempt so fallback actually diversifies model family instead of only changing auth path.

Closes-issue: #461

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
