### PR TITLE
fix(init): skip pre-commit hook install when cwd is not a git repo

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -13186,8 +13186,9 @@ def doctor(as_json: bool) -> None:
     "--hooks/--no-hooks",
     default=True,
     help=(
-        "Install pre-commit refresh hook for embed-only files "
-        "(default: yes; pass --no-hooks to skip)."
+        "Install pre-commit refresh hook in the current directory "
+        "(default: yes; pass --no-hooks to skip). "
+        "No-op when the current directory is not a git repository."
     ),
 )
 def init(
@@ -13261,8 +13262,23 @@ def _run_unwire() -> int:
 
 
 def _run_install_hooks(*, quiet: bool = False) -> int:
-    """Install the local pre-commit hook entry for refresh-on-commit."""
-    config_path = Path.cwd() / PRE_COMMIT_CONFIG
+    """Install the local pre-commit hook entry for refresh-on-commit.
+
+    Per issue #493: the hook is meaningful only inside a git repo. When the
+    user runs `conductor init` from `~/`, `~/Downloads`, or any non-repo cwd,
+    silently writing `.pre-commit-config.yaml` there is a surprise — the file
+    is dead weight and pollutes the directory. Skip with a clear notice
+    instead.
+    """
+    cwd = Path.cwd()
+    if not (cwd / ".git").exists():
+        if not quiet:
+            click.echo(
+                f"==> Skipping conductor-refresh pre-commit hook install: "
+                f"{cwd} is not a git repository."
+            )
+        return 0
+    config_path = cwd / PRE_COMMIT_CONFIG
     try:
         changed = _install_refresh_pre_commit_hook(config_path)
     except OSError as e:

--- a/tests/test_refresh_on_commit.py
+++ b/tests/test_refresh_on_commit.py
@@ -307,6 +307,7 @@ def test_update_check_exits_zero_when_current(tmp_path, monkeypatch):
 
 def test_init_hooks_creates_pre_commit_config_by_default(tmp_path):
     repo = tmp_path / "repo"
+    _init_git_repo(repo)
 
     result = CliRunner().invoke(main, ["init", "--yes"])
 
@@ -322,6 +323,7 @@ def test_init_hooks_creates_pre_commit_config_by_default(tmp_path):
 
 def test_init_no_hooks_skips_pre_commit_config(tmp_path):
     repo = tmp_path / "repo"
+    _init_git_repo(repo)
 
     result = CliRunner().invoke(main, ["init", "--yes", "--no-hooks"])
 
@@ -331,6 +333,7 @@ def test_init_no_hooks_skips_pre_commit_config(tmp_path):
 
 def test_init_accept_defaults_no_hooks_skips_prompts_and_hooks(tmp_path):
     repo = tmp_path / "repo"
+    _init_git_repo(repo)
 
     result = CliRunner().invoke(main, ["init", "-y", "--no-hooks"])
 
@@ -339,16 +342,38 @@ def test_init_accept_defaults_no_hooks_skips_prompts_and_hooks(tmp_path):
     assert not (repo / ".pre-commit-config.yaml").exists()
 
 
+def test_init_hooks_skipped_when_cwd_is_not_git_repo(tmp_path):
+    """Regression guard for #493.
+
+    Why: running `conductor init` from `~/`, `~/Downloads`, or any non-repo
+    directory used to silently write `.pre-commit-config.yaml` there. The hook
+    is dead weight outside a git repo. Skip with a clear notice instead.
+    """
+    repo = tmp_path / "repo"
+    # Deliberately do NOT call _init_git_repo — this is the no-git case.
+
+    result = CliRunner().invoke(main, ["init", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert not (repo / ".pre-commit-config.yaml").exists()
+    assert "Skipping conductor-refresh pre-commit hook install" in result.output
+    assert "is not a git repository" in result.output
+
+
 def test_init_help_documents_hooks_default():
     result = CliRunner().invoke(main, ["init", "--help"])
 
     assert result.exit_code == 0, result.output
     assert "--hooks / --no-hooks" in result.output
-    assert "default: yes; pass --no-hooks to skip" in result.output
+    # Click wraps the help text, so check normalized whitespace.
+    normalized = " ".join(result.output.split())
+    assert "default: yes" in normalized
+    assert "is not a git repository" in normalized
 
 
 def test_init_hooks_merges_existing_config_without_duplication(tmp_path):
     repo = tmp_path / "repo"
+    _init_git_repo(repo)
     config = repo / ".pre-commit-config.yaml"
     config.write_text(
         """repos:
@@ -371,6 +396,7 @@ def test_init_hooks_merges_existing_config_without_duplication(tmp_path):
 
 def test_init_hooks_inserts_inside_repos_before_later_top_level_keys(tmp_path):
     repo = tmp_path / "repo"
+    _init_git_repo(repo)
     config = repo / ".pre-commit-config.yaml"
     config.write_text(
         """repos:
@@ -394,6 +420,7 @@ default_language_version:
 
 def test_init_hooks_is_idempotent(tmp_path):
     repo = tmp_path / "repo"
+    _init_git_repo(repo)
 
     first = CliRunner().invoke(main, ["init", "--yes"])
     second = CliRunner().invoke(main, ["init", "--yes"])

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -214,7 +214,11 @@ def test_init_1password_choice_only_appears_when_op_detected(
     )
 
     assert result.exit_code == 0, result.output
-    assert "1password" not in result.output.lower()
+    # Test name leaks into tmp_path, which can appear in our new "skipping hook
+    # install" diagnostic. Check for the wizard's actual 1Password prompt copy
+    # instead of a bare substring.
+    assert "1Password indirection" not in result.output
+    assert "op read op://" not in result.output
 
 
 def test_init_1password_invalid_reference_aborts(mocker, monkeypatch, tmp_path):


### PR DESCRIPTION
## Linked Issues

Closes #493

Per issue #493: running `conductor init` from `~/`, `~/Downloads`, or any
non-repo directory used to silently write `.pre-commit-config.yaml`
there. The hook is meaningful only inside a git repo; outside one the
file is dead weight that pollutes the directory and surprises the
operator.

Gate `_run_install_hooks` on `(cwd / ".git").exists()` and print a clear
skip notice in non-quiet mode. Update the --hooks help text to name the
cwd coupling so the contract is documented at the surface.

Existing init-hook tests now `_init_git_repo()` the temp directory so
they exercise the real (in-repo) path. A new test guards the regression
for the no-git case.

Closes #493.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
