### PR TITLE
fix(review): cascade falls to cheap OpenRouter stack, not premium codex

### DIFF
--- a/.cursor/rules/conductor-delegation.mdc
+++ b/.cursor/rules/conductor-delegation.mdc
@@ -2,7 +2,7 @@
 description: Use when delegating or routing tasks to a different LLM via the conductor CLI — e.g., cheap second opinions, long-context reads, web search, or offline runs.
 globs: ""
 alwaysApply: false
-managed-by: conductor v0.10.29
+managed-by: conductor v0.10.30
 ---
 
 # Conductor delegation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,7 @@ If there are zero blocking issues, the review is just: "LGTM."
 
 @.cortex/protocol.md
 
-<!-- conductor:begin v0.10.29 -->
+<!-- conductor:begin v0.10.30 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
 
-<!-- conductor:begin v0.10.29 -->
+<!-- conductor:begin v0.10.30 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/src/conductor/openrouter_model_stacks.py
+++ b/src/conductor/openrouter_model_stacks.py
@@ -45,6 +45,16 @@ OPENROUTER_CODING_MAX: tuple[str, ...] = (
     "deepseek/deepseek-v4-pro",
 )
 
+# Review fallback stack — used when codex/claude native review are unavailable.
+# Starts cheap on purpose: review is a high-volume path (every push through the
+# Touchstone merge gate retries the cascade) and the coding stacks above cost
+# ~20x more per equivalent review. See issue #501.
+OPENROUTER_REVIEW_CHEAP: tuple[str, ...] = (
+    "deepseek/deepseek-v4-pro",
+    "moonshotai/kimi-k2.6",
+    "qwen/qwen3-coder-plus",
+)
+
 
 def model_family(model: str) -> str:
     """Return the lowercased provider family prefix for a model slug."""

--- a/src/conductor/semantic.py
+++ b/src/conductor/semantic.py
@@ -14,6 +14,7 @@ from typing import Literal
 from conductor.openrouter_model_stacks import (
     OPENROUTER_CODING_HIGH,
     OPENROUTER_CODING_MAX,
+    OPENROUTER_REVIEW_CHEAP,
 )
 
 SemanticKind = Literal["research", "code", "review", "council"]
@@ -205,12 +206,7 @@ _REVIEW: dict[EffortBucket, SemanticPlan] = {
         candidates=(
             SemanticCandidate("codex"),
             SemanticCandidate("claude"),
-            SemanticCandidate(
-                "openrouter",
-                OPENROUTER_CODING_MAX
-                if bucket == "max"
-                else OPENROUTER_CODING_HIGH,
-            ),
+            SemanticCandidate("openrouter", OPENROUTER_REVIEW_CHEAP),
         ),
     )
     for bucket in EFFORT_BUCKETS

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -34,7 +34,10 @@ from conductor.cli import (
     main,
 )
 from conductor.network_profile import NetworkProfile
-from conductor.openrouter_model_stacks import OPENROUTER_CODING_HIGH
+from conductor.openrouter_model_stacks import (
+    OPENROUTER_CODING_HIGH,
+    OPENROUTER_REVIEW_CHEAP,
+)
 from conductor.providers import (
     CallResponse,
     ClaudeProvider,
@@ -1621,7 +1624,7 @@ def test_review_with_openrouter_uses_hosted_review_prompt(mocker, tmp_path):
         "call",
         return_value=_fake_response(
             "openrouter",
-            OPENROUTER_CODING_HIGH[0],
+            OPENROUTER_REVIEW_CHEAP[0],
             text="No blocking issues found.\nCODEX_REVIEW_CLEAN",
         ),
     )
@@ -1648,7 +1651,7 @@ def test_review_with_openrouter_uses_hosted_review_prompt(mocker, tmp_path):
 
     assert result.exit_code == 0, result.output
     assert openrouter_call.called
-    assert openrouter_call.call_args.kwargs["models"] == OPENROUTER_CODING_HIGH
+    assert openrouter_call.call_args.kwargs["models"] == OPENROUTER_REVIEW_CHEAP
     assert openrouter_call.call_args.kwargs["task_tags"] == ["code-review"]
     assert openrouter_call.call_args.kwargs["prefer"] == "best"
     prompt = openrouter_call.call_args.args[0]
@@ -1731,7 +1734,7 @@ def test_review_auto_claude_rate_limit_falls_through_to_next_provider(mocker):
         "call",
         return_value=_fake_response(
             "openrouter",
-            OPENROUTER_CODING_HIGH[0],
+            OPENROUTER_REVIEW_CHEAP[0],
             text="No blocking issues found.\nCODEX_REVIEW_CLEAN",
         ),
     )
@@ -1772,7 +1775,7 @@ def test_review_auto_next_provider_success_json_reports_winner_and_status(mocker
         "call",
         return_value=_fake_response(
             "openrouter",
-            OPENROUTER_CODING_HIGH[0],
+            OPENROUTER_REVIEW_CHEAP[0],
             text="No blocking issues found.\nCODEX_REVIEW_CLEAN",
         ),
     )
@@ -1804,7 +1807,7 @@ def test_review_auto_next_provider_success_json_reports_winner_and_status(mocker
     assert payload["exit_class"] == "clean"
     assert payload["failure_code"] is None
     assert payload["selected_provider"] == "openrouter"
-    assert payload["selected_model"] == OPENROUTER_CODING_HIGH[0]
+    assert payload["selected_model"] == OPENROUTER_REVIEW_CHEAP[0]
     assert payload["review_verdict"] == "clean"
     assert [
         (attempt["provider"], attempt["status"], attempt["failure_code"])
@@ -2053,7 +2056,7 @@ def test_review_auto_generic_fallback_prompt_includes_diff(mocker, tmp_path):
     )
 
     assert result.exit_code == 0, result.output
-    assert openrouter_call.call_args.kwargs["models"] == OPENROUTER_CODING_HIGH
+    assert openrouter_call.call_args.kwargs["models"] == OPENROUTER_REVIEW_CHEAP
     assert openrouter_call.call_args.kwargs["task_tags"] == ["code-review"]
     assert openrouter_call.call_args.kwargs["timeout_sec"] == 75
     assert openrouter_call.call_args.kwargs["max_stall_sec"] == 75
@@ -2063,7 +2066,7 @@ def test_review_auto_generic_fallback_prompt_includes_diff(mocker, tmp_path):
     assert "+fallback diff marker" in prompt
 
 
-def test_ask_review_uses_openrouter_code_stack_instead_of_gemini(mocker, tmp_path):
+def test_ask_review_uses_cheap_openrouter_stack_instead_of_gemini(mocker, tmp_path):
     from conductor.providers.interface import ProviderStalledError
 
     repo = _make_diff_repo(tmp_path)
@@ -2089,7 +2092,7 @@ def test_ask_review_uses_openrouter_code_stack_instead_of_gemini(mocker, tmp_pat
     openrouter_call = mocker.patch.object(
         OpenRouterProvider,
         "call",
-        return_value=_fake_response("openrouter", OPENROUTER_CODING_HIGH[0]),
+        return_value=_fake_response("openrouter", OPENROUTER_REVIEW_CHEAP[0]),
     )
 
     result = CliRunner().invoke(
@@ -2113,7 +2116,7 @@ def test_ask_review_uses_openrouter_code_stack_instead_of_gemini(mocker, tmp_pat
     assert result.exit_code == 0, result.output
     assert not gemini_review.called
     assert openrouter_call.called
-    assert openrouter_call.call_args.kwargs["models"] == OPENROUTER_CODING_HIGH
+    assert openrouter_call.call_args.kwargs["models"] == OPENROUTER_REVIEW_CHEAP
     assert openrouter_call.call_args.kwargs["task_tags"] == ["code-review"]
     assert openrouter_call.call_args.kwargs["timeout_sec"] == 75
     assert openrouter_call.call_args.kwargs["max_stall_sec"] == 75
@@ -2125,7 +2128,7 @@ def test_ask_review_uses_openrouter_code_stack_instead_of_gemini(mocker, tmp_pat
         "claude",
         "openrouter",
     ]
-    assert payload["semantic"]["candidates"][2]["models"] == list(OPENROUTER_CODING_HIGH)
+    assert payload["semantic"]["candidates"][2]["models"] == list(OPENROUTER_REVIEW_CHEAP)
 
 
 def test_review_auto_generic_fallback_rejects_missing_requested_sentinel(

--- a/tests/test_semantic.py
+++ b/tests/test_semantic.py
@@ -7,6 +7,7 @@ import pytest
 from conductor.openrouter_model_stacks import (
     OPENROUTER_CODING_HIGH,
     OPENROUTER_CODING_MAX,
+    OPENROUTER_REVIEW_CHEAP,
 )
 from conductor.semantic import SEMANTIC_KINDS, plan_for
 
@@ -63,7 +64,7 @@ def test_high_code_escalates_to_agentic_coding_stack(effort):
 
 
 @pytest.mark.parametrize("effort", ["minimal", "low", "medium", "high", "max"])
-def test_review_uses_openrouter_code_stack_after_native_reviewers(effort):
+def test_review_falls_back_to_cheap_openrouter_stack(effort):
     plan = plan_for("review", effort)
 
     assert plan.mode == "review"
@@ -72,10 +73,25 @@ def test_review_uses_openrouter_code_stack_after_native_reviewers(effort):
         "claude",
         "openrouter",
     ]
-    expected_stack = (
-        OPENROUTER_CODING_MAX if effort == "max" else OPENROUTER_CODING_HIGH
-    )
-    assert plan.candidates[2].models == expected_stack
+    assert plan.candidates[2].models == OPENROUTER_REVIEW_CHEAP
+
+
+@pytest.mark.parametrize("effort", ["minimal", "low", "medium", "high", "max"])
+def test_review_openrouter_step_never_starts_with_premium_coding_model(effort):
+    """Regression guard for #501.
+
+    Why: when codex and claude native review fail, the OpenRouter step used to
+    start with `openai/gpt-5.3-codex` (premium), burning ~$30/day at the
+    operator's observed volume. The cascade must fail toward the cheapest
+    correct provider, not the most expensive same-category one.
+    """
+    plan = plan_for("review", effort)
+    openrouter_models = plan.candidates[2].models
+
+    assert openrouter_models[0] != "openai/gpt-5.3-codex"
+    assert "openai/gpt-5.3-codex" not in openrouter_models
+    assert "openai/gpt-5.5-pro" not in openrouter_models
+    assert "anthropic/claude-opus-4.7" not in openrouter_models
 
 
 def test_integer_effort_maps_into_bucketed_matrix():


### PR DESCRIPTION
When codex and claude native review fail, the OpenRouter step used
OPENROUTER_CODING_HIGH starting with openai/gpt-5.3-codex. At observed
volume (146 review events / 7d, each session ~80 HTTP turns) this drove
$215/week on a single premium model — 99% of OpenRouter spend on review
that codex CLI was meant to absorb for free.

Add OPENROUTER_REVIEW_CHEAP (deepseek-v4-pro, kimi-k2.6, qwen3-coder-plus)
and rewire the _REVIEW semantic plan to use it. Cascade now reads:
codex → claude → cheap-OpenRouter → fail.

Touchstone's TOML/env knobs keep working — no surface change, only the
default models for the openrouter fallback step change. Per-request cost
drops ~20× when the cascade reaches OpenRouter.

Adds a regression guard test asserting the openrouter step in review
never starts with a premium coding model.

Refs #501 (canonical design issue) — this is PR A of the multi-PR plan.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
