### PR TITLE
fix(code-cascade): insert claude CLI, fall to cheap OpenRouter, not premium

### DIFF
--- a/src/conductor/openrouter_model_stacks.py
+++ b/src/conductor/openrouter_model_stacks.py
@@ -55,6 +55,18 @@ OPENROUTER_REVIEW_CHEAP: tuple[str, ...] = (
     "qwen/qwen3-coder-plus",
 )
 
+# Coding-tool-use fallback stack. Used when both flat-rate subscriptions
+# (codex CLI, claude CLI) are unavailable and the cascade has to spend
+# metered budget. Ordering bias differs from review: put the
+# coding-specialized model first, then the strong-reasoning model, then
+# the long-context backstop for huge diffs. See issue #448 for the
+# cost-shape argument; PR landed alongside the review-cascade fix in #502.
+OPENROUTER_CODING_CHEAP: tuple[str, ...] = (
+    "qwen/qwen3-coder-plus",
+    "deepseek/deepseek-v4-pro",
+    "moonshotai/kimi-k2.6",
+)
+
 
 def model_family(model: str) -> str:
     """Return the lowercased provider family prefix for a model slug."""

--- a/src/conductor/semantic.py
+++ b/src/conductor/semantic.py
@@ -12,8 +12,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 from conductor.openrouter_model_stacks import (
-    OPENROUTER_CODING_HIGH,
-    OPENROUTER_CODING_MAX,
+    OPENROUTER_CODING_CHEAP,
     OPENROUTER_REVIEW_CHEAP,
 )
 
@@ -176,7 +175,8 @@ _CODE: dict[EffortBucket, SemanticPlan] = {
         tools=_CODE_EXEC_TOOLS,
         candidates=(
             SemanticCandidate("codex"),
-            SemanticCandidate("openrouter", OPENROUTER_CODING_HIGH),
+            SemanticCandidate("claude"),
+            SemanticCandidate("openrouter", OPENROUTER_CODING_CHEAP),
             SemanticCandidate("ollama"),
         ),
     ),
@@ -189,7 +189,8 @@ _CODE: dict[EffortBucket, SemanticPlan] = {
         tools=_CODE_EXEC_TOOLS,
         candidates=(
             SemanticCandidate("codex"),
-            SemanticCandidate("openrouter", OPENROUTER_CODING_MAX),
+            SemanticCandidate("claude"),
+            SemanticCandidate("openrouter", OPENROUTER_CODING_CHEAP),
             SemanticCandidate("ollama"),
         ),
     ),

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -35,7 +35,7 @@ from conductor.cli import (
 )
 from conductor.network_profile import NetworkProfile
 from conductor.openrouter_model_stacks import (
-    OPENROUTER_CODING_HIGH,
+    OPENROUTER_CODING_CHEAP,
     OPENROUTER_REVIEW_CHEAP,
 )
 from conductor.providers import (
@@ -723,6 +723,9 @@ def test_ask_code_high_read_only_brief_restricts_exec_tools(mocker):
 def test_ask_code_high_read_only_fallback_stays_read_only(mocker):
     from conductor.providers.interface import ProviderStalledError
 
+    # Claude not in stub set → its configured() returns False, so the
+    # cascade walks past it to openrouter. Mirrors a real CI environment
+    # where only OPENROUTER_API_KEY is set.
     _stub_all_configured(mocker, {"codex", "openrouter"})
     codex_exec = mocker.patch.object(
         CodexProvider,
@@ -759,7 +762,7 @@ def test_ask_code_high_read_only_fallback_stays_read_only(mocker):
         {"Read", "Grep", "Glob"}
     )
     assert openrouter_exec.call_args.kwargs["sandbox"] == "read-only"
-    assert openrouter_exec.call_args.kwargs["models"] == OPENROUTER_CODING_HIGH
+    assert openrouter_exec.call_args.kwargs["models"] == OPENROUTER_CODING_CHEAP
     assert "read-only brief detected; restricting exec tools to Read,Grep,Glob" in result.stderr
 
 
@@ -795,7 +798,7 @@ def test_ask_code_high_falls_back_immediately_to_openrouter_on_quota(mocker):
     assert result.exit_code == 0, result.output
     assert codex_exec.called
     assert openrouter_exec.called
-    assert openrouter_exec.call_args.kwargs["models"] == OPENROUTER_CODING_HIGH
+    assert openrouter_exec.call_args.kwargs["models"] == OPENROUTER_CODING_CHEAP
     assert openrouter_exec.call_args.kwargs["previous_provider"] == "codex"
     assert "codex failed (rate-limit)" in result.stderr
     assert "falling back" in result.stderr
@@ -840,15 +843,26 @@ def test_ask_code_high_falls_back_to_openrouter_exec_before_ollama(mocker):
     assert exec_mock.call_args.kwargs["tools"] == frozenset(
         {"Read", "Grep", "Glob", "Edit", "Write", "Bash"}
     )
-    assert exec_mock.call_args.kwargs["models"] == OPENROUTER_CODING_HIGH
+    assert exec_mock.call_args.kwargs["models"] == OPENROUTER_CODING_CHEAP
     assert "excluding ollama from fallback chain" in result.stderr
     assert "falling through to ollama" not in result.stderr
     payload = json.loads(result.stdout)
+    # Plan now includes claude between codex and openrouter (per #448 — both
+    # flat-rate subscriptions are exhausted before any metered call). The
+    # semantic candidates field shows the routing intent, not the configured
+    # subset, so claude appears even though it's unconfigured here.
     assert [candidate["provider"] for candidate in payload["semantic"]["candidates"]] == [
         "codex",
+        "claude",
         "openrouter",
     ]
-    assert payload["semantic"]["candidates"][1]["models"] == list(OPENROUTER_CODING_HIGH)
+    openrouter_idx = next(
+        i for i, c in enumerate(payload["semantic"]["candidates"])
+        if c["provider"] == "openrouter"
+    )
+    assert payload["semantic"]["candidates"][openrouter_idx]["models"] == list(
+        OPENROUTER_CODING_CHEAP
+    )
 
 
 def test_ask_code_high_without_frontier_fallback_refuses_ollama(mocker):
@@ -4966,6 +4980,7 @@ def test_exclusion_rule_registry_applies_all_current_rules_without_conflict(mock
     assert online_message == OLLAMA_ONLINE_EXCLUSION_MESSAGE
     assert [candidate.provider for candidate in online_plan.candidates] == [
         "codex",
+        "claude",
         "openrouter",
     ]
 
@@ -4981,6 +4996,7 @@ def test_exclusion_rule_registry_applies_all_current_rules_without_conflict(mock
     assert tagged_message == OLLAMA_ONLINE_EXCLUSION_MESSAGE
     assert [candidate.provider for candidate in tagged_plan.candidates] == [
         "codex",
+        "claude",
         "openrouter",
     ]
 

--- a/tests/test_semantic.py
+++ b/tests/test_semantic.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from conductor.openrouter_model_stacks import (
+    OPENROUTER_CODING_CHEAP,
     OPENROUTER_CODING_HIGH,
     OPENROUTER_CODING_MAX,
     OPENROUTER_REVIEW_CHEAP,
@@ -46,21 +47,45 @@ def test_high_code_escalates_to_agentic_coding_stack(effort):
     plan = plan_for("code", effort)
 
     assert plan.mode == "exec"
+    # Per #448: claude CLI sits between codex and the metered openrouter step
+    # so both flat-rate subscriptions are exhausted before any per-token spend.
     assert [candidate.provider for candidate in plan.candidates] == [
         "codex",
+        "claude",
         "openrouter",
         "ollama",
     ]
-    openrouter_candidate = plan.candidates[1]
-    expected_stack = (
-        OPENROUTER_CODING_MAX if effort == "max" else OPENROUTER_CODING_HIGH
-    )
-    assert openrouter_candidate.models == expected_stack
-    assert openrouter_candidate.models[0] == "openai/gpt-5.3-codex"
-    assert "openrouter/auto" not in openrouter_candidate.models
-    assert "google/gemini-2.5-flash-lite" not in openrouter_candidate.models
+    openrouter_candidate = plan.candidates[2]
+    assert openrouter_candidate.models == OPENROUTER_CODING_CHEAP
     assert plan.tools == frozenset({"Read", "Grep", "Glob", "Edit", "Write", "Bash"})
     assert plan.sandbox == "none"
+
+
+@pytest.mark.parametrize("effort", ["high", "max"])
+def test_code_openrouter_step_never_starts_with_premium_model(effort):
+    """Regression guard for #448 (parallel to the review-cascade guard).
+
+    Why: the openrouter step used to start with `openai/gpt-5.3-codex` and
+    drove ~$30/day at observed volume. The cascade must fall to a cheap
+    coding-tuned model first, not the most expensive same-category one.
+    Premium models stay available via the legacy CODING_HIGH / CODING_MAX
+    stacks for callers that explicitly opt in.
+    """
+    plan = plan_for("code", effort)
+    openrouter_models = plan.candidates[2].models
+
+    assert openrouter_models[0] != "openai/gpt-5.3-codex"
+    assert "openai/gpt-5.3-codex" not in openrouter_models
+    assert "openai/gpt-5.5-pro" not in openrouter_models
+    assert "anthropic/claude-opus-4.7" not in openrouter_models
+
+
+def test_legacy_premium_coding_stacks_still_available_for_opt_in():
+    """OPENROUTER_CODING_HIGH/MAX stay defined so callers that explicitly
+    want premium-first can import them. The cascade default no longer uses
+    them, but they're not dead code — they're an opt-in escape hatch."""
+    assert OPENROUTER_CODING_HIGH[0] == "openai/gpt-5.3-codex"
+    assert OPENROUTER_CODING_MAX[0] == "openai/gpt-5.3-codex"
 
 
 @pytest.mark.parametrize("effort", ["minimal", "low", "medium", "high", "max"])


### PR DESCRIPTION
## Linked Issues

Closes #448

Per issue #448 and the policy locked in #501: when the codex CLI flat-rate
subscription fails on a `--effort high` or `--effort max` code/exec task,
the cascade used to jump straight to `OPENROUTER_CODING_HIGH` starting
with `openai/gpt-5.3-codex` — the most expensive option that does the
same job. Author's investigation showed 1305 calls / $31.21 over 36h
landing on gpt-5.3-codex, with the cheaper models in the stack never
reached.

Two changes:

1. **Insert claude CLI between codex and openrouter.** Both flat-rate
   subscriptions get tried before any metered call. Mirrors the review
   cascade shape shipped in PR #502.

2. **Use OPENROUTER_CODING_CHEAP for the fallback step.** New constant:
   `(qwen/qwen3-coder-plus, deepseek/deepseek-v4-pro, moonshotai/kimi-k2.6)`.
   Coding-specialized first, then strong-reasoning, then long-context
   backstop. The legacy `OPENROUTER_CODING_HIGH` / `_MAX` stacks stay
   defined so callers that explicitly want premium-first can still import
   them — they're an opt-in escape hatch, not the default.

Cascade is now:
  codex CLI → claude CLI → cheap OpenRouter → ollama (offline) → fail

Adds a regression-guard test asserting the openrouter step in the code
cascade never starts with a premium model — same guard shape as #502
introduced for review.

Closes #448.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
