### PR TITLE
fix(tools): scrub secret env vars from BashTool; correct sandbox docstring

### DIFF
--- a/src/conductor/tools/registry.py
+++ b/src/conductor/tools/registry.py
@@ -29,6 +29,59 @@ _BASH_DEFAULT_TIMEOUT_SEC = 60
 _BASH_MAX_TIMEOUT_SEC = 600
 _BASH_MAX_OUTPUT_BYTES = 256_000
 
+# Per #496: BashTool runs with `shell=True` and inherits the parent
+# environment. Any provider API key or credential the operator exported
+# for conductor itself was previously visible to every shell command the
+# model ran. Scrub names matching these patterns before invoking
+# subprocess. Set CONDUCTOR_BASH_ALLOW_ENV to a comma-separated list of
+# names to opt specific vars back in (e.g. NPM_TOKEN for private deps).
+_BASH_ENV_SCRUB_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"API_KEY$", re.IGNORECASE),
+    re.compile(r"_TOKEN$", re.IGNORECASE),
+    re.compile(r"SECRET", re.IGNORECASE),
+    re.compile(r"PASSWORD", re.IGNORECASE),
+    re.compile(r"_CREDENTIALS?$", re.IGNORECASE),
+)
+_BASH_ENV_SCRUB_EXPLICIT: frozenset[str] = frozenset(
+    {
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "OPENROUTER_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "CLOUDFLARE_API_TOKEN",
+        "HUGGINGFACE_API_TOKEN",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+    }
+)
+
+
+def _build_bash_subprocess_env() -> dict[str, str]:
+    """Return a copy of ``os.environ`` with secret-looking vars stripped.
+
+    Per #496. The operator can opt specific vars back in via
+    ``CONDUCTOR_BASH_ALLOW_ENV=NAME1,NAME2,...``. Never returns the
+    actual values to the caller — this is a sealed copy.
+    """
+    allow_raw = os.environ.get("CONDUCTOR_BASH_ALLOW_ENV", "")
+    allow: set[str] = {
+        name.strip() for name in allow_raw.split(",") if name.strip()
+    }
+    env: dict[str, str] = {}
+    for name, value in os.environ.items():
+        if name in allow:
+            env[name] = value
+            continue
+        if name in _BASH_ENV_SCRUB_EXPLICIT:
+            continue
+        if any(pat.search(name) for pat in _BASH_ENV_SCRUB_PATTERNS):
+            continue
+        env[name] = value
+    return env
+
 # --------------------------------------------------------------------------- #
 # Public error types
 # --------------------------------------------------------------------------- #
@@ -505,10 +558,14 @@ WriteTool.parameters_schema = {
 class BashTool:
     name = "Bash"
     description = (
-        "Run a shell command inside the workspace. The command's working "
-        "directory is pinned to the workspace root; you cannot cd outside "
-        "it. Output is captured up to 256KB. Per-command timeout is 60 "
-        "seconds by default (configurable up to 600)."
+        "Run a shell command. The command starts in the workspace root, "
+        "but this tool does not OS-sandbox the shell — `cd`, absolute "
+        "paths, and other filesystem operations work as they would in a "
+        "normal terminal. Output is captured up to 256KB. Per-command "
+        "timeout is 60 seconds by default (configurable up to 600). "
+        "Provider API keys and other secret-looking environment variables "
+        "are scrubbed from the subprocess; opt specific vars back in via "
+        "CONDUCTOR_BASH_ALLOW_ENV=NAME1,NAME2."
     )
     parameters_schema: dict  # assigned below
 
@@ -529,6 +586,7 @@ class BashTool:
                 capture_output=True,
                 text=True,
                 timeout=timeout,
+                env=_build_bash_subprocess_env(),
             )
         except subprocess.TimeoutExpired as e:
             # text=True on the run() call ensures e.stdout/e.stderr are str,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -671,6 +671,75 @@ def test_bash_tool_truncates_huge_output(tmp_path: Path):
     assert "truncated" in out
 
 
+# --------------------------------------------------------------------------- #
+# BashTool — env-var scrubbing (issue #496)
+# --------------------------------------------------------------------------- #
+
+
+def test_bash_tool_scrubs_secret_looking_env_vars(tmp_path: Path, monkeypatch):
+    """Regression guard for #496.
+
+    Why: BashTool runs `shell=True` and used to inherit the parent process
+    environment unchanged. That meant any provider API key the operator
+    exported for conductor itself was readable by every shell command the
+    model ran. The fix: scrub secret-looking names from the subprocess env
+    before invocation. This test pins the contract.
+    """
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-secret-leak")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-secret-leak")
+    monkeypatch.setenv("MY_CUSTOM_TOKEN", "another-secret")
+    monkeypatch.setenv("DATABASE_PASSWORD", "hunter2")
+    monkeypatch.setenv("APP_SECRET_KEY", "shh")
+    # And one that should survive scrubbing — looks normal:
+    monkeypatch.setenv("EDITOR", "vim")
+
+    tool = get_tool("Bash")
+    out = tool.execute(
+        {"command": "env | sort"}, cwd=tmp_path
+    )
+
+    # Secret-shaped vars must not appear in the subprocess env at all.
+    assert "OPENROUTER_API_KEY" not in out
+    assert "ANTHROPIC_API_KEY" not in out
+    assert "MY_CUSTOM_TOKEN" not in out
+    assert "DATABASE_PASSWORD" not in out
+    assert "APP_SECRET_KEY" not in out
+    # Their values must not appear either (cheap belt-and-suspenders check).
+    assert "sk-or-v1-secret-leak" not in out
+    assert "sk-ant-secret-leak" not in out
+    assert "hunter2" not in out
+    # Normal env vars survive.
+    assert "EDITOR=vim" in out
+
+
+def test_bash_tool_allow_env_opts_specific_vars_back_in(tmp_path: Path, monkeypatch):
+    """The CONDUCTOR_BASH_ALLOW_ENV escape hatch lets the operator opt
+    specific scrubbed-pattern names back in (e.g. NPM_TOKEN for private
+    package installs). Comma-separated."""
+    monkeypatch.setenv("NPM_TOKEN", "npm-secret-build-token")
+    monkeypatch.setenv("LEAKED_TOKEN", "should-stay-blocked")
+    monkeypatch.setenv("CONDUCTOR_BASH_ALLOW_ENV", "NPM_TOKEN")
+
+    tool = get_tool("Bash")
+    out = tool.execute({"command": "env"}, cwd=tmp_path)
+
+    assert "NPM_TOKEN=npm-secret-build-token" in out
+    assert "LEAKED_TOKEN" not in out
+
+
+def test_bash_tool_description_does_not_claim_workspace_confinement(tmp_path: Path):
+    """Per #496 the tool description used to claim 'you cannot cd outside
+    it', which is false — shell=True with no OS sandbox can `cd /` or use
+    absolute paths freely. The description must be honest about what's
+    actually enforced (start cwd is pinned; the shell itself is not
+    confined) so callers don't build security assumptions on top of a
+    misleading claim."""
+    tool = get_tool("Bash")
+    assert "cannot cd outside" not in tool.description
+    assert "does not OS-sandbox" in tool.description
+    assert "scrubbed" in tool.description.lower()
+
+
 def test_executor_still_blocks_path_escape(tmp_path: Path):
     executor = ToolExecutor(cwd=tmp_path)
     with pytest.raises(ToolExecutionError) as exc:


### PR DESCRIPTION
## Linked Issues

Closes #496

Per #496 security review:

1. BashTool ran subprocess.run(shell=True) inheriting the full parent
   environment. Any provider API key the operator exported for conductor
   itself (OPENROUTER_API_KEY, ANTHROPIC_API_KEY, etc.) was readable by
   every shell command the model ran, including via the model writing
   `echo $OPENROUTER_API_KEY` to a file in the workspace. This is an
   exfiltration path that mattered as soon as any automation surface fed
   conductor untrusted text.

2. The tool description claimed "you cannot cd outside [the workspace
   root]" — false. shell=True without an OS-level sandbox can `cd /` or
   use absolute paths freely. A future caller reading the description
   might build security assumptions on a claim the tool doesn't enforce.

Fix:

- New `_build_bash_subprocess_env()` builds the subprocess env from a
  copy of os.environ with secret-shaped names stripped. Patterns:
  `*API_KEY`, `*_TOKEN`, `*SECRET*`, `*PASSWORD*`, `*_CREDENTIALS`. Plus
  an explicit denylist of known provider names. `CONDUCTOR_BASH_ALLOW_ENV`
  is a comma-separated escape hatch for legitimate use cases (e.g.
  NPM_TOKEN for private deps).
- The description now states honestly that the command starts in the
  workspace root but the shell itself is not OS-sandboxed, and that
  secret-looking env vars are scrubbed (with the opt-in mechanism named).

Three regression tests pin the contract: secret-shaped vars never appear
in subprocess env, the allow-env opt-in works, and the description
doesn't claim confinement it doesn't enforce.

Closes #496.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
