### PR TITLE
fix: normalize duplicate review sentinels

### DIFF
--- a/src/conductor/providers/review_contract.py
+++ b/src/conductor/providers/review_contract.py
@@ -371,9 +371,32 @@ def _review_sentinel_violation(text: str) -> tuple[str | None, str, list[str]]:
         body = "\n".join(body_lines).rstrip()
         normalized = f"{body}\n{sentinel}" if body else sentinel
         return None, normalized, lines
+    if len(sentinel_indexes) > 1:
+        normalized = _normalize_duplicate_terminal_sentinel(lines, sentinel_indexes)
+        if normalized is not None:
+            return None, normalized, lines
     if not sentinel_indexes:
         return "missing", stripped, lines
     return "multiple", stripped, lines
+
+
+def _normalize_duplicate_terminal_sentinel(
+    lines: list[str],
+    sentinel_indexes: list[int],
+) -> str | None:
+    first_sentinel_idx = sentinel_indexes[0]
+    first_match = _REVIEW_SENTINEL_RE.match(lines[first_sentinel_idx])
+    if first_match is None:
+        return None
+    sentinel = first_match.group(1)
+
+    for line in lines[first_sentinel_idx:]:
+        match = _REVIEW_SENTINEL_RE.match(line)
+        if line.strip() and (match is None or match.group(1) != sentinel):
+            return None
+
+    body = "\n".join(lines[:first_sentinel_idx]).rstrip()
+    return f"{body}\n{sentinel}" if body else sentinel
 
 
 def _contract_error_preview(text: str) -> str:

--- a/tests/test_adapters_subprocess.py
+++ b/tests/test_adapters_subprocess.py
@@ -1714,7 +1714,10 @@ def test_codex_review_rejects_malformed_json_stdout(mocker, capsys):
     mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
     mocker.patch(
         "conductor.providers.codex.build_review_task_prompt",
-        return_value="PROMPT",
+        return_value=(
+            "Return a final standalone CODEX_REVIEW_CLEAN or "
+            "CODEX_REVIEW_BLOCKED line."
+        ),
     )
     captured = mocker.patch(
         "conductor.providers.codex.subprocess.run",
@@ -1782,6 +1785,43 @@ def test_codex_review_synthesizes_findings_with_blocked_sentinel(mocker):
     assert response.text == (
         "Missing null check on line 42 will crash.\n\nCODEX_REVIEW_BLOCKED"
     )
+
+
+def test_codex_review_normalizes_duplicate_blocked_sentinel_from_findings(mocker):
+    """Codex can repeat the requested sentinel inside the structured findings.
+    The legacy boundary still emits exactly one final sentinel line."""
+    mocker.patch("conductor.providers.codex.shutil.which", return_value="/usr/bin/codex")
+    mocker.patch(
+        "conductor.providers.codex.build_review_task_prompt",
+        return_value=(
+            "Return a final standalone CODEX_REVIEW_CLEAN or "
+            "CODEX_REVIEW_BLOCKED line."
+        ),
+    )
+    mocker.patch(
+        "conductor.providers.codex.subprocess.run",
+        return_value=_fake_completed(
+            stdout=json.dumps(
+                {
+                    "status": "BLOCKED",
+                    "findings": (
+                        "Missing null check on line 42 will crash.\n"
+                        "CODEX_REVIEW_BLOCKED"
+                    ),
+                }
+            )
+            + "\n"
+        ),
+    )
+
+    response = CodexProvider().review(
+        "Return a final standalone CODEX_REVIEW_CLEAN or CODEX_REVIEW_BLOCKED line.",
+    )
+
+    assert response.text == (
+        "Missing null check on line 42 will crash.\nCODEX_REVIEW_BLOCKED"
+    )
+    assert response.text.splitlines().count("CODEX_REVIEW_BLOCKED") == 1
 
 
 def test_codex_review_caps_non_streaming_timeout_to_stall_budget(mocker):

--- a/tests/test_review_contract.py
+++ b/tests/test_review_contract.py
@@ -79,6 +79,46 @@ def test_review_sentinel_contract_rejects_multiple_sentinels():
         )
 
 
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        (
+            "Review body.\nCODEX_REVIEW_BLOCKED\nCODEX_REVIEW_BLOCKED\n",
+            "Review body.\nCODEX_REVIEW_BLOCKED",
+        ),
+        (
+            "Review body.\nCODEX_REVIEW_BLOCKED\n\nCODEX_REVIEW_BLOCKED\n",
+            "Review body.\nCODEX_REVIEW_BLOCKED",
+        ),
+    ],
+)
+def test_review_sentinel_contract_normalizes_duplicate_terminal_sentinel(
+    text: str,
+    expected: str,
+):
+    validated = validate_requested_review_sentinel(
+        provider_name="codex",
+        prompt=STRICT_SENTINEL_PROMPT,
+        text=text,
+    )
+
+    assert validated == expected
+
+
+def test_review_sentinel_contract_rejects_duplicate_sentinel_with_trailing_prose():
+    with pytest.raises(ReviewOutputContractError, match="multiple"):
+        validate_requested_review_sentinel(
+            provider_name="codex",
+            prompt=STRICT_SENTINEL_PROMPT,
+            text=(
+                "Review body.\n"
+                "CODEX_REVIEW_BLOCKED\n"
+                "Additional prose after the verdict.\n"
+                "CODEX_REVIEW_BLOCKED\n"
+            ),
+        )
+
+
 def test_review_sentinel_contract_accepts_footer_and_normalizes_final_sentinel():
     validated = validate_requested_review_sentinel(
         provider_name="codex",


### PR DESCRIPTION
## Linked Issues

Closes #480
Closes #481

Accept duplicate identical terminal review sentinel lines by normalizing them to the single final verdict line while continuing to fail closed on mixed or non-terminal sentinel output.

Closes-issue: #480

Closes-issue: #481

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
