### PR TITLE
feat(reap): add conductor reap to detect and kill long-running provider processes

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -12762,6 +12762,102 @@ def git_cleanup(
         click.echo("Run with --execute to actually delete.")
 
 
+@main.command("reap")
+@click.option(
+    "--older-than",
+    "older_than",
+    default="1h",
+    show_default=True,
+    help="Age threshold (30s, 5m, 2h, 1d). Processes younger than this are ignored.",
+)
+@click.option(
+    "--execute",
+    is_flag=True,
+    default=False,
+    help="Send SIGTERM then SIGKILL to matching processes. Dry-run by default.",
+)
+@click.option(
+    "--pattern",
+    "extra_patterns",
+    multiple=True,
+    help=(
+        "Additional command substring to match. May be repeated. Defaults cover "
+        "codex --dangerously, codex exec, conductor exec, conductor swarm."
+    ),
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit structured reap report as JSON.",
+)
+def reap(
+    older_than: str,
+    execute: bool,
+    extra_patterns: tuple[str, ...],
+    as_json: bool,
+) -> None:
+    """Find and kill long-running provider processes that escape attention.
+
+    See issue #499. Detects codex / conductor-spawned processes alive longer
+    than --older-than and offers to terminate them. Dry-run by default so an
+    operator can confirm the list before killing.
+    """
+    from conductor.reap import (
+        DEFAULT_REAP_PATTERNS,
+        format_etime_human,
+        parse_duration,
+        reap_processes,
+        scan_stale_processes,
+    )
+
+    try:
+        threshold = parse_duration(older_than)
+    except ValueError as e:
+        raise click.UsageError(str(e)) from e
+
+    patterns = DEFAULT_REAP_PATTERNS + tuple(extra_patterns)
+    stale = scan_stale_processes(threshold_sec=threshold, patterns=patterns)
+
+    killed: list[int] = []
+    errors: list[dict[str, object]] = []
+    if execute and stale:
+        killed, errors = reap_processes(stale)
+
+    if as_json:
+        payload = {
+            "dry_run": not execute,
+            "threshold_sec": threshold,
+            "patterns": list(patterns),
+            "stale": [p.payload() for p in stale],
+            "killed": killed,
+            "errors": errors,
+        }
+        click.echo(json.dumps(payload, indent=2))
+        return
+
+    click.echo(
+        f"Provider processes older than {older_than} ({len(stale)} found):"
+    )
+    if stale:
+        for p in stale:
+            human = format_etime_human(p.etime_seconds)
+            click.echo(f"  pid={p.pid} ppid={p.ppid} age={human}  {p.command}")
+    else:
+        click.echo("  (none)")
+
+    click.echo("")
+    if execute:
+        click.echo(f"Killed {len(killed)} processes.")
+        if errors:
+            click.echo(f"{len(errors)} processes could not be terminated:")
+            for err in errors:
+                click.echo(f"  pid={err['pid']}: {err['error']}", err=True)
+    else:
+        click.echo("Run with --execute to send SIGTERM then SIGKILL.")
+
+
 @main.command()
 @click.option(
     "--json",
@@ -12972,6 +13068,22 @@ def doctor(as_json: bool) -> None:
         click.echo("  Refresh with:")
         click.echo("    conductor git-cleanup           # dry-run (default)")
         click.echo("    conductor git-cleanup --execute # actually delete")
+
+    try:
+        from conductor.reap import format_etime_human, scan_stale_processes
+
+        stale_procs = scan_stale_processes()
+    except Exception:
+        stale_procs = []
+    if stale_procs:
+        click.echo("")
+        click.echo("⚠ Long-running provider processes detected:")
+        for p in stale_procs:
+            human = format_etime_human(p.etime_seconds)
+            click.echo(f"    pid={p.pid} age={human}  {p.command[:80]}")
+        click.echo("  These keep burning provider tokens until killed. Reap with:")
+        click.echo("    conductor reap                  # dry-run (default)")
+        click.echo("    conductor reap --execute        # SIGTERM then SIGKILL")
 
     click.echo("")
     click.echo("Next steps:")

--- a/src/conductor/reap.py
+++ b/src/conductor/reap.py
@@ -1,0 +1,251 @@
+"""Detect and reap long-running provider processes that escape operator attention.
+
+See issue #499. Real incident on 2026-05-20: 8 forgotten codex agents ran 40+
+hours each in Vesper panes the operator had stopped watching, driving a
+$215/week OpenRouter bill. The right structural fix is a single command the
+operator can run (and a `conductor doctor` audit that surfaces the same data)
+to find and kill these before they compound.
+
+Pure detection lives here; the CLI wiring is in cli.py. Keep the surface tight
+so tests can drive it without spawning real processes.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import signal
+import subprocess
+import time
+from dataclasses import dataclass
+
+DEFAULT_REAP_PATTERNS: tuple[str, ...] = (
+    "codex --dangerously",
+    "codex exec",
+    "conductor exec",
+    "conductor swarm",
+)
+
+DEFAULT_REAP_THRESHOLD_SEC = 3600  # 1 hour
+
+_PS_FIELDS = ("pid", "ppid", "etime", "command")
+
+
+@dataclass(frozen=True)
+class StaleProcess:
+    """One provider-related process that has been alive longer than the threshold."""
+
+    pid: int
+    ppid: int
+    etime_seconds: int
+    etime_str: str
+    command: str
+
+    def payload(self) -> dict[str, object]:
+        return {
+            "pid": self.pid,
+            "ppid": self.ppid,
+            "etime_seconds": self.etime_seconds,
+            "etime": self.etime_str,
+            "command": self.command,
+        }
+
+
+def parse_etime(value: str) -> int | None:
+    """Parse a ps ``etime`` field (``MM:SS``, ``HH:MM:SS``, ``DD-HH:MM:SS``).
+
+    Returns total seconds, or None on unrecognized formats. ps uses these forms
+    on Linux and macOS, with leading zeros stripped from the most-significant
+    field.
+    """
+    if not value or value == "-":
+        return None
+    days = 0
+    rest = value
+    if "-" in rest:
+        head, _, rest = rest.partition("-")
+        if not head.isdigit():
+            return None
+        days = int(head)
+    parts = rest.split(":")
+    if not all(p.isdigit() for p in parts):
+        return None
+    if len(parts) == 2:
+        h, m, s = 0, int(parts[0]), int(parts[1])
+    elif len(parts) == 3:
+        h, m, s = int(parts[0]), int(parts[1]), int(parts[2])
+    else:
+        return None
+    return days * 86400 + h * 3600 + m * 60 + s
+
+
+def _matches_any(command: str, patterns: tuple[str, ...]) -> bool:
+    return any(pat in command for pat in patterns)
+
+
+def scan_ps(ps_runner=None) -> list[tuple[int, int, str, str]]:
+    """Run ``ps`` and return parsed rows. Injectable for tests."""
+    if ps_runner is None:
+        result = subprocess.run(
+            ["ps", "-o", ",".join(_PS_FIELDS), "-ax"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return []
+        output = result.stdout
+    else:
+        output = ps_runner()
+
+    rows: list[tuple[int, int, str, str]] = []
+    for line in output.splitlines()[1:]:  # skip header
+        # ps fixed-width output: PID PPID ETIME COMMAND...
+        # Splitting on whitespace works because PID/PPID/ETIME never contain spaces.
+        parts = line.split(None, 3)
+        if len(parts) < 4:
+            continue
+        pid_s, ppid_s, etime, command = parts[0], parts[1], parts[2], parts[3]
+        if not pid_s.isdigit() or not ppid_s.isdigit():
+            continue
+        rows.append((int(pid_s), int(ppid_s), etime, command))
+    return rows
+
+
+def scan_stale_processes(
+    *,
+    threshold_sec: int = DEFAULT_REAP_THRESHOLD_SEC,
+    patterns: tuple[str, ...] = DEFAULT_REAP_PATTERNS,
+    ps_runner=None,
+) -> list[StaleProcess]:
+    """Return processes matching ``patterns`` whose age >= ``threshold_sec``.
+
+    The ``ps_runner`` hook returns a ps-style stdout string and exists so tests
+    can drive the parser without invoking the real binary.
+    """
+    rows = scan_ps(ps_runner=ps_runner)
+    own_pid = os.getpid()
+    stale: list[StaleProcess] = []
+    for pid, ppid, etime, command in rows:
+        if pid == own_pid:
+            continue
+        if not _matches_any(command, patterns):
+            continue
+        age = parse_etime(etime)
+        if age is None or age < threshold_sec:
+            continue
+        stale.append(
+            StaleProcess(
+                pid=pid,
+                ppid=ppid,
+                etime_seconds=age,
+                etime_str=etime,
+                command=command,
+            )
+        )
+    stale.sort(key=lambda p: p.etime_seconds, reverse=True)
+    return stale
+
+
+def reap_processes(
+    processes: list[StaleProcess],
+    *,
+    grace_sec: float = 5.0,
+    signal_sender=None,
+    sleeper=None,
+    alive_check=None,
+) -> tuple[list[int], list[dict[str, object]]]:
+    """Send SIGTERM then SIGKILL to ``processes`` and report what happened.
+
+    Returns ``(killed_pids, errors)``. ``errors`` is a list of dicts each with
+    ``pid`` and ``error`` keys for processes the reaper couldn't terminate.
+
+    The signal sender, sleeper, and alive check are injectable for tests so we
+    don't need to spawn real processes to exercise the kill flow.
+    """
+    if not processes:
+        return [], []
+
+    if signal_sender is None:
+        def signal_sender(pid: int, sig: int) -> None:
+            os.kill(pid, sig)
+
+    if sleeper is None:
+        sleeper = time.sleep
+
+    if alive_check is None:
+        def alive_check(pid: int) -> bool:
+            try:
+                os.kill(pid, 0)
+                return True
+            except ProcessLookupError:
+                return False
+            except PermissionError:
+                return True
+
+    killed: list[int] = []
+    errors: list[dict[str, object]] = []
+
+    for proc in processes:
+        try:
+            signal_sender(proc.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            killed.append(proc.pid)
+            continue
+        except OSError as e:
+            errors.append({"pid": proc.pid, "error": f"SIGTERM failed: {e}"})
+
+    sleeper(grace_sec)
+
+    for proc in processes:
+        if any(err["pid"] == proc.pid for err in errors):
+            continue
+        if not alive_check(proc.pid):
+            if proc.pid not in killed:
+                killed.append(proc.pid)
+            continue
+        try:
+            signal_sender(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            killed.append(proc.pid)
+            continue
+        except OSError as e:
+            errors.append({"pid": proc.pid, "error": f"SIGKILL failed: {e}"})
+            continue
+        # one more brief grace, then a final liveness check
+        sleeper(0.5)
+        if alive_check(proc.pid):
+            errors.append(
+                {"pid": proc.pid, "error": "process survived SIGKILL (zombie?)"}
+            )
+        else:
+            killed.append(proc.pid)
+
+    return killed, errors
+
+
+_DURATION_RE = re.compile(r"^(\d+)\s*([smhdw])?$", re.IGNORECASE)
+
+
+def parse_duration(value: str) -> int:
+    """Parse ``30m``, ``2h``, ``1d``, ``300s``, or bare integer seconds."""
+    m = _DURATION_RE.match(value.strip())
+    if not m:
+        raise ValueError(
+            f"invalid duration {value!r}: expected forms like 30s, 5m, 2h, 1d"
+        )
+    n = int(m.group(1))
+    unit = (m.group(2) or "s").lower()
+    multipliers = {"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 86400 * 7}
+    return n * multipliers[unit]
+
+
+def format_etime_human(seconds: int) -> str:
+    """Human-readable age: ``2d 4h``, ``45m``, ``30s``."""
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    if seconds < 86400:
+        return f"{seconds // 3600}h {(seconds % 3600) // 60}m"
+    return f"{seconds // 86400}d {(seconds % 86400) // 3600}h"

--- a/tests/test_reap.py
+++ b/tests/test_reap.py
@@ -1,0 +1,265 @@
+"""Tests for the reap module: detection, parsing, and kill flow."""
+
+from __future__ import annotations
+
+import signal
+
+import pytest
+
+from conductor.reap import (
+    DEFAULT_REAP_PATTERNS,
+    StaleProcess,
+    format_etime_human,
+    parse_duration,
+    parse_etime,
+    reap_processes,
+    scan_stale_processes,
+)
+
+
+class TestParseEtime:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("00:30", 30),
+            ("05:00", 300),
+            ("01:30:00", 5400),
+            ("12:34:56", 12 * 3600 + 34 * 60 + 56),
+            ("1-00:00:00", 86400),
+            ("2-04:30:15", 2 * 86400 + 4 * 3600 + 30 * 60 + 15),
+        ],
+    )
+    def test_known_formats(self, value, expected):
+        assert parse_etime(value) == expected
+
+    @pytest.mark.parametrize("value", ["", "-", "garbage", "01", "xx:yy"])
+    def test_unrecognized_returns_none(self, value):
+        assert parse_etime(value) is None
+
+
+class TestParseDuration:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("30s", 30),
+            ("30", 30),
+            ("5m", 300),
+            ("2h", 7200),
+            ("1d", 86400),
+            ("1w", 86400 * 7),
+            ("2H", 7200),  # case-insensitive
+        ],
+    )
+    def test_known_forms(self, value, expected):
+        assert parse_duration(value) == expected
+
+    @pytest.mark.parametrize("value", ["", "abc", "5x", "1.5h", "h5"])
+    def test_invalid_raises(self, value):
+        with pytest.raises(ValueError):
+            parse_duration(value)
+
+
+class TestFormatEtimeHuman:
+    @pytest.mark.parametrize(
+        "seconds,expected",
+        [
+            (5, "5s"),
+            (59, "59s"),
+            (60, "1m"),
+            (3599, "59m"),
+            (3600, "1h 0m"),
+            (7320, "2h 2m"),
+            (86400, "1d 0h"),
+            (180_000, "2d 2h"),
+        ],
+    )
+    def test_format(self, seconds, expected):
+        assert format_etime_human(seconds) == expected
+
+
+def _ps_output(*rows: tuple[int, int, str, str]) -> str:
+    """Build a fake ps stdout. Each row is (pid, ppid, etime, command)."""
+    lines = ["  PID  PPID     ELAPSED COMMAND"]
+    for pid, ppid, etime, command in rows:
+        lines.append(f"{pid:>5} {ppid:>5} {etime:>11} {command}")
+    return "\n".join(lines) + "\n"
+
+
+class TestScanStaleProcesses:
+    def test_filters_by_pattern(self):
+        codex_cmd = (
+            "/opt/homebrew/bin/codex --dangerously-bypass-approvals-and-sandbox"
+        )
+        ps = _ps_output(
+            (100, 1, "02:00:00", codex_cmd),
+            (101, 1, "02:00:00", "/usr/bin/python3 some-other-thing.py"),
+            (102, 1, "02:00:00", "conductor exec --brief-file /tmp/b.md"),
+        )
+        stale = scan_stale_processes(threshold_sec=3600, ps_runner=lambda: ps)
+        pids = sorted(p.pid for p in stale)
+        assert pids == [100, 102]
+
+    def test_threshold_excludes_young(self):
+        ps = _ps_output(
+            (100, 1, "00:30:00", "codex --dangerously-x"),
+            (200, 1, "02:00:00", "codex --dangerously-x"),
+        )
+        stale = scan_stale_processes(threshold_sec=3600, ps_runner=lambda: ps)
+        assert [p.pid for p in stale] == [200]
+
+    def test_default_patterns_cover_known_offenders(self):
+        ps = _ps_output(
+            (100, 1, "02:00:00", "codex --dangerously-bypass-approvals-and-sandbox"),
+            (101, 1, "02:00:00", "codex exec --resume"),
+            (102, 1, "02:00:00", "conductor exec --with codex"),
+            (103, 1, "02:00:00", "conductor swarm --brief a.md"),
+        )
+        stale = scan_stale_processes(threshold_sec=3600, ps_runner=lambda: ps)
+        assert sorted(p.pid for p in stale) == [100, 101, 102, 103]
+
+    def test_extra_patterns_extend_defaults(self):
+        ps = _ps_output(
+            (100, 1, "02:00:00", "my-custom-agent --loop"),
+            (101, 1, "02:00:00", "codex --dangerously-x"),
+        )
+        stale = scan_stale_processes(
+            threshold_sec=3600,
+            patterns=DEFAULT_REAP_PATTERNS + ("my-custom-agent",),
+            ps_runner=lambda: ps,
+        )
+        assert sorted(p.pid for p in stale) == [100, 101]
+
+    def test_results_sorted_by_age_desc(self):
+        ps = _ps_output(
+            (100, 1, "01:30:00", "codex --dangerously-x"),
+            (101, 1, "04:00:00", "codex --dangerously-x"),
+            (102, 1, "02:00:00", "codex --dangerously-x"),
+        )
+        stale = scan_stale_processes(threshold_sec=3600, ps_runner=lambda: ps)
+        assert [p.pid for p in stale] == [101, 102, 100]
+
+    def test_excludes_own_pid(self):
+        import os
+
+        ps = _ps_output(
+            (os.getpid(), 1, "02:00:00", "codex --dangerously-x"),
+            (9999, 1, "02:00:00", "codex --dangerously-x"),
+        )
+        stale = scan_stale_processes(threshold_sec=3600, ps_runner=lambda: ps)
+        assert [p.pid for p in stale] == [9999]
+
+    def test_malformed_ps_lines_are_skipped(self):
+        ps = "PID PPID ELAPSED COMMAND\nbroken line\n100 1 02:00:00 codex --dangerously-x\n"
+        stale = scan_stale_processes(threshold_sec=3600, ps_runner=lambda: ps)
+        assert [p.pid for p in stale] == [100]
+
+
+class _FakeSignals:
+    def __init__(
+        self,
+        *,
+        dies_on_term: set[int] | None = None,
+        dies_on_kill: set[int] | None = None,
+    ):
+        self.dies_on_term = dies_on_term or set()
+        self.dies_on_kill = dies_on_kill or set()
+        self.alive: set[int] = set()
+        self.calls: list[tuple[int, int]] = []
+
+    def register(self, *pids: int) -> None:
+        self.alive.update(pids)
+
+    def send(self, pid: int, sig: int) -> None:
+        self.calls.append((pid, sig))
+        if pid not in self.alive:
+            raise ProcessLookupError(f"no such pid {pid}")
+        if (sig == signal.SIGTERM and pid in self.dies_on_term) or (
+            sig == signal.SIGKILL and pid in self.dies_on_kill
+        ):
+            self.alive.discard(pid)
+
+    def is_alive(self, pid: int) -> bool:
+        return pid in self.alive
+
+
+class TestReapProcesses:
+    def _proc(self, pid: int, etime_seconds: int = 7200) -> StaleProcess:
+        return StaleProcess(
+            pid=pid,
+            ppid=1,
+            etime_seconds=etime_seconds,
+            etime_str="02:00:00",
+            command=f"codex --dangerously-x-{pid}",
+        )
+
+    def test_empty_input_returns_empty(self):
+        killed, errors = reap_processes([])
+        assert killed == []
+        assert errors == []
+
+    def test_dies_on_sigterm(self):
+        sigs = _FakeSignals(dies_on_term={100})
+        sigs.register(100)
+        killed, errors = reap_processes(
+            [self._proc(100)],
+            signal_sender=sigs.send,
+            sleeper=lambda _s: None,
+            alive_check=sigs.is_alive,
+        )
+        assert killed == [100]
+        assert errors == []
+        assert (100, signal.SIGTERM) in sigs.calls
+        assert (100, signal.SIGKILL) not in sigs.calls
+
+    def test_escalates_to_sigkill(self):
+        sigs = _FakeSignals(dies_on_kill={100})
+        sigs.register(100)
+        killed, errors = reap_processes(
+            [self._proc(100)],
+            signal_sender=sigs.send,
+            sleeper=lambda _s: None,
+            alive_check=sigs.is_alive,
+        )
+        assert killed == [100]
+        assert errors == []
+        # SIGTERM tried first, then SIGKILL when it didn't take
+        assert (100, signal.SIGTERM) in sigs.calls
+        assert (100, signal.SIGKILL) in sigs.calls
+
+    def test_zombie_survives_sigkill_reported_as_error(self):
+        sigs = _FakeSignals()  # dies on neither — pretends to be a stuck process
+        sigs.register(100)
+        killed, errors = reap_processes(
+            [self._proc(100)],
+            signal_sender=sigs.send,
+            sleeper=lambda _s: None,
+            alive_check=sigs.is_alive,
+        )
+        assert killed == []
+        assert len(errors) == 1
+        assert errors[0]["pid"] == 100
+        assert "survived" in errors[0]["error"]
+
+    def test_already_dead_process_counts_as_killed(self):
+        sigs = _FakeSignals()  # nothing registered, so SIGTERM raises ProcessLookupError
+        killed, errors = reap_processes(
+            [self._proc(100)],
+            signal_sender=sigs.send,
+            sleeper=lambda _s: None,
+            alive_check=sigs.is_alive,
+        )
+        assert killed == [100]
+        assert errors == []
+
+    def test_mixed_outcomes(self):
+        sigs = _FakeSignals(dies_on_term={100}, dies_on_kill={101})
+        sigs.register(100, 101, 102)
+        killed, errors = reap_processes(
+            [self._proc(100), self._proc(101), self._proc(102)],
+            signal_sender=sigs.send,
+            sleeper=lambda _s: None,
+            alive_check=sigs.is_alive,
+        )
+        assert sorted(killed) == [100, 101]
+        assert len(errors) == 1
+        assert errors[0]["pid"] == 102


### PR DESCRIPTION
## Linked Issues

Closes #499

Real incident on 2026-05-20: 8 forgotten codex agents ran 40+ hours each
in Vesper panes the operator had stopped watching, driving a $215/week
OpenRouter bill. Even after manual cleanup, a 9th orphan was caught by
this command during development. No operator-side audit existed for the
"codex agent burning tokens in a pane I forgot about" failure mode.

`conductor reap` scans ps output for codex/conductor-spawned processes
alive longer than --older-than (default 1h), reports them, and on
--execute sends SIGTERM, waits 5s, then SIGKILL stragglers. Dry-run is
the default so an operator can confirm before killing.

`conductor doctor` now surfaces the same data as a warning section,
mirroring the existing git-state-drift section. Operators running doctor
as their regular health check see forgotten provider sessions before
they compound.

Closes #499.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
