### PR TITLE
fix(open-pr): verify_pr_merged uses state field; tolerate brief mergedAt lag

### DIFF
--- a/scripts/open-pr.sh
+++ b/scripts/open-pr.sh
@@ -96,11 +96,16 @@ print_orphan_warning() {
   # Re-check merge state on exit — if the PR actually merged in flight (e.g.
   # we ran past the merge step but tripped on a follow-up like the local pull)
   # then this isn't an orphan. The exit code stays nonzero; we just suppress
-  # the misleading orphan banner.
-  if [ -n "$ORPHAN_PR_NUMBER" ] \
-    && command -v gh >/dev/null 2>&1 \
-    && [ -n "$(gh pr view "$ORPHAN_PR_NUMBER" --json mergedAt --jq '.mergedAt // empty' 2>/dev/null || true)" ]; then
-    return 0
+  # the misleading orphan banner. Per #489: use `state=MERGED` as the
+  # authoritative signal alongside `mergedAt`, since `mergedAt` can briefly
+  # come back empty during the seconds right after `gh pr merge` returns.
+  if [ -n "$ORPHAN_PR_NUMBER" ] && command -v gh >/dev/null 2>&1; then
+    local exit_state exit_payload
+    exit_payload="$(gh pr view "$ORPHAN_PR_NUMBER" --json state,mergedAt 2>/dev/null || echo '{}')"
+    exit_state="$(printf '%s' "$exit_payload" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("state",""))' 2>/dev/null || echo "")"
+    if [ "$exit_state" = "MERGED" ]; then
+      return 0
+    fi
   fi
   touchstone_emit_event failed phase=open-pr reason=orphan-risk pr_number="$ORPHAN_PR_NUMBER"
   {
@@ -114,17 +119,35 @@ print_orphan_warning() {
   } >&2
 }
 
-# Verify the PR actually merged. Returns 0 if mergedAt is non-empty, 1 otherwise.
-# Used as the post-merge sanity check that turns the script's exit contract from
-# "merge-pr.sh exited 0" (proxy) into "GitHub says it's merged" (truth).
+# Verify the PR actually merged. Returns 0 if the PR is MERGED on GitHub,
+# 1 otherwise. Used as the post-merge sanity check that turns the script's
+# exit contract from "merge-pr.sh exited 0" (proxy) into "GitHub says it's
+# merged" (truth).
+#
+# Per #489: the previous implementation read only `mergedAt` from a single
+# `gh pr view`, which produced false-alarm ORPHAN RISK banners on PRs that
+# were actually merged. Root cause was a brief API lag right after the
+# merge call — `mergedAt` came back empty for a window even though the PR
+# state was already MERGED. Now: prefer the `state` field as authoritative
+# (it's the strongest signal), fall back to `mergedAt`, and retry once with
+# a short backoff on transient empties before declaring failure.
 verify_pr_merged() {
   local pr_number="$1"
-  local merged_at
-  merged_at="$(gh pr view "$pr_number" --json mergedAt --jq '.mergedAt // empty' 2>/dev/null || echo "")"
-  if [ -n "$merged_at" ]; then
-    echo "==> Verified: PR #$pr_number merged at $merged_at"
-    return 0
-  fi
+  local attempt payload state merged_at
+  for attempt in 1 2; do
+    payload="$(gh pr view "$pr_number" --json state,mergedAt 2>/dev/null || echo '{}')"
+    state="$(printf '%s' "$payload" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("state",""))' 2>/dev/null || echo "")"
+    merged_at="$(printf '%s' "$payload" | python3 -c 'import json,sys; v=json.load(sys.stdin).get("mergedAt"); print(v or "")' 2>/dev/null || echo "")"
+    if [ "$state" = "MERGED" ]; then
+      if [ -n "$merged_at" ]; then
+        echo "==> Verified: PR #$pr_number merged at $merged_at"
+      else
+        echo "==> Verified: PR #$pr_number state=MERGED (mergedAt not yet populated by API)"
+      fi
+      return 0
+    fi
+    [ "$attempt" -eq 1 ] && sleep "${VERIFY_PR_MERGED_BACKOFF_SEC:-2}"
+  done
   return 1
 }
 

--- a/tests/test-open-pr-verify-merged.sh
+++ b/tests/test-open-pr-verify-merged.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Regression tests for verify_pr_merged in scripts/open-pr.sh (issue #489).
+#
+# The previous implementation read only `mergedAt` from a single `gh pr view`
+# call, which produced false-alarm ORPHAN RISK banners on PRs that were
+# actually merged — the API briefly returned empty `mergedAt` right after
+# `gh pr merge` returned. The fix prefers `state == MERGED` as authoritative
+# and retries once on transient empties.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OPEN_PR_SCRIPT="$REPO_ROOT/scripts/open-pr.sh"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/open-pr-verify.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+FUNCTIONS_FILE="$TMP_ROOT/functions.sh"
+
+# Extract the verify_pr_merged function only (the rest of open-pr.sh has
+# side effects on source). Strip the comment block above it so awk's brace
+# matching doesn't confuse helper code.
+awk '/^verify_pr_merged\(\)/,/^}$/' "$OPEN_PR_SCRIPT" >"$FUNCTIONS_FILE"
+if ! grep -q "^verify_pr_merged()" "$FUNCTIONS_FILE"; then
+  printf 'FAIL: could not extract verify_pr_merged from %s\n' "$OPEN_PR_SCRIPT" >&2
+  exit 1
+fi
+
+# Inject a fake `gh` whose behavior is driven by FAKE_GH_PAYLOAD env vars.
+# Each call consumes the next payload and increments the call counter so we
+# can assert the retry-after-empty path. Use a counter file because env
+# mutations don't propagate out of the gh function back to the test runner.
+COUNTER_FILE="$TMP_ROOT/calls"
+PAYLOAD_DIR="$TMP_ROOT/payloads"
+mkdir -p "$PAYLOAD_DIR"
+
+cat >>"$FUNCTIONS_FILE" <<'STUB'
+gh() {
+  if [ "$1" != "pr" ] || [ "$2" != "view" ]; then
+    printf 'unexpected gh call: %s\n' "$*" >&2
+    return 1
+  fi
+  local n
+  n="$(cat "$COUNTER_FILE" 2>/dev/null || echo 0)"
+  n=$((n + 1))
+  printf '%s\n' "$n" >"$COUNTER_FILE"
+  if [ -f "$PAYLOAD_DIR/$n" ]; then
+    cat "$PAYLOAD_DIR/$n"
+    return 0
+  fi
+  return 1
+}
+STUB
+
+# shellcheck source=/dev/null
+source "$FUNCTIONS_FILE"
+
+# Make the retry backoff effectively zero so the test runs fast.
+export VERIFY_PR_MERGED_BACKOFF_SEC=0
+export COUNTER_FILE PAYLOAD_DIR
+
+assert_call_count() {
+  local expected="$1" actual
+  actual="$(cat "$COUNTER_FILE" 2>/dev/null || echo 0)"
+  if [ "$actual" != "$expected" ]; then
+    printf 'FAIL: expected %s gh calls, got %s\n' "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+reset_fake() {
+  printf '0\n' >"$COUNTER_FILE"
+  rm -f "$PAYLOAD_DIR"/*
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: clean happy path — first call returns MERGED + mergedAt.
+# ---------------------------------------------------------------------------
+reset_fake
+printf '{"state":"MERGED","mergedAt":"2026-05-20T12:00:00Z"}\n' >"$PAYLOAD_DIR/1"
+if ! out="$(verify_pr_merged 100 2>&1)"; then
+  printf 'FAIL test 1: verify_pr_merged returned non-zero on clear MERGED state\n' >&2
+  exit 1
+fi
+echo "$out" | grep -q "Verified: PR #100 merged at 2026-05-20T12:00:00Z" \
+  || {
+    printf 'FAIL test 1: expected Verified line, got: %s\n' "$out" >&2
+    exit 1
+  }
+assert_call_count 1
+printf 'PASS test 1: clean MERGED + mergedAt\n'
+
+# ---------------------------------------------------------------------------
+# Test 2: the #489 bug case — MERGED but mergedAt briefly empty. Should
+# still return 0 because state is authoritative.
+# ---------------------------------------------------------------------------
+reset_fake
+printf '{"state":"MERGED","mergedAt":""}\n' >"$PAYLOAD_DIR/1"
+if ! out="$(verify_pr_merged 200 2>&1)"; then
+  printf 'FAIL test 2: returned non-zero when state=MERGED but mergedAt empty (the regression)\n' >&2
+  exit 1
+fi
+echo "$out" | grep -q "state=MERGED" \
+  || {
+    printf 'FAIL test 2: expected state=MERGED diagnostic, got: %s\n' "$out" >&2
+    exit 1
+  }
+assert_call_count 1
+printf 'PASS test 2: MERGED state with empty mergedAt (the #489 fix)\n'
+
+# ---------------------------------------------------------------------------
+# Test 3: transient empty on first call, MERGED on retry. Should succeed.
+# ---------------------------------------------------------------------------
+reset_fake
+printf '{"state":"OPEN","mergedAt":""}\n' >"$PAYLOAD_DIR/1"
+printf '{"state":"MERGED","mergedAt":"2026-05-20T12:00:01Z"}\n' >"$PAYLOAD_DIR/2"
+if ! verify_pr_merged 300 >/dev/null 2>&1; then
+  printf 'FAIL test 3: retry path did not succeed\n' >&2
+  exit 1
+fi
+assert_call_count 2
+printf 'PASS test 3: retry succeeds when first attempt sees stale OPEN\n'
+
+# ---------------------------------------------------------------------------
+# Test 4: genuinely open PR — both attempts return OPEN. Must return 1.
+# ---------------------------------------------------------------------------
+reset_fake
+printf '{"state":"OPEN","mergedAt":""}\n' >"$PAYLOAD_DIR/1"
+printf '{"state":"OPEN","mergedAt":""}\n' >"$PAYLOAD_DIR/2"
+if verify_pr_merged 400 >/dev/null 2>&1; then
+  printf 'FAIL test 4: verify_pr_merged returned 0 on truly open PR\n' >&2
+  exit 1
+fi
+assert_call_count 2
+printf 'PASS test 4: open PR correctly reports not merged\n'
+
+# ---------------------------------------------------------------------------
+# Test 5: gh fails entirely (network/auth). Must return 1, must not crash.
+# ---------------------------------------------------------------------------
+reset_fake
+# No payloads written -> fake gh returns non-zero with empty output.
+if verify_pr_merged 500 >/dev/null 2>&1; then
+  printf 'FAIL test 5: verify_pr_merged returned 0 when gh failed entirely\n' >&2
+  exit 1
+fi
+assert_call_count 2
+printf 'PASS test 5: gh failure reports not merged (does not crash)\n'
+
+printf '\nALL verify_pr_merged regression tests passed.\n'

--- a/tests/test_cli_phase5.py
+++ b/tests/test_cli_phase5.py
@@ -46,6 +46,30 @@ def _isolated_agent_homes(tmp_path, monkeypatch):
     monkeypatch.setattr("shutil.which", lambda _cmd: None)
 
 
+def _stub_openrouter_configured_for_init(mocker, monkeypatch):
+    """Per #494: `init -y` exits 2 when no remote providers are configured.
+
+    Tests that chain `init -y --remaining` as a setup step (consumer refresh,
+    update-all, etc.) need at least one remote provider configured for that
+    step to exit 0. Mirrors the realistic CI scenario where OPENROUTER_API_KEY
+    is in env. Tests that exercise the no-remote-providers path don't call
+    this helper.
+
+    update-all spawns init as a subprocess (`python -m conductor.cli init -y
+    --remaining`), so a mocker-only patch wouldn't apply across the process
+    boundary. Set ``OPENROUTER_API_KEY`` in the parent env (via monkeypatch
+    so the value reverts at test teardown without leaking) so the subprocess
+    inherits it and ``OpenRouterProvider.configured()`` returns True there.
+    The in-process mocker stub is kept for the parent-process check.
+    """
+    from conductor.providers import OpenRouterProvider
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key-not-used-for-network")
+    mocker.patch.object(
+        OpenRouterProvider, "configured", lambda self: (True, None)
+    )
+
+
 def _stub_all_unconfigured(mocker):
     from conductor.providers import (
         ClaudeProvider,
@@ -1132,8 +1156,9 @@ def test_refresh_consumers_alias_warns_and_still_works():
     assert "No consumer repos configured." in result.output
 
 
-def test_update_all_commits_updated_repo_integration(mocker, tmp_path):
+def test_update_all_commits_updated_repo_integration(mocker, tmp_path, monkeypatch):
     _stub_all_unconfigured(mocker)
+    _stub_openrouter_configured_for_init(mocker, monkeypatch)
     version = cli_mod.__version__.split("+", 1)[0]
 
     consumer = tmp_path / "consumer"
@@ -1171,7 +1196,8 @@ def test_update_all_commits_updated_repo_integration(mocker, tmp_path):
     ).stdout
 
 
-def test_refresh_consumers_default_branch_uses_typed_prefix(mocker, tmp_path):
+def test_refresh_consumers_default_branch_uses_typed_prefix(mocker, tmp_path, monkeypatch):
+    _stub_openrouter_configured_for_init(mocker, monkeypatch)
     """Default branch name should have the `chore/` type prefix so that
     consumer repos with the standard `<type>/<slug>` branch-naming pre-push
     hook accept the push (closes conductor#273)."""
@@ -1201,7 +1227,8 @@ def test_refresh_consumers_default_branch_uses_typed_prefix(mocker, tmp_path):
     assert _git(consumer, "branch", "--show-current").stdout.strip() == expected_branch
 
 
-def test_refresh_consumers_auto_stashes_dirty_repo(mocker, tmp_path):
+def test_refresh_consumers_auto_stashes_dirty_repo(mocker, tmp_path, monkeypatch):
+    _stub_openrouter_configured_for_init(mocker, monkeypatch)
     """Dirty repo with operator changes outside the conductor sentinel block
     should be auto-stashed, refreshed on the refresh branch, and popped back
     on the original branch (closes #289 piece 3)."""
@@ -1278,8 +1305,9 @@ def test_refresh_consumers_no_auto_stash_skips_dirty_repo(mocker, tmp_path):
     assert (consumer / "operator-file.txt").read_text(encoding="utf-8") == "dirty\n"
 
 
-def test_refresh_consumers_reads_config_file(mocker, tmp_path):
+def test_refresh_consumers_reads_config_file(mocker, tmp_path, monkeypatch):
     _stub_all_unconfigured(mocker)
+    _stub_openrouter_configured_for_init(mocker, monkeypatch)
     consumer = tmp_path / "consumer-from-config"
     consumer.mkdir()
     _git(consumer, "init", "-q", "-b", "main")

--- a/tests/test_open_pr_verify_merged.py
+++ b/tests/test_open_pr_verify_merged.py
@@ -1,0 +1,23 @@
+"""Pytest wrapper for the verify_pr_merged regression tests (issue #489).
+
+The actual assertions live in tests/test-open-pr-verify-merged.sh — bash
+shell function is the system under test, so the cleanest contract is a
+shell script that extracts the function and drives it with a fake gh.
+This wrapper just guarantees the shell test runs in CI.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(shutil.which("git") is None, reason="git not installed")
+
+
+def test_open_pr_verify_merged_regression() -> None:
+    repo = Path(__file__).resolve().parent.parent
+    test_script = repo / "tests" / "test-open-pr-verify-merged.sh"
+    subprocess.run(["bash", str(test_script)], cwd=repo, check=True)


### PR DESCRIPTION
## Linked Issues

Closes #489

Per #489: when shipping PRs from isolated worktrees with main checked
out in a sibling worktree, `open-pr.sh --auto-merge` sometimes exited
non-zero with an ORPHAN RISK banner after the PR had successfully
merged. Reproduced shipping #486/#487/#488 on 2026-05-18.

Root cause: `verify_pr_merged` read `mergedAt` from a single
`gh pr view` call with no retry. GitHub's API briefly returns empty
`mergedAt` for a window right after `gh pr merge` returns — even though
the PR's `state` is already `MERGED`. The strict mergedAt-only check
fired a false-alarm error and triggered the orphan-warning banner; the
on_exit re-check used the same flawed logic so it didn't suppress.

Fix:

- `verify_pr_merged` now reads both `state` and `mergedAt`, treating
  `state == MERGED` as the authoritative signal. When state is MERGED
  but mergedAt is still empty, the function reports a diagnostic line
  noting the API lag rather than rejecting the merge.
- One retry with a short backoff (2s default, override via
  `VERIFY_PR_MERGED_BACKOFF_SEC` for tests) absorbs the lag window.
- The on_exit trap's re-check uses the same `state == MERGED` rule so
  the orphan banner is also correctly suppressed.

Adds a shell-script regression test (with pytest wrapper) covering:
1. clean happy path (MERGED + populated mergedAt)
2. the bug case (MERGED + empty mergedAt) — was returning failure
3. transient OPEN → MERGED on retry
4. genuinely open PR (no false positive)
5. gh failure (no crash, reports not merged)

Closes #489.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
