### PR TITLE
fix(router): format 'no provider satisfies' error like doctor's → fix: lines

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -2192,11 +2192,12 @@ def _apply_auto_route_exclusion_rules(
     if len(retained) == len(decision.ranked):
         return decision, inclusion_message
     if not retained:
-        detail = f"{'; '.join(messages)}. " if messages else ""
-        raise NoConfiguredProvider(
-            "no provider satisfies the routing request after planning exclusions. "
-            f"{detail}Skipped: {skipped}"
-        )
+        from conductor.router import format_no_provider_error
+
+        headline = "no provider satisfies the routing request after planning exclusions."
+        if messages:
+            headline += " " + "; ".join(messages)
+        raise NoConfiguredProvider(format_no_provider_error(headline, skipped))
 
     winner = retained[0]
     return (

--- a/src/conductor/router.py
+++ b/src/conductor/router.py
@@ -69,6 +69,55 @@ class InvalidRouterRequest(ProviderError):  # noqa: N818  — public API name, s
     """Raised when the caller passes an invalid combination (e.g. unknown prefer mode)."""
 
 
+def format_no_provider_error(
+    headline: str,
+    skipped: list[tuple[str, str]] | tuple[tuple[str, str], ...],
+    *,
+    context: dict[str, object] | None = None,
+) -> str:
+    """Format a NoConfiguredProvider error as a scannable multi-line block.
+
+    Per issue #495: the old format was one ~700-char line with a Python tuple
+    repr of ``skipped`` embedded. Mirror ``conductor doctor`` / ``conductor
+    list``'s shape — one provider per line, with the provider's ``fix_command``
+    when known.
+    """
+    lines = [headline]
+    if context:
+        ctx_bits = []
+        for key, val in context.items():
+            if val is None or val == "" or val == () or val == []:
+                continue
+            ctx_bits.append(f"{key}={val!r}" if isinstance(val, str) else f"{key}={val}")
+        if ctx_bits:
+            lines.append("  context: " + ", ".join(ctx_bits))
+    if skipped:
+        lines.append("  skipped:")
+        for name, reason in skipped:
+            reason_one_line = " ".join((reason or "").split())
+            lines.append(f"    ✗ {name}")
+            lines.append(f"        └─ {reason_one_line}")
+            fix = _lookup_fix_command(name, reason)
+            if fix:
+                lines.append(f"        → fix: {fix}")
+    return "\n".join(lines)
+
+
+def _lookup_fix_command(provider_name: str, reason: str | None) -> str | None:
+    """Best-effort: pull the provider's class-level fix_command. Never raises."""
+    try:
+        provider = get_provider(provider_name)
+    except Exception:
+        return None
+    fix_for_reason = getattr(provider, "fix_command_for_reason", None)
+    if callable(fix_for_reason):
+        try:
+            return fix_for_reason(reason)
+        except Exception:
+            pass
+    return getattr(provider, "fix_command", None)
+
+
 # --------------------------------------------------------------------------- #
 # Session-local health tracking.
 # --------------------------------------------------------------------------- #
@@ -599,10 +648,16 @@ def pick(
 
     if not ranked:
         raise NoConfiguredProvider(
-            "no provider satisfies the routing request. "
-            f"prefer={prefer!r} tools={sorted(tools_set)} "
-            f"attachments_required={attachments_required} "
-            f"exclude={sorted(exclude_set)}. Skipped: {skipped}"
+            format_no_provider_error(
+                "no provider satisfies the routing request.",
+                skipped,
+                context={
+                    "prefer": prefer,
+                    "tools": sorted(tools_set),
+                    "attachments_required": attachments_required,
+                    "exclude": sorted(exclude_set),
+                },
+            )
         )
 
     tag_default_applied: dict[str, str] = {}

--- a/tests/test_cli_auto.py
+++ b/tests/test_cli_auto.py
@@ -150,6 +150,14 @@ def test_call_auto_with_no_configured_providers_exits_2(mocker):
     )
     assert result.exit_code == 2
     assert "no provider satisfies" in result.output.lower()
+    # Issue #495: error must be multi-line with one entry per skipped provider,
+    # not a Python tuple repr on a single line. Reuse doctor's → fix: style.
+    assert "skipped:" in result.output
+    assert "✗ kimi" in result.output
+    assert "→ fix:" in result.output
+    # No literal Python tuple repr (the bug we're fixing).
+    assert "('kimi'," not in result.output
+    assert "', '" not in result.output  # tuple-of-tuples separator
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -136,7 +136,11 @@ def test_pick_raises_when_no_provider_configured(mocker):
     with pytest.raises(NoConfiguredProvider) as exc:
         pick(["long-context"])
     # Error lists what was skipped so users can see which CLI/env is missing.
-    assert "Skipped" in str(exc.value)
+    # Issue #495: format is now multi-line per-provider with → fix: lines.
+    rendered = str(exc.value)
+    assert "skipped:" in rendered
+    assert "→ fix:" in rendered
+    assert "✗ kimi" in rendered
 
 
 def test_pick_empty_tags_falls_back_to_priority(mocker):


### PR DESCRIPTION
## Linked Issues

Closes #495

Per #495: the old format was one ~700-char line that embedded the
skipped list as a Python tuple repr with escaped \n inside Claude's
auth-status JSON. All the right information was there, but it wasn't
scannable.

Add `router.format_no_provider_error()` that builds a multi-line block
mirroring `conductor doctor` / `conductor list` shape — one provider per
line with the reason, plus the provider's class-level `fix_command` when
known. Both raise sites (router.py for the initial pick, cli.py for
post-planning exclusions) use the shared helper.

Before:

  conductor: no provider satisfies the routing request after planning
  exclusions. [conductor] excluding ollama... Skipped: [('kimi', 'missing
  credential: OPENROUTER_API_KEY...'), ('claude', '`claude auth status`
  exited 1: {\n  "loggedIn": false...

After:

  conductor: no provider satisfies the routing request after planning exclusions.
    skipped:
      ✗ kimi
          └─ missing credential: OPENROUTER_API_KEY. ...
          → fix: conductor init --only openrouter
      ✗ claude
          └─ `claude auth status` exited 1: ...
          → fix: brew install claude && claude auth login
      ...

Closes #495.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
