### PR TITLE
--body-file

### DIFF
--- a/.cursor/rules/conductor-delegation.mdc
+++ b/.cursor/rules/conductor-delegation.mdc
@@ -2,7 +2,7 @@
 description: Use when delegating or routing tasks to a different LLM via the conductor CLI — e.g., cheap second opinions, long-context reads, web search, or offline runs.
 globs: ""
 alwaysApply: false
-managed-by: conductor v0.10.27
+managed-by: conductor v0.10.28
 ---
 
 # Conductor delegation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,7 @@ If there are zero blocking issues, the review is just: "LGTM."
 
 @.cortex/protocol.md
 
-<!-- conductor:begin v0.10.27 -->
+<!-- conductor:begin v0.10.28 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Conductor is a small CLI that owns LLM provider adapters and the user-facing "pi
 
 You are building the fourth peer of the Autumn Garage. The trio (Touchstone, Cortex, Sentinel) composes through file contracts, not shared code. Conductor extends that pattern: it's an independently-released CLI that other garage tools call as a subprocess, never import as a library.
 
-"Good" looks like: a stable, narrow CLI surface (`conductor call`, `conductor list`, `conductor smoke`, `conductor init`, `conductor doctor`); provider adapters that follow the same Provider Protocol regardless of whether they wrap an HTTP API or a CLI; auto-mode routing that's documented and predictable, never magical; setup UX that satisfies Doctrine 0002 (interactive on TTY, flag-driven in CI).
+"Good" looks like: a stable, narrow CLI surface (`conductor call`, `conductor list`, `conductor smoke`, `conductor init`, `conductor doctor`); provider adapters that follow the same Provider Protocol regardless of whether they wrap an HTTP API or a CLI; auto-mode routing that's documented and predictable, never magical; setup UX that satisfies Doctrine 0002 (interactive on TTY, flag-driven in CI); and a hard bias against band-aid fixes — every bug-fix runs the pattern-check process in `principles/bug-triage.md` before implementation begins.
 
 The companion plan in autumn-garage names what v0.1 ships and what's deferred: `~/Repos/autumn-garage/.cortex/plans/conductor-bootstrap.md`. The doctrine that establishes Conductor's role is `~/Repos/autumn-garage/.cortex/doctrine/0004-conductor-as-fourth-peer.md`.
 
@@ -15,6 +15,7 @@ The companion plan in autumn-garage names what v0.1 ships and what's deferred: `
 @principles/engineering-principles.md
 @principles/pre-implementation-checklist.md
 @principles/audit-weak-points.md
+@principles/bug-triage.md
 @principles/documentation-ownership.md
 
 ## Git Workflow

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
 
-<!-- conductor:begin v0.10.27 -->
+<!-- conductor:begin v0.10.28 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/principles/bug-triage.md
+++ b/principles/bug-triage.md
@@ -1,0 +1,59 @@
+# Bug Triage: Pattern Check Before Fix Design
+
+Bug reports describe symptoms. Symptoms are the *result* of a root cause, not the root cause itself. When a report arrives, the first action is to understand the failure class — never to start designing the fix the report literally asks for. Building exactly what the report requested produces band-aids: the reporter saw one instance of the failure and described a fix that would handle that instance, not the class.
+
+This is a hard prerequisite, not a preference. Every bug-fix PR must show it ran.
+
+## When this fires
+
+The trigger is the moment a bug enters scope. Pattern-match on:
+
+- A GitHub issue referenced by number ("#460", "look at #459", "claim this issue")
+- A `Closes #N` / `Fixes #N` / `Refs #N` reference in a brief
+- A user message naming a failure observed in production ("X is broken", "exec keeps hitting the cap", "review is stalling")
+- A bug-fix task arriving via `conductor exec` or any agent-delegation surface
+- The phrase "fix this bug" or "let's address this"
+
+At that moment, before designing anything, run the process below. Do not skip even when the fix "looks easy" — the easy-looking fixes are the ones that ship as band-aids.
+
+## The process
+
+1. **Capture the literal failure.** What was observed? What was expected? Command, provider, route, version. State it back in one sentence.
+
+2. **Scan recent issues for related failures.** Run this exact command:
+
+   ```bash
+   gh issue list --state all --limit 30 \
+     --json number,title,state,createdAt,closedAt,closedByPullRequestsReferences \
+     --jq 'sort_by(.number) | reverse | .[] | "#\(.number) [\(.state)] \(.title)"'
+   ```
+
+   Skim titles for the same area (routing, exec lifecycle, telemetry, commit-boundary, etc.). Pull bodies of the 2–5 most related issues. The question to answer: is this report isolated, or part of a cluster?
+
+3. **Name the root cause hypothesis explicitly.** Write it down in the PR body or the conversation. If multiple recent issues share a root cause, the fix must address the shared cause — not each instance separately.
+
+4. **Choose: root-cause fix, or scoped symptom patch?** Root-cause fixes are the default. Symptom patches are allowed only under the next section — never silently.
+
+## When a symptom patch is the right call
+
+Time pressure, scope, or risk sometimes make a symptom patch the right scoped choice. When that's the case, the PR must:
+
+- State explicitly in the description that it is a symptom patch.
+- Name the root cause and what a proper fix would require.
+- Open or link a follow-up issue tracking the root cause.
+
+This matches **No band-aids** in [engineering-principles.md](engineering-principles.md). That principle covers *implementation*. This file covers the *triage step that happens before implementation*, so the band-aid-vs-root-cause choice is made consciously instead of by accident.
+
+## Smell tests: signs the proposed fix is a band-aid
+
+If the proposed fix matches any of these, stop and reconsider:
+
+- **Adjusts a single constant.** Raises a cap, extends a timeout, adds another retry, bumps a threshold. The next failure hits the next-bigger version of the same boundary. (Recent example: PR #464 raised `--effort high` iteration cap from 60→100 to close #459; the root cause is that exec has no commit-checkpoint contract and no internal run-health awareness, not that the cap was wrong.)
+- **Adds a warning instead of preventing the failure.** "Warn when X happens" lets X happen indefinitely. (Recent example: PR #466 warns when pre-commit hooks auto-stage files outside the brief — closing #460 without giving exec a real commit-boundary contract.)
+- **Adds a provider-specific routing rule, classification code, or guard.** Each provider's quirks belong in its adapter, not as another shared-code branch — see CLAUDE.md "Hard-Won Lessons" #3. The recurring routing-fallback issues (#399, #410, #411, #412, #420, #423, #427, #431, #434, #438, #445, #461) are the canonical example of this anti-pattern.
+- **PR title shape: "warn when…", "skip if…", "retry on…", "raise the cap…".** These shapes correlate strongly with symptom patches.
+- **Touches no design surface.** Only a value, a string, or a conditional. Root-cause fixes usually touch interfaces or contracts.
+
+## Why this is automatic, not on-demand
+
+A reader who already noticed the band-aid pattern doesn't need this principle. The slip happens when nobody is watching for it — a tired session, a focused implementer, a bug report that "looks easy." Making the triage step a hard prerequisite catches the slip when nobody is asking the question. The operator should not have to remind us; the principle should fire on its trigger every time.


### PR DESCRIPTION
When a bug report arrives, the first action must be to understand the
failure class — not to design the fix the report literally asks for.
Two recent merges (one raising the iteration cap, one warning when hooks
auto-stage out-of-brief files) are textbook band-aids of the kind this
principle is meant to catch.

The new file codifies a hard process: capture the literal failure, scan
recent issues for related failures with `gh issue list`, name the root
cause hypothesis, then choose root-cause-fix or scoped-symptom-patch
explicitly. Smell tests list the patterns that correlate with band-aids
(adjusting a single constant, adding warnings, provider-specific shared-
code branches, "warn/skip/retry/raise" PR titles).

Wired into CLAUDE.md's principles import block so it loads every session,
and the "Who You Are" vision sentence calls out the hard bias against
band-aid fixes.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
