### PR TITLE
fix: cap OpenRouter output token budgets

### DIFF
--- a/src/conductor/providers/openrouter.py
+++ b/src/conductor/providers/openrouter.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import subprocess
 import sys
 import time
@@ -65,6 +66,18 @@ OPENROUTER_MAX_TOOL_ITERATIONS = 10
 OPENROUTER_MODELS_ARRAY_MAX = 3
 OPENROUTER_HTTP_REFERER = "https://github.com/autumngarage/conductor"
 OPENROUTER_X_TITLE = "conductor"
+OPENROUTER_MAX_TOKENS_BY_EFFORT = {
+    "minimal": 512,
+    "low": 1_024,
+    "medium": 2_048,
+    "high": 4_096,
+    "max": 8_192,
+}
+_OPENROUTER_MAX_TOKENS_AFFORDABILITY_RE = re.compile(
+    r"requested up to\s+(?P<requested>[\d,]+)\s+tokens.*?"
+    r"can only afford\s+(?P<affordable>[\d,]+)",
+    re.IGNORECASE | re.DOTALL,
+)
 _TERMINAL_REVIEW_ANSWER_PROMPT = (
     "You are at the review tool-iteration cap. Stop calling tools and give the "
     "final review answer now. If the prompt requested a final sentinel such as "
@@ -228,6 +241,24 @@ class OpenRouterProvider:
                     headers=self._headers(),
                     json=payload,
                 )
+                retry_payload = _max_tokens_affordability_retry_payload(
+                    resp.status_code,
+                    resp.text,
+                    payload,
+                )
+                if retry_payload is not None:
+                    _LOG.info(
+                        "retrying OpenRouter request with lower max_tokens: "
+                        "requested=%s retry=%s",
+                        payload.get("max_tokens"),
+                        retry_payload.get("max_tokens"),
+                    )
+                    resp = client.post(
+                        f"{self._base_url}/chat/completions",
+                        headers=self._headers(),
+                        json=retry_payload,
+                    )
+                    payload = retry_payload
         except httpx.TimeoutException as e:
             raise ProviderHTTPError(
                 f"network error calling OpenRouter: {e}",
@@ -372,6 +403,8 @@ class OpenRouterProvider:
         }
         if max_tokens is not None:
             payload["max_tokens"] = max(1, max_tokens)
+        else:
+            payload["max_tokens"] = _max_tokens_for_effort(effort)
 
         attempts: list[dict[str, object]] = []
         start = time.monotonic()
@@ -550,6 +583,7 @@ class OpenRouterProvider:
                 "messages": messages,
                 "tools": tool_specs,
                 "tool_choice": "auto",
+                "max_tokens": _max_tokens_for_effort(effort),
             }
             if tools & {"Bash", "Edit", "Write"}:
                 payload["parallel_tool_calls"] = False
@@ -1375,6 +1409,23 @@ def _reasoning_payload(effort: str | int) -> dict[str, str] | None:
     return {"effort": mapped}
 
 
+def _max_tokens_for_effort(effort: str | int) -> int:
+    if isinstance(effort, int):
+        if effort <= 0:
+            return OPENROUTER_MAX_TOKENS_BY_EFFORT["minimal"]
+        if effort <= 2_000:
+            return OPENROUTER_MAX_TOKENS_BY_EFFORT["low"]
+        if effort <= 8_000:
+            return OPENROUTER_MAX_TOKENS_BY_EFFORT["medium"]
+        if effort <= 24_000:
+            return OPENROUTER_MAX_TOKENS_BY_EFFORT["high"]
+        return OPENROUTER_MAX_TOKENS_BY_EFFORT["max"]
+    return OPENROUTER_MAX_TOKENS_BY_EFFORT.get(
+        effort,
+        OPENROUTER_MAX_TOKENS_BY_EFFORT["medium"],
+    )
+
+
 def _openrouter_models_wire_list(models: tuple[str, ...] | list[str]) -> list[str]:
     return list(models[:OPENROUTER_MODELS_ARRAY_MAX])
 
@@ -1435,6 +1486,46 @@ def _format_openrouter_http_error(status_code: int, response_text: str, payload:
         )
     parts.append(f"upstream response: {response_text[:500]}")
     return " ".join(parts)
+
+
+def _max_tokens_affordability_retry_payload(
+    status_code: int,
+    response_text: str,
+    payload: dict,
+) -> dict | None:
+    if status_code != 402:
+        return None
+    current = _positive_int(payload.get("max_tokens"))
+    requested, affordable = _parse_max_tokens_affordability(response_text)
+    if current is None:
+        current = requested
+    if current is None or affordable is None or affordable <= 0:
+        return None
+    if current <= affordable:
+        return None
+    retry_payload = dict(payload)
+    retry_payload["max_tokens"] = max(1, affordable)
+    return retry_payload
+
+
+def _parse_max_tokens_affordability(response_text: str) -> tuple[int | None, int | None]:
+    match = _OPENROUTER_MAX_TOKENS_AFFORDABILITY_RE.search(response_text)
+    if match is None:
+        return None, None
+    return (
+        _positive_int(match.group("requested")),
+        _positive_int(match.group("affordable")),
+    )
+
+
+def _positive_int(value: object) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        parsed = int(str(value).replace(",", ""))
+    except ValueError:
+        return None
+    return parsed if parsed > 0 else None
 
 
 def _openrouter_http_failure_reason(status_code: int, response_text: str) -> str:

--- a/tests/test_deepseek_migration.py
+++ b/tests/test_deepseek_migration.py
@@ -102,6 +102,7 @@ def test_deepseek_chat_call_uses_preset_openrouter_model(monkeypatch):
     assert captured["payload"] == {
         "model": DEEPSEEK_CHAT_MODEL,
         "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 2048,
         "usage": {"include": True},
     }
 

--- a/tests/test_kimi_migration.py
+++ b/tests/test_kimi_migration.py
@@ -88,6 +88,7 @@ def test_kimi_call_uses_preset_openrouter_model(monkeypatch):
         "model": KIMI_DEFAULT_MODEL,
         "messages": [{"role": "user", "content": "hi"}],
         "reasoning": {"effort": "medium"},
+        "max_tokens": 2048,
         "usage": {"include": True},
     }
 

--- a/tests/test_openrouter.py
+++ b/tests/test_openrouter.py
@@ -427,6 +427,7 @@ def test_call_sends_reasoning_effort_and_openrouter_headers(configured):
         "model": "anthropic/claude-sonnet-4",
         "messages": [{"role": "user", "content": "hi"}],
         "reasoning": {"effort": "xhigh"},
+        "max_tokens": 8192,
         "usage": {"include": True},
     }
 
@@ -458,6 +459,157 @@ def test_call_opts_in_to_usage_cost_reporting(configured):
         OpenRouterProvider().call("hi", model="openai/gpt-5.5")
 
     assert captured["payload"]["usage"] == {"include": True}
+
+
+@pytest.mark.parametrize(
+    ("effort", "expected_max_tokens"),
+    [
+        ("minimal", 512),
+        ("low", 1024),
+        ("medium", 2048),
+        ("high", 4096),
+        ("max", 8192),
+    ],
+)
+def test_call_caps_default_max_tokens_by_effort(
+    configured,
+    effort,
+    expected_max_tokens,
+):
+    """Regression for #513: OpenRouter charges/affordability preflight checks
+    the request's max_tokens ceiling, so Conductor must send a bounded output
+    budget instead of letting hosted models default to 65k+ tokens."""
+    captured: dict[str, object] = {}
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        captured["payload"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "model": "openai/gpt-5.5",
+                "choices": [{"message": {"content": "ok"}}],
+                "usage": {},
+            },
+        )
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.post("/chat/completions").mock(side_effect=_record)
+        OpenRouterProvider().call("hi", model="openai/gpt-5.5", effort=effort)
+
+    assert captured["payload"]["max_tokens"] == expected_max_tokens
+
+
+def test_call_honors_explicit_max_tokens(configured):
+    captured: dict[str, object] = {}
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        captured["payload"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "model": "openai/gpt-5.5",
+                "choices": [{"message": {"content": "ok"}}],
+                "usage": {},
+            },
+        )
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.post("/chat/completions").mock(side_effect=_record)
+        OpenRouterProvider().call(
+            "hi",
+            model="openai/gpt-5.5",
+            max_tokens=333,
+        )
+
+    assert captured["payload"]["max_tokens"] == 333
+
+
+def test_call_retries_openrouter_credit_402_with_affordable_max_tokens(configured):
+    requests: list[dict] = []
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        requests.append(payload)
+        if len(requests) == 1:
+            return httpx.Response(
+                402,
+                json={
+                    "error": {
+                        "message": (
+                            "This request requires more credits, or fewer max_tokens. "
+                            "You requested up to 2048 tokens, but can only afford 1688."
+                        ),
+                        "code": 402,
+                    }
+                },
+            )
+        return httpx.Response(
+            200,
+            json={
+                "model": "openai/gpt-5.5",
+                "choices": [{"message": {"content": "ok"}}],
+                "usage": {},
+            },
+        )
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.post("/chat/completions").mock(side_effect=_record)
+        response = OpenRouterProvider().call(
+            "hi",
+            model="openai/gpt-5.5",
+            effort="medium",
+        )
+
+    assert response.text == "ok"
+    assert requests[0]["max_tokens"] == 2048
+    assert requests[1]["max_tokens"] == 1688
+
+
+def test_exec_with_tools_retries_credit_402_with_affordable_max_tokens(
+    configured,
+    tmp_path,
+):
+    requests: list[dict] = []
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        requests.append(payload)
+        if len(requests) == 1:
+            return httpx.Response(
+                402,
+                json={
+                    "error": {
+                        "message": (
+                            "This request requires more credits, or fewer max_tokens. "
+                            "You requested up to 2048 tokens, but can only afford 1688."
+                        ),
+                        "code": 402,
+                    }
+                },
+            )
+        return httpx.Response(
+            200,
+            json={
+                "model": "openai/gpt-5.5",
+                "choices": [{"message": {"content": "done"}}],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 2},
+            },
+        )
+
+    with respx.mock(base_url="https://openrouter.ai/api/v1") as router:
+        router.post("/chat/completions").mock(side_effect=_record)
+        response = OpenRouterProvider().exec(
+            "Inspect the repo.",
+            model="openai/gpt-5.5",
+            tools=frozenset({"Read"}),
+            cwd=str(tmp_path),
+        )
+
+    assert response.text == "done"
+    assert requests[0]["max_tokens"] == 2048
+    assert requests[0]["tools"][0]["function"]["name"] == "Read"
+    assert requests[1]["max_tokens"] == 1688
+    assert requests[1]["tools"][0]["function"]["name"] == "Read"
 
 
 def test_call_sends_ordered_models_stack(configured):
@@ -495,6 +647,7 @@ def test_call_sends_ordered_models_stack(configured):
         ],
         "messages": [{"role": "user", "content": "hi"}],
         "reasoning": {"effort": "low"},
+        "max_tokens": 1024,
         "usage": {"include": True},
     }
     assert len(captured["payload"]["models"]) <= OPENROUTER_MODELS_ARRAY_MAX
@@ -545,6 +698,7 @@ def test_call_without_model_invokes_selector_and_builds_payload(configured, mock
         "model": OPENROUTER_DEFAULT_MODEL,
         "messages": [{"role": "user", "content": "hi"}],
         "reasoning": {"effort": "medium"},
+        "max_tokens": 2048,
         "usage": {"include": True},
     }
     assert response.model == "google/gemini-flash-1.5"
@@ -695,6 +849,8 @@ def test_exec_with_tools_runs_openai_tool_loop(configured, tmp_path):
     assert response.usage["iterations"][1]["cost_usd"] == pytest.approx(0.002)
     assert response.cost_usd == pytest.approx(0.003)
     assert requests[0]["tools"][0]["function"]["name"] == "Read"
+    assert requests[0]["max_tokens"] == 2048
+    assert requests[1]["max_tokens"] == 2048
     assert "parallel_tool_calls" not in requests[0]
     assert requests[1]["messages"][1]["tool_calls"][0]["id"] == "call_read"
     assert requests[1]["messages"][2] == {
@@ -762,6 +918,8 @@ def test_exec_with_write_tools_disables_parallel_tool_calls(configured, tmp_path
         )
 
     assert response.text == "done"
+    assert requests[0]["max_tokens"] == 2048
+    assert requests[1]["max_tokens"] == 2048
     assert requests[0]["parallel_tool_calls"] is False
     assert requests[1]["parallel_tool_calls"] is False
 


### PR DESCRIPTION
## Linked Issues

Closes #513

Bound OpenRouter call and tool-loop request max_tokens by effort so hosted models cannot default to unaffordable 65k-token ceilings. Retry once with OpenRouter's reported affordable token count when a 402 explicitly asks for fewer max_tokens.

Closes-issue: #513

Refs #515

Refs #516

Refs #518

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
