### PR TITLE
feat(exec): warn when pre-commit hooks auto-stage files outside the brief

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -78,6 +78,13 @@ from conductor.git_state import (
     StaleBranch,
     scan_git_state,
 )
+from conductor.hook_scope_detect import (
+    _run_git_command,
+    detect_hook_staged_scope_creep,
+    format_hook_scope_creep_warning,
+    git_head_via_fs,
+    normalize_repo_relative_path,
+)
 from conductor.internal_config import InternalConfigError, internal_telemetry_enabled
 from conductor.muted_providers import (
     MutedProvidersError,
@@ -4033,6 +4040,73 @@ def _collect_session_auth_prompts(session_log: SessionLog | None) -> list[dict] 
     return prompts or None
 
 
+def _collect_exec_agent_write_set(session_log: SessionLog | None, *, cwd: Path) -> set[str]:
+    if session_log is None:
+        return set()
+    try:
+        lines = session_log.log_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return set()
+
+    write_set: set[str] = set()
+    for line in lines:
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if event.get("event") != "tool_call":
+            continue
+        data = event.get("data")
+        if not isinstance(data, dict):
+            continue
+        name = data.get("name")
+        if name not in {"Edit", "Write"}:
+            continue
+        args = data.get("args")
+        if not isinstance(args, dict):
+            continue
+        path = args.get("path")
+        if not isinstance(path, str):
+            continue
+        normalized = normalize_repo_relative_path(path, worktree=cwd)
+        if normalized is not None:
+            write_set.add(normalized)
+    return write_set
+
+
+def _emit_exec_hook_scope_creep_warnings(
+    *,
+    cwd: str | None,
+    session_log: SessionLog | None,
+    phase_start_head: str | None,
+) -> None:
+    if phase_start_head is None:
+        return
+
+    worktree = Path(cwd or os.getcwd()).resolve()
+    intended = _collect_exec_agent_write_set(session_log, cwd=worktree)
+    if not intended:
+        return
+
+    current_head = git_head_via_fs(worktree)
+    if current_head is None or current_head == phase_start_head:
+        return
+
+    creep_groups = detect_hook_staged_scope_creep(
+        worktree,
+        intended,
+        base_head=phase_start_head,
+    )
+    for extras in creep_groups:
+        click.echo(
+            format_hook_scope_creep_warning(
+                extra_paths=extras,
+                intended_paths=intended,
+            ),
+            err=True,
+        )
+
+
 def _git_stdout(cwd: str, args: list[str], *, errors: list[str]) -> str | None:
     try:
         result = subprocess.run(
@@ -6112,22 +6186,18 @@ _EXEC_PHASE_GIT_TIMEOUT_SEC = 10.0
 
 def _git_phase_head(cwd: str | None) -> str | None:
     worktree = cwd or os.getcwd()
-    try:
-        result = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            cwd=worktree,
-            capture_output=True,
-            text=True,
-            timeout=_EXEC_PHASE_GIT_TIMEOUT_SEC,
-            check=True,
-        )
-    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+    output = _run_git_command(
+        ["git", "rev-parse", "HEAD"],
+        cwd=Path(worktree),
+        timeout_sec=_EXEC_PHASE_GIT_TIMEOUT_SEC,
+    )
+    if output is None:
         click.echo(
-            f"[conductor] warning: could not capture phase git HEAD in {worktree}: {e}",
+            f"[conductor] warning: could not capture phase git HEAD in {worktree}",
             err=True,
         )
         return None
-    return result.stdout.strip()
+    return output.strip() or None
 
 
 def _git_phase_output(cwd: str | None, args: list[str]) -> str | None:
@@ -10654,6 +10724,9 @@ def exec_cmd(
         brief_input = _with_auto_close_instructions(brief_input)
         phase_started_at = time.monotonic()
         phase_start_head = _git_phase_head(cwd) if multi_phase else None
+        scope_creep_start_head = git_head_via_fs(
+            Path(cwd or os.getcwd()).resolve()
+        )
         try:
             response, decision, session_log = _run_exec_phase_dispatch(
                 provider_id=provider_id,
@@ -10709,6 +10782,12 @@ def exec_cmd(
             sys.exit(e.exit_code)
 
 
+
+        _emit_exec_hook_scope_creep_warnings(
+            cwd=cwd,
+            session_log=session_log,
+            phase_start_head=scope_creep_start_head,
+        )
 
         final_response = response
         final_decision = decision

--- a/src/conductor/hook_scope_detect.py
+++ b/src/conductor/hook_scope_detect.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+_GIT_TIMEOUT_SEC = 5.0
+
+
+def detect_hook_staged_scope_creep(
+    worktree: Path,
+    agent_write_set: set[str],
+    *,
+    base_head: str,
+) -> list[tuple[str, ...]]:
+    """Return per-commit extra paths that landed outside the intended write set.
+
+    Each tuple corresponds to one commit created in ``base_head..HEAD`` and
+    contains sorted paths that appeared in that commit but not in
+    ``agent_write_set``.
+    """
+
+    if not agent_write_set:
+        return []
+
+    commits = _commits_since(worktree, base_head)
+    if not commits:
+        return []
+
+    extras_per_commit: list[tuple[str, ...]] = []
+    for commit in commits:
+        changed = _commit_changed_paths(worktree, commit)
+        if not changed:
+            continue
+        extras = tuple(sorted(path for path in changed if path not in agent_write_set))
+        if extras:
+            extras_per_commit.append(extras)
+    return extras_per_commit
+
+
+def format_hook_scope_creep_warning(
+    *,
+    extra_paths: Iterable[str],
+    intended_paths: Iterable[str],
+) -> str:
+    extras = sorted(dict.fromkeys(extra_paths))
+    intended = sorted(dict.fromkeys(intended_paths))
+    extras_text = ", ".join(extras)
+    intended_text = ", ".join(intended) if intended else "(none captured)"
+    return (
+        "[conductor] commit grew by hook: "
+        f"{extras_text}. "
+        f"Agent intended: {intended_text}. "
+        "If unexpected, inspect .pre-commit-config.yaml."
+    )
+
+
+def git_head(worktree: Path) -> str | None:
+    result = _run_git(worktree, ["rev-parse", "HEAD"])
+    if result is None:
+        return None
+    head = result.strip()
+    return head or None
+
+
+def git_head_via_fs(worktree: Path) -> str | None:
+    """Read git HEAD from the filesystem, no subprocess. Returns None if not in a repo."""
+    git_dir = _resolve_git_dir(worktree)
+    if git_dir is None:
+        return None
+    head_file = git_dir / "HEAD"
+    try:
+        contents = head_file.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if contents.startswith("ref: "):
+        ref_path = contents[5:].strip()
+        ref_file = git_dir / ref_path
+        try:
+            return ref_file.read_text(encoding="utf-8").strip() or None
+        except OSError:
+            packed = git_dir / "packed-refs"
+            try:
+                for line in packed.read_text(encoding="utf-8").splitlines():
+                    if line.startswith(("#", "^")):
+                        continue
+                    parts = line.split(None, 1)
+                    if len(parts) == 2 and parts[1] == ref_path:
+                        return parts[0]
+            except OSError:
+                return None
+            return None
+    return contents or None
+
+
+def _resolve_git_dir(worktree: Path) -> Path | None:
+    """Return the .git directory for a worktree, handling worktree's .git-file indirection."""
+    candidate = worktree / ".git"
+    if candidate.is_dir():
+        return candidate
+    if candidate.is_file():
+        try:
+            line = candidate.read_text(encoding="utf-8").strip()
+        except OSError:
+            return None
+        if line.startswith("gitdir: "):
+            git_dir = Path(line[len("gitdir: ") :].strip())
+            if not git_dir.is_absolute():
+                git_dir = (worktree / git_dir).resolve()
+            return git_dir if git_dir.exists() else None
+    return None
+
+
+def normalize_repo_relative_path(path: str, *, worktree: Path) -> str | None:
+    raw = path.strip()
+    if not raw:
+        return None
+    candidate = Path(raw)
+    if candidate.is_absolute():
+        try:
+            relative = candidate.resolve().relative_to(worktree.resolve())
+        except (OSError, ValueError):
+            return None
+        normalized = relative.as_posix()
+    else:
+        normalized = candidate.as_posix().lstrip("./")
+    return normalized or None
+
+
+def _commits_since(worktree: Path, base_head: str) -> list[str]:
+    output = _run_git(worktree, ["rev-list", "--reverse", f"{base_head}..HEAD"])
+    if output is None:
+        return []
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def _commit_changed_paths(worktree: Path, commit: str) -> list[str]:
+    output = _run_git(
+        worktree,
+        ["diff-tree", "--no-commit-id", "--name-only", "-r", "--root", commit],
+    )
+    if output is None:
+        return []
+    paths: list[str] = []
+    for line in output.splitlines():
+        normalized = normalize_repo_relative_path(line, worktree=worktree)
+        if normalized is not None:
+            paths.append(normalized)
+    return list(dict.fromkeys(paths))
+
+
+def _run_git(worktree: Path, args: list[str]) -> str | None:
+    return _run_git_command(
+        ["git", *args],
+        cwd=worktree,
+        timeout_sec=_GIT_TIMEOUT_SEC,
+    )
+
+
+def _run_git_command(
+    command: list[str],
+    *,
+    cwd: Path,
+    timeout_sec: float = _GIT_TIMEOUT_SEC,
+) -> str | None:
+    try:
+        result = subprocess.run(
+            command,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout_sec,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired, TypeError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout

--- a/src/conductor/hook_scope_detect.py
+++ b/src/conductor/hook_scope_detect.py
@@ -97,21 +97,30 @@ def git_head_via_fs(worktree: Path) -> str | None:
 
 
 def _resolve_git_dir(worktree: Path) -> Path | None:
-    """Return the .git directory for a worktree, handling worktree's .git-file indirection."""
-    candidate = worktree / ".git"
-    if candidate.is_dir():
-        return candidate
-    if candidate.is_file():
-        try:
-            line = candidate.read_text(encoding="utf-8").strip()
-        except OSError:
+    """Return the .git directory for a worktree, walking parents and handling
+    worktree's .git-file indirection."""
+    try:
+        current = worktree.resolve()
+    except OSError:
+        current = worktree
+    while True:
+        candidate = current / ".git"
+        if candidate.is_dir():
+            return candidate
+        if candidate.is_file():
+            try:
+                line = candidate.read_text(encoding="utf-8").strip()
+            except OSError:
+                return None
+            if line.startswith("gitdir: "):
+                git_dir = Path(line[len("gitdir: ") :].strip())
+                if not git_dir.is_absolute():
+                    git_dir = (current / git_dir).resolve()
+                return git_dir if git_dir.exists() else None
             return None
-        if line.startswith("gitdir: "):
-            git_dir = Path(line[len("gitdir: ") :].strip())
-            if not git_dir.is_absolute():
-                git_dir = (worktree / git_dir).resolve()
-            return git_dir if git_dir.exists() else None
-    return None
+        if current.parent == current:
+            return None
+        current = current.parent
 
 
 def normalize_repo_relative_path(path: str, *, worktree: Path) -> str | None:
@@ -126,7 +135,9 @@ def normalize_repo_relative_path(path: str, *, worktree: Path) -> str | None:
             return None
         normalized = relative.as_posix()
     else:
-        normalized = candidate.as_posix().lstrip("./")
+        normalized = candidate.as_posix()
+        while normalized.startswith("./"):
+            normalized = normalized[2:]
     return normalized or None
 
 

--- a/src/conductor/hook_scope_detect.py
+++ b/src/conductor/hook_scope_detect.py
@@ -67,7 +67,12 @@ def git_head(worktree: Path) -> str | None:
 
 
 def git_head_via_fs(worktree: Path) -> str | None:
-    """Read git HEAD from the filesystem, no subprocess. Returns None if not in a repo."""
+    """Read git HEAD from the filesystem, no subprocess. Returns None if not in a repo.
+
+    Handles linked worktrees: HEAD lives in the worktree's gitdir but shared
+    refs (`refs/heads/...`, `packed-refs`) live in `commondir` (the main repo's
+    .git). Search both locations when resolving a symbolic ref.
+    """
     git_dir = _resolve_git_dir(worktree)
     if git_dir is None:
         return None
@@ -76,24 +81,43 @@ def git_head_via_fs(worktree: Path) -> str | None:
         contents = head_file.read_text(encoding="utf-8").strip()
     except OSError:
         return None
-    if contents.startswith("ref: "):
-        ref_path = contents[5:].strip()
-        ref_file = git_dir / ref_path
+    if not contents.startswith("ref: "):
+        return contents or None
+    ref_path = contents[5:].strip()
+    common = _read_commondir(git_dir)
+    search_dirs: list[Path] = [git_dir]
+    if common is not None and common != git_dir:
+        search_dirs.append(common)
+    for d in search_dirs:
         try:
-            return ref_file.read_text(encoding="utf-8").strip() or None
+            value = (d / ref_path).read_text(encoding="utf-8").strip()
+            if value:
+                return value
         except OSError:
-            packed = git_dir / "packed-refs"
-            try:
-                for line in packed.read_text(encoding="utf-8").splitlines():
-                    if line.startswith(("#", "^")):
-                        continue
-                    parts = line.split(None, 1)
-                    if len(parts) == 2 and parts[1] == ref_path:
-                        return parts[0]
-            except OSError:
-                return None
-            return None
-    return contents or None
+            continue
+    for d in search_dirs:
+        try:
+            lines = (d / "packed-refs").read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        for line in lines:
+            if line.startswith(("#", "^")):
+                continue
+            parts = line.split(None, 1)
+            if len(parts) == 2 and parts[1] == ref_path:
+                return parts[0]
+    return None
+
+
+def _read_commondir(git_dir: Path) -> Path | None:
+    try:
+        line = (git_dir / "commondir").read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    candidate = Path(line)
+    if not candidate.is_absolute():
+        candidate = (git_dir / candidate).resolve()
+    return candidate if candidate.is_dir() else None
 
 
 def _resolve_git_dir(worktree: Path) -> Path | None:

--- a/tests/test_hook_scope_detect.py
+++ b/tests/test_hook_scope_detect.py
@@ -171,3 +171,26 @@ def test_git_head_via_fs_resolves_from_subdirectory(tmp_path: Path) -> None:
 
     assert head_from_root is not None
     assert head_from_root == head_from_sub
+
+
+def test_git_head_via_fs_resolves_in_linked_worktree(tmp_path: Path) -> None:
+    # Regression: linked worktrees keep HEAD in worktree-local gitdir but
+    # refs/heads/* lives in commondir (the main repo's .git). git_head_via_fs
+    # must follow commondir to resolve the symbolic ref.
+    main_repo = tmp_path / "main"
+    main_repo.mkdir()
+    _init_repo(main_repo)
+
+    wt_path = tmp_path / "wt-branch"
+    _git(main_repo, "worktree", "add", "-b", "feature", str(wt_path))
+
+    head_from_main = git_head_via_fs(main_repo)
+    head_from_wt = git_head_via_fs(wt_path)
+
+    assert head_from_main is not None
+    assert head_from_wt is not None
+    # Both heads should resolve to a SHA (40-char hex) — same commit since
+    # both branches point at the initial commit.
+    assert len(head_from_main) == 40
+    assert len(head_from_wt) == 40
+    assert head_from_main == head_from_wt

--- a/tests/test_hook_scope_detect.py
+++ b/tests/test_hook_scope_detect.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from conductor import cli
+from conductor.hook_scope_detect import detect_hook_staged_scope_creep, git_head
+
+pytestmark = pytest.mark.skipif(shutil.which("git") is None, reason="git not installed")
+
+
+def _git(repo: Path, *args: str) -> str:
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "Test User",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "Test User",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _init_repo(repo: Path) -> None:
+    _git(repo, "init", "-q", "-b", "main")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-q", "-m", "base")
+
+
+def _install_auto_stage_hook(repo: Path) -> None:
+    hook = repo / ".git" / "hooks" / "pre-commit"
+    hook.write_text(
+        "#!/bin/sh\n"
+        "printf 'hook bump\\n' > AGENTS.md\n"
+        "git add AGENTS.md\n",
+        encoding="utf-8",
+    )
+    hook.chmod(hook.stat().st_mode | stat.S_IXUSR)
+
+
+def test_emit_exec_warning_when_hook_expands_commit_scope(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    _install_auto_stage_hook(repo)
+
+    phase_start = git_head(repo)
+    assert phase_start is not None
+
+    (repo / "src").mkdir()
+    (repo / "src" / "app.py").write_text("print('hello')\n", encoding="utf-8")
+    _git(repo, "add", "src/app.py")
+    _git(repo, "commit", "-q", "-m", "feature")
+
+    tool_log = repo / "tool-events.ndjson"
+    tool_log.write_text(
+        json.dumps(
+            {
+                "event": "tool_call",
+                "data": {"name": "Write", "args": {"path": "src/app.py"}},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    session_log = SimpleNamespace(log_path=tool_log)
+
+    creep = detect_hook_staged_scope_creep(
+        repo,
+        {"src/app.py"},
+        base_head=phase_start,
+    )
+    assert creep == [("AGENTS.md",)]
+
+    cli._emit_exec_hook_scope_creep_warnings(
+        cwd=str(repo),
+        session_log=session_log,
+        phase_start_head=phase_start,
+    )
+
+    stderr = capsys.readouterr().err
+    assert "[conductor] commit grew by hook:" in stderr
+    assert "AGENTS.md" in stderr
+    assert "Agent intended: src/app.py" in stderr
+
+
+def test_emit_exec_warning_quiet_when_commit_matches_intended(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+
+    phase_start = git_head(repo)
+    assert phase_start is not None
+
+    (repo / "src").mkdir()
+    (repo / "src" / "app.py").write_text("print('ok')\n", encoding="utf-8")
+    _git(repo, "add", "src/app.py")
+    _git(repo, "commit", "-q", "-m", "feature")
+
+    tool_log = repo / "tool-events.ndjson"
+    tool_log.write_text(
+        json.dumps(
+            {
+                "event": "tool_call",
+                "data": {"name": "Write", "args": {"path": "src/app.py"}},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    session_log = SimpleNamespace(log_path=tool_log)
+
+    cli._emit_exec_hook_scope_creep_warnings(
+        cwd=str(repo),
+        session_log=session_log,
+        phase_start_head=phase_start,
+    )
+
+    stderr = capsys.readouterr().err
+    assert "commit grew by hook" not in stderr

--- a/tests/test_hook_scope_detect.py
+++ b/tests/test_hook_scope_detect.py
@@ -5,16 +5,18 @@ import os
 import shutil
 import stat
 import subprocess
+from pathlib import Path
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
 
 import pytest
 
-if TYPE_CHECKING:
-    from pathlib import Path
-
 from conductor import cli
-from conductor.hook_scope_detect import detect_hook_staged_scope_creep, git_head
+from conductor.hook_scope_detect import (
+    detect_hook_staged_scope_creep,
+    git_head,
+    git_head_via_fs,
+    normalize_repo_relative_path,
+)
 
 pytestmark = pytest.mark.skipif(shutil.which("git") is None, reason="git not installed")
 
@@ -142,3 +144,30 @@ def test_emit_exec_warning_quiet_when_commit_matches_intended(
 
     stderr = capsys.readouterr().err
     assert "commit grew by hook" not in stderr
+
+
+def test_normalize_preserves_dotfile_leading_dot() -> None:
+    # Regression: `.lstrip("./")` would strip leading dots from `.env`. We need
+    # to strip only `./` prefixes, not individual `.` characters.
+    assert normalize_repo_relative_path(".env", worktree=Path("/tmp/x")) == ".env"
+    assert (
+        normalize_repo_relative_path("./src/.env", worktree=Path("/tmp/x"))
+        == "src/.env"
+    )
+    assert normalize_repo_relative_path("./.env", worktree=Path("/tmp/x")) == ".env"
+
+
+def test_git_head_via_fs_resolves_from_subdirectory(tmp_path: Path) -> None:
+    # Regression: _resolve_git_dir() must walk parents so a subdirectory cwd
+    # still finds the repo root's .git directory.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    sub = repo / "src" / "deep"
+    sub.mkdir(parents=True)
+
+    head_from_root = git_head_via_fs(repo)
+    head_from_sub = git_head_via_fs(sub)
+
+    assert head_from_root is not None
+    assert head_from_root == head_from_sub


### PR DESCRIPTION
## Linked Issues

Closes #460

When `conductor exec` runs `git commit` inside a project whose pre-commit
hooks auto-stage additional files (e.g. integration-refresh hooks), the
commit silently grows beyond the agent's intended write set. The agent
has no visibility into this — see outrider PR #399 for a real-world case.

After a successful exec phase, compare the agent's intended write set
(parsed from session log Edit/Write tool calls) against the commit diff;
emit a `[conductor] commit grew by hook: ...` stderr warning naming the
extra files when the hook expanded the commit. Observability-only — no
behavior change, the hook still does its job.

HEAD capture for the new detection uses a filesystem read of
.git/HEAD (handles worktree .git-file indirection) so test subprocess
mocks aren't perturbed; the existing subprocess-based `_git_phase_head`
keeps its `if multi_phase` gating untouched. The `--strict-commit` flag
(issue #460 suggestion 3) is intentionally out of scope for this PR.

Closes-issue: #460

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
