### PR TITLE
fix(init): -y exits 2 when no remote providers configured (not silent skip)

### DIFF
--- a/src/conductor/wizard.py
+++ b/src/conductor/wizard.py
@@ -425,6 +425,38 @@ def run_init_wizard(
         _print_next_steps(outcomes)
     if aborted or not wiring_ok:
         return 1
+    # Per #494: silent skip in non-interactive mode is a footgun for CI /
+    # Dockerfile users who set CONDUCTOR_* env vars and reasonably expect
+    # init -y to either succeed or fail loud. If zero providers ended up
+    # configured AND we were non-interactive AND the caller didn't scope
+    # to a single provider (--only), that's a hard "no credential sources
+    # available" failure, not a success.
+    if not interactive and not only:
+        # Ollama is local — its readiness doesn't prove the operator has
+        # network providers wired. Require at least one remote provider
+        # to be configured at the end of init -y. Re-check current state
+        # (rather than counting wizard outcomes) so `--remaining` skips
+        # of already-configured providers count toward the threshold.
+        remote_configured = 0
+        for provider_name in known_providers():
+            if provider_name == "ollama":
+                continue
+            provider = get_provider(provider_name)
+            ok, _reason = provider.configured()
+            if ok:
+                remote_configured += 1
+                break
+        if remote_configured == 0:
+            if not quiet:
+                click.echo("")
+                click.echo(
+                    "conductor: init -y completed with no remote providers configured."
+                )
+                click.echo(
+                    "  Set a credential env var (e.g. OPENROUTER_API_KEY) "
+                    "and re-run, or run `conductor init` on a TTY."
+                )
+            return 2
     return 0
 
 

--- a/tests/test_migration_flow.py
+++ b/tests/test_migration_flow.py
@@ -38,6 +38,13 @@ def _set_version(monkeypatch, version: str) -> None:
 
 
 def _stub_all_providers_unconfigured(monkeypatch) -> None:
+    """Stub every non-OpenRouter provider as unconfigured.
+
+    Per #494, `init -y` exits 2 when no remote provider is configured.
+    These end-to-end migration tests exercise the post-install + commit-hook
+    refresh path, not credential setup, so stub OpenRouter as configured
+    (matching the realistic CI scenario where OPENROUTER_API_KEY is in env).
+    """
     from conductor.providers import (
         ClaudeProvider,
         CodexProvider,
@@ -57,9 +64,9 @@ def _stub_all_providers_unconfigured(monkeypatch) -> None:
         GeminiProvider,
         KimiProvider,
         OllamaProvider,
-        OpenRouterProvider,
     ):
         monkeypatch.setattr(cls, "configured", lambda self: (False, "stubbed"))
+    monkeypatch.setattr(OpenRouterProvider, "configured", lambda self: (True, None))
 
 
 def _versions_by_kind(repo: Path) -> dict[str, str | None]:

--- a/tests/test_refresh_on_commit.py
+++ b/tests/test_refresh_on_commit.py
@@ -20,6 +20,15 @@ def _isolated_agent_homes(tmp_path, monkeypatch):
     monkeypatch.setenv("CONDUCTOR_HOME", str(tmp_path / ".conductor"))
     monkeypatch.setenv("CLAUDE_HOME", str(tmp_path / ".claude"))
     monkeypatch.setattr("shutil.which", lambda _cmd: None)
+    # Per #494: init -y exits 2 when no remote providers are configured.
+    # These tests exercise hook-install / refresh behavior, not credential
+    # setup, so keep OpenRouter at configured=True to mirror the realistic
+    # CI scenario (OPENROUTER_API_KEY in env).
+    from conductor.providers import OpenRouterProvider
+
+    monkeypatch.setattr(
+        OpenRouterProvider, "configured", lambda self: (True, None)
+    )
 
 
 def _git(repo: Path, *args: str) -> str:

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -13,7 +13,15 @@ from conductor.providers.openrouter import OPENROUTER_API_KEY_ENV
 def _isolated_agent_homes(tmp_path, monkeypatch):
     """Isolate ~/.claude, ~/.conductor, and cwd for every wizard test —
     otherwise a wizard run could write into the developer's real home
-    dir, and AGENTS.md detection would see the real repo's file."""
+    dir, and AGENTS.md detection would see the real repo's file.
+
+    Per #494: `init -y` now exits 2 when zero remote providers end up
+    configured. Tests that exercise non-credential behavior (agent
+    wiring, summary printing, etc.) get OpenRouter pre-stubbed as
+    configured so they continue to assert exit_code == 0 without
+    needing to mock providers themselves. Tests that care about the
+    no-providers-configured case override this explicitly.
+    """
     repo_dir = tmp_path / "repo"
     repo_dir.mkdir()
     monkeypatch.setenv("CONDUCTOR_HOME", str(tmp_path / ".conductor"))
@@ -25,12 +33,22 @@ def _isolated_agent_homes(tmp_path, monkeypatch):
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     monkeypatch.delenv("CLOUDFLARE_API_TOKEN", raising=False)
     monkeypatch.delenv("CLOUDFLARE_ACCOUNT_ID", raising=False)
+    # Default: one remote provider configured so tests that don't care
+    # about credentials still get exit_code == 0. Tests that need a
+    # "nothing configured" scenario override this in their own setup.
+    from conductor.providers import OpenRouterProvider
+
+    monkeypatch.setattr(
+        OpenRouterProvider, "configured", lambda self: (True, None)
+    )
     # Default: Claude CLI not on PATH. Tests that need it patch explicitly.
     monkeypatch.setattr("shutil.which", lambda _cmd: None)
 
 
 def test_init_non_interactive_mode_reports_state(mocker, monkeypatch):
-    # Non-interactive: everything unconfigured, wizard should report and exit 0.
+    # Non-interactive: everything unconfigured. Per #494 this now exits 2 with
+    # a clear "no remote providers configured" message — silent skip is the
+    # original bug being fixed.
     from conductor.providers import (
         ClaudeProvider,
         CodexProvider,
@@ -52,10 +70,42 @@ def test_init_non_interactive_mode_reports_state(mocker, monkeypatch):
     mocker.patch("conductor.wizard.credentials.get", return_value=None)
 
     result = CliRunner().invoke(main, ["init", "--yes"])
-    assert result.exit_code == 0, result.output
+    assert result.exit_code == 2, result.output
     assert "Summary" in result.output
     for name in ("kimi", "claude", "codex", "gemini", "ollama", "openrouter"):
         assert name in result.output
+    # New diagnostic: tell the operator why init -y is exiting non-zero.
+    assert "no remote providers configured" in result.output
+
+
+def test_init_yes_succeeds_when_remote_provider_already_configured(mocker):
+    """Counterpart to test_init_non_interactive_mode_reports_state.
+
+    Per #494: when at least one remote provider is configured (e.g. via
+    OPENROUTER_API_KEY in env), `init -y` exits 0 — the no-remote-providers
+    exit-2 only fires when nothing is wired.
+    """
+    from conductor.providers import (
+        ClaudeProvider,
+        CodexProvider,
+        GeminiProvider,
+        KimiProvider,
+        OllamaProvider,
+        OpenRouterProvider,
+    )
+
+    # The autouse fixture already stubs OpenRouter as configured. Keep
+    # the rest unconfigured to mirror a realistic CI scenario where only
+    # OPENROUTER_API_KEY is set.
+    for cls in (
+        ClaudeProvider, CodexProvider, GeminiProvider, KimiProvider, OllamaProvider
+    ):
+        mocker.patch.object(cls, "configured", lambda self: (False, "stubbed"))
+    assert OpenRouterProvider().configured()[0] is True  # sanity-check fixture
+
+    result = CliRunner().invoke(main, ["init", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert "no remote providers configured" not in result.output
 
 
 def test_init_skips_already_configured_providers(mocker):
@@ -812,9 +862,19 @@ _ALL_PROVIDER_CLASSES = (
 
 
 def _stub_all_providers_unconfigured(mocker):
+    """Stub every provider as unconfigured EXCEPT OpenRouter.
+
+    Per #494, `init -y` now exits 2 when no remote providers end up
+    configured. These wiring tests assert exit_code == 0 because they
+    exercise agent-integration writes, not the credential-failure path.
+    Leaving OpenRouter at the autouse fixture's configured=True default
+    keeps the init walk succeeding so the wiring assertions are meaningful.
+    """
     import conductor.providers as providers_pkg
 
     for class_name in _ALL_PROVIDER_CLASSES:
+        if class_name == "OpenRouterProvider":
+            continue
         cls = getattr(providers_pkg, class_name)
         mocker.patch.object(cls, "configured", lambda self: (False, "stubbed"))
 


### PR DESCRIPTION
## Linked Issues

Closes #494

Per #494: `conductor init -y` was a status report, not a setup. With no
credential env vars present, it printed "(non-interactive mode —
reporting status without prompting)", silently skipped every remote
provider, and exited 0 — so Dockerfile/CI users couldn't tell that
their `init` step had accomplished nothing.

The contract now matches the issue's spec: if no remote provider is
configured at the end of init -y (ollama doesn't count — it's local),
print a clear "no remote providers configured" diagnostic and exit 2.
When at least one remote provider IS configured (e.g. via
OPENROUTER_API_KEY in env), exit 0 silently as before.

Existing wizard/migration/refresh tests that ran `init --yes` with all
providers stubbed False now stub OpenRouter as configured so they
continue to assert exit_code == 0 for non-credential behavior (agent
wiring, hook installation, etc.). The original "everything unconfigured"
scenario is asserted by a new test against the exit-2 path.

Closes #494.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
