### PR TITLE
fix: block ambiguous no-change review fixes

### DIFF
--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -3289,10 +3289,14 @@ append_findings_history_event() {
   commits="$(review_history_commits_since_prior "$prior_head" "$head")"
 
   findings_block="$(extract_findings_block "$output")"
-  if [ -z "$findings_block" ] && [ "$result" = "CODEX_REVIEW_FIXED" ]; then
+  if [ -z "$findings_block" ] \
+    && { [ "$result" = "CODEX_REVIEW_FIXED" ] || [ "$result" = "CODEX_REVIEW_BLOCKED" ]; }; then
     findings_block="$(extract_review_body_without_sentinel "$output")"
   fi
   findings_count="$(printf '%s\n' "$findings_block" | grep -c '^- ' || true)"
+  if [ "$findings_count" -eq 0 ] && [ -n "$findings_block" ]; then
+    findings_count=1
+  fi
   if [ "$result" = "CODEX_REVIEW_FIXED" ] && [ "$auto_fixed_count" -eq 0 ] && [ -n "$findings_block" ]; then
     auto_fixed_count="$findings_count"
     [ "$auto_fixed_count" -gt 0 ] || auto_fixed_count=1
@@ -4244,7 +4248,7 @@ ${fix_output}"
 
 review_completion_status() {
   case "${1:-}" in
-    clean | blocked | cache-hit)
+    clean | blocked | ambiguous-fixed-no-changes | cache-hit)
       printf 'completed\n'
       ;;
     *)
@@ -4690,10 +4694,24 @@ for iter in $(seq 1 "$MAX_ITERATIONS"); do
 
       AUTOFIX_CHANGED_PATHS="$(changed_paths)"
       if [ -z "$AUTOFIX_CHANGED_PATHS" ]; then
+        findings_block="$(extract_findings_block "$OUTPUT")"
+        REVIEW_FINDINGS_COUNT="$(printf '%s\n' "$findings_block" | grep -c '^- ' || true)"
+        if [ "$REVIEW_FINDINGS_COUNT" -eq 0 ] \
+          && [ -n "$(extract_review_body_without_sentinel "$OUTPUT")" ]; then
+          REVIEW_FINDINGS_COUNT=1
+        fi
         echo "==> $REVIEWER_LABEL emitted FIXED but no working-tree changes detected."
-        echo "    Treating as ambiguous — not blocking push."
-        log_skip_event other "ambiguous-fixed-no-changes:iter=${iter}"
-        exit 0
+        echo "    Treating as ambiguous — blocking push and surfacing reviewer output."
+        tk_verdict fail "PUSH BLOCKED" "${REVIEWER_LABEL} returned FIXED without file changes"
+        printf '%s\n' "$OUTPUT" | sed 's/^/    /'
+        echo ""
+        echo "    Resolve the ambiguity or rerun the review before merging."
+        REVIEW_EXIT_REASON="ambiguous-fixed-no-changes"
+        print_summary
+        write_review_findings "$OUTPUT"
+        append_findings_history_event "CODEX_REVIEW_BLOCKED" "$iter" "$OUTPUT" 0
+        log_skip_event ran "ambiguous-fixed-no-changes:iter=${iter}:findings=${REVIEW_FINDINGS_COUNT}"
+        exit 1
       fi
 
       if [ "$WORKTREE_DIRTY_BEFORE_REVIEW" = true ]; then

--- a/tests/test_codex_review_sentinel.py
+++ b/tests/test_codex_review_sentinel.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import textwrap
@@ -462,3 +463,79 @@ def test_codex_review_wrapper_blocks_below_minimum_conductor_version(
     assert "installed: 0.10.29" in result.stderr
     assert "brew update && brew upgrade autumngarage/conductor/conductor" in result.stderr
     assert "CODEX_REVIEW_CLEAN" not in result.stdout
+
+
+def test_codex_review_wrapper_blocks_ambiguous_fixed_without_changes(
+    tmp_path: Path,
+) -> None:
+    repo, env = _make_review_repo(tmp_path)
+    fakes = tmp_path / "fakes"
+    fakes.mkdir()
+    summary_file = tmp_path / "review-summary.json"
+    review_log = tmp_path / "review-log.tsv"
+    findings_history = tmp_path / "findings-history.jsonl"
+
+    conductor = fakes / "conductor"
+    conductor.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            case "$1" in
+              doctor)
+                printf '{"configured": true}\\n'
+                ;;
+              review|exec)
+                cat >/dev/null
+                printf 'Potential concern: freshness canary no longer covers the new source.\\n'
+                printf 'CODEX_REVIEW_FIXED\\n'
+                ;;
+              *)
+                exit 1
+                ;;
+            esac
+            """
+        ),
+        encoding="utf-8",
+    )
+    conductor.chmod(0o755)
+
+    script = Path(__file__).resolve().parent.parent / "scripts" / "codex-review.sh"
+    result = subprocess.run(
+        ["bash", str(script)],
+        cwd=repo,
+        env={
+            **env,
+            "PATH": f"{fakes}:{os.environ.get('PATH', '')}",
+            "CODEX_REVIEW_BASE": "HEAD~1",
+            "CODEX_REVIEW_MODE": "fix",
+            "CODEX_REVIEW_DISABLE_CACHE": "1",
+            "CODEX_REVIEW_TIMEOUT": "5",
+            "CODEX_REVIEW_SUMMARY_FILE": str(summary_file),
+            "CODEX_REVIEW_FINDINGS_HISTORY_FILE": str(findings_history),
+            "TOUCHSTONE_REVIEW_LOG": str(review_log),
+            "NO_COLOR": "1",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "emitted FIXED but no working-tree changes detected" in result.stdout
+    assert "Treating as ambiguous" in result.stdout
+    assert "Potential concern: freshness canary" in result.stdout
+    assert "exit reason:    ambiguous-fixed-no-changes" in result.stdout
+
+    summary = json.loads(summary_file.read_text(encoding="utf-8"))
+    assert summary["exit_reason"] == "ambiguous-fixed-no-changes"
+    assert summary["findings"] == 1
+
+    history = json.loads(findings_history.read_text(encoding="utf-8").splitlines()[-1])
+    assert history["result"] == "CODEX_REVIEW_BLOCKED"
+    assert history["findings_count"] == 1
+    assert "Potential concern: freshness canary" in history["findings"]
+    assert "CODEX_REVIEW_FIXED" not in history["findings"]
+
+    log_lines = review_log.read_text(encoding="utf-8").splitlines()
+    assert log_lines
+    assert "\tran\tambiguous-fixed-no-changes:" in log_lines[-1]


### PR DESCRIPTION
## Linked Issues

Closes #471

Closes-issue: #471

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
