### PR TITLE
feat(cli): add simplified job verbs

### DIFF
--- a/.cursor/rules/conductor-delegation.mdc
+++ b/.cursor/rules/conductor-delegation.mdc
@@ -2,7 +2,7 @@
 description: Use when delegating or routing tasks to a different LLM via the conductor CLI — e.g., cheap second opinions, long-context reads, web search, or offline runs.
 globs: ""
 alwaysApply: false
-managed-by: conductor v0.10.32
+managed-by: conductor v0.10.33
 ---
 
 # Conductor delegation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,7 @@ If there are zero blocking issues, the review is just: "LGTM."
 
 @.cortex/protocol.md
 
-<!-- conductor:begin v0.10.32 -->
+<!-- conductor:begin v0.10.33 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
 
-<!-- conductor:begin v0.10.32 -->
+<!-- conductor:begin v0.10.33 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 
 # conductor
 
-Pick an LLM, give it a job. Manual or auto routing across providers.
+Pick an LLM, give it a job. Job verbs plus compatibility routing across providers.
 
-**Status:** shipping. Current tap release is v0.8.7 — built-in providers for `kimi`, `openrouter`, `deepseek-chat`, `deepseek-reasoner`, `claude`, `codex`, `gemini`, and `ollama`; semantic `ask`; manual + auto routing; single-turn `call`; native `review`; multi-turn unsandboxed `exec` with tools; and agent-wiring for Claude Code, Codex, Gemini, Cursor, and repo instruction files.
+**Status:** shipping. Current releases are published through the Homebrew tap and GitHub Releases — built-in providers for `kimi`, `openrouter`, `deepseek-chat`, `deepseek-reasoner`, `claude`, `codex`, `gemini`, and `ollama`; simplified job verbs; manual + auto compatibility routing; single-turn `call`; native `review`; multi-turn unsandboxed `exec` with tools; and agent-wiring for Claude Code, Codex, Gemini, Cursor, and repo instruction files.
 
 DeepSeek note: `deepseek-chat` and `deepseek-reasoner` now use OpenRouter credentials. Set `OPENROUTER_API_KEY`; `DEEPSEEK_API_KEY` is deprecated. Conductor resolves the newest matching DeepSeek slug from the OpenRouter catalog and falls back to the pinned default if the catalog is unavailable.
 Kimi note: `kimi` now routes through OpenRouter. Set `OPENROUTER_API_KEY`; legacy `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` are no longer used. Conductor resolves the newest matching Kimi slug from the OpenRouter catalog and falls back to the pinned default if the catalog is unavailable.
@@ -71,11 +71,19 @@ pip install git+https://github.com/autumngarage/conductor
 # Kimi now routes through OpenRouter.
 export OPENROUTER_API_KEY=sk-or-v1-...
 
-# Manual mode: pick a specific provider
-conductor call --with kimi --brief "What is 2+2?"
+# Ask a cheap text question. Conductor chooses the provider.
+conductor ask "What is 2+2?"
+
+# Research, code work, and council synthesis are first-class job verbs.
+conductor research --brief-file /tmp/research.md
+conductor code --brief-file /tmp/implementation.md
+conductor council --brief-file /tmp/options.md
 
 # Pipe content as the brief
-cat README.md | conductor call --with kimi --brief "Summarize this in one sentence."
+cat README.md | conductor ask --brief "Summarize this in one sentence."
+
+# Compatibility mode: hard-pin a specific provider when you really need to.
+conductor call --with kimi --brief "Use this provider explicitly."
 
 # Override the default model (default: moonshotai/kimi-k2.6)
 conductor call --with kimi --model moonshotai/kimi-k2 --brief "..."
@@ -86,7 +94,7 @@ conductor call --with kimi --brief "ping" --json
 # Read-only code review uses the semantic review cascade by default
 conductor review --base origin/main --brief-file /tmp/review.md
 
-# Semantic API: say what kind of work this is and let Conductor pick
+# Legacy semantic API remains available during the migration
 conductor ask --kind research --effort medium --brief-file /tmp/brief.md
 conductor ask --kind code --effort high --brief-file /tmp/brief.md
 conductor ask --kind council --effort medium --brief-file /tmp/brief.md
@@ -106,7 +114,7 @@ Headless orchestrators can run repo-changing work with
 Shipped:
 
 - Built-in providers: `kimi` (OpenRouter-backed HTTP preset), `openrouter`, `deepseek-chat`, `deepseek-reasoner`, `claude`, `codex`, `gemini`, and `ollama`.
-- `conductor ask --kind <research|code|review|council> --effort <level>` — deterministic semantic routing. Research and low/medium code favor call-mode answer synthesis and cannot write files or open PRs; high-effort code escalates through Codex, Claude, OpenRouter tool-use exec, then Ollama; review routes to native review; council fans out through OpenRouter and synthesizes the results.
+- `conductor ask`, `conductor research`, `conductor code`, and `conductor council` — simplified job verbs backed by deterministic semantic routing. Text verbs favor call-mode answer synthesis and cannot write files or open PRs; code work uses the coding cascade through Codex, Claude, cheap OpenRouter tool-use exec, then eligible local fallback; council fans out through OpenRouter and synthesizes the results. Legacy `conductor ask --kind <research|code|review|council> --effort <level>` remains available during migration.
 - `conductor call --with <id> --brief "..."` — manual mode for any provider.
 - `conductor call --auto [--tags a,b,c] --brief "..."` — rule-based router picks the best configured provider for the task's tags.
 - `conductor swarm --brief a.md --brief b.md --provider codex --max-parallel 2 --json` — first-class multi-task coding supervisor with isolated worktrees and structured per-task results.

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -399,6 +399,9 @@ def _parameter_is_default(name: str) -> bool:
     ctx = click.get_current_context(silent=True)
     if ctx is None:
         return True
+    inherited_defaults = ctx.meta.get("conductor_inherited_default_parameters")
+    if isinstance(inherited_defaults, set) and name in inherited_defaults:
+        return True
     return ctx.get_parameter_source(name) == ParameterSource.DEFAULT
 
 
@@ -5527,7 +5530,13 @@ def ask(
 def _invoke_job_verb(ctx: click.Context, command_name: str, **kwargs: object) -> None:
     previous = ctx.meta.get("conductor_record_command")
     had_previous = "conductor_record_command" in ctx.meta
+    previous_inherited_defaults = ctx.meta.get("conductor_inherited_default_parameters")
+    had_previous_inherited_defaults = "conductor_inherited_default_parameters" in ctx.meta
     ctx.meta["conductor_record_command"] = command_name
+    ctx.meta["conductor_inherited_default_parameters"] = {
+        "timeout_sec",
+        "max_stall_sec",
+    }
     try:
         ctx.invoke(ask, **kwargs)
     finally:
@@ -5535,6 +5544,10 @@ def _invoke_job_verb(ctx: click.Context, command_name: str, **kwargs: object) ->
             ctx.meta["conductor_record_command"] = previous
         else:
             ctx.meta.pop("conductor_record_command", None)
+        if had_previous_inherited_defaults:
+            ctx.meta["conductor_inherited_default_parameters"] = previous_inherited_defaults
+        else:
+            ctx.meta.pop("conductor_inherited_default_parameters", None)
 
 
 @main.command(name="code")

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -5103,6 +5103,12 @@ def ask(
                 "--brief, --brief-file, --task, --task-file, or --issue."
             )
         task = prompt
+    ctx = click.get_current_context(silent=True)
+    ledger_command = (
+        str(ctx.meta.get("conductor_record_command"))
+        if ctx is not None and ctx.meta.get("conductor_record_command")
+        else "ask"
+    )
     timeout_is_default = _parameter_is_default("timeout_sec")
     max_stall_is_default = _parameter_is_default("max_stall_sec")
     effort_value = _parse_effort(effort)
@@ -5282,7 +5288,7 @@ def ask(
             )
         except ProviderConfigError as e:
             _record_failed_delegation(
-                "ask",
+                ledger_command,
                 provider_id=decision.provider,
                 model=None,
                 effort=effort_value,
@@ -5295,7 +5301,7 @@ def ask(
             sys.exit(2)
         except ProviderError as e:
             _record_failed_delegation(
-                "ask",
+                ledger_command,
                 provider_id=decision.provider,
                 model=None,
                 effort=effort_value,
@@ -5308,7 +5314,7 @@ def ask(
             sys.exit(1)
         _emit_usage_log(response, silent=silent_route or as_json)
         _record_response_delegation(
-            "ask",
+            ledger_command,
             response,
             effort=effort_value,
             decision=decision,
@@ -5392,7 +5398,7 @@ def ask(
                 )
                 session_log.mark_finished()
             _record_failed_delegation(
-                "ask",
+                ledger_command,
                 provider_id=provider_obj.name,
                 model=None,
                 effort=effort_value,
@@ -5432,7 +5438,7 @@ def ask(
             session_log.emit("provider_failed", {"error": str(e)})
             session_log.mark_finished()
         _record_failed_delegation(
-            "ask",
+            ledger_command,
             provider_id=decision.provider,
             model=None,
             effort=effort_value,
@@ -5449,7 +5455,7 @@ def ask(
             session_log.emit("provider_failed", {"error": str(e)})
             session_log.mark_finished()
         _record_failed_delegation(
-            "ask",
+            ledger_command,
             provider_id=decision.provider,
             model=None,
             effort=effort_value,
@@ -5465,7 +5471,7 @@ def ask(
         if session_log is not None:
             session_log.mark_finished()
         _record_failed_delegation(
-            "ask",
+            ledger_command,
             provider_id=decision.provider,
             model=None,
             effort=effort_value,
@@ -5496,7 +5502,7 @@ def ask(
     if session_log is not None:
         session_log.mark_finished()
     _record_response_delegation(
-        "ask",
+        ledger_command,
         response,
         effort=effort_value,
         decision=decision,
@@ -5516,6 +5522,19 @@ def ask(
 # --------------------------------------------------------------------------- #
 # simplified job verbs
 # --------------------------------------------------------------------------- #
+
+
+def _invoke_job_verb(ctx: click.Context, command_name: str, **kwargs: object) -> None:
+    previous = ctx.meta.get("conductor_record_command")
+    had_previous = "conductor_record_command" in ctx.meta
+    ctx.meta["conductor_record_command"] = command_name
+    try:
+        ctx.invoke(ask, **kwargs)
+    finally:
+        if had_previous:
+            ctx.meta["conductor_record_command"] = previous
+        else:
+            ctx.meta.pop("conductor_record_command", None)
 
 
 @main.command(name="code")
@@ -5582,8 +5601,9 @@ def code_cmd(
     prompt_words: tuple[str, ...],
 ) -> None:
     """Run code work through Conductor's default coding cascade."""
-    ctx.invoke(
-        ask,
+    _invoke_job_verb(
+        ctx,
+        "code",
         kind="code",
         effort="high",
         cwd=cwd,
@@ -5643,8 +5663,9 @@ def research_cmd(
     prompt_words: tuple[str, ...],
 ) -> None:
     """Run research through Conductor's default research cascade."""
-    ctx.invoke(
-        ask,
+    _invoke_job_verb(
+        ctx,
+        "research",
         kind="research",
         effort="medium",
         cwd=cwd,
@@ -5698,8 +5719,9 @@ def council_cmd(
     prompt_words: tuple[str, ...],
 ) -> None:
     """Run a multi-model council and synthesize the result."""
-    ctx.invoke(
-        ask,
+    _invoke_job_verb(
+        ctx,
+        "council",
         kind="council",
         effort="medium",
         task=task,

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -4909,10 +4909,11 @@ def main(ctx: click.Context) -> None:
 @main.command()
 @click.option(
     "--kind",
-    required=True,
+    required=False,
+    default=None,
     type=click.Choice(SEMANTIC_KINDS),
     help=(
-        "What kind of work this is. Picks the provider stack and physical "
+        "Legacy semantic kind. Omit for cheap general Q&A. Picks the provider stack and physical "
         "execution shape:\n"
         "  research = cheap single-model lookup / synthesis\n"
         "  code     = coding-optimized stack; --effort high switches to a "
@@ -5058,8 +5059,9 @@ def main(ctx: click.Context) -> None:
     default=False,
     help="Suppress the short-brief warning when semantic code routes to exec.",
 )
+@click.argument("prompt_words", nargs=-1)
 def ask(
-    kind: str,
+    kind: str | None,
     effort: str | None,
     tags: str | None,
     cwd: str | None,
@@ -5086,8 +5088,21 @@ def ask(
     offline: bool | None,
     preflight: bool,
     allow_short_brief: bool,
+    prompt_words: tuple[str, ...],
 ) -> None:
-    """Run a task through Conductor's deterministic semantic routing matrix."""
+    """Ask a question. With --kind, use the legacy semantic matrix surface."""
+    if kind is None:
+        kind = "research"
+        if effort is None:
+            effort = "minimal"
+    prompt = " ".join(prompt_words).strip()
+    if prompt:
+        if any(value is not None for value in (task, task_file, brief, brief_file, issue)):
+            raise click.UsageError(
+                "brief source is ambiguous. Use a prompt argument or one of "
+                "--brief, --brief-file, --task, --task-file, or --issue."
+            )
+        task = prompt
     timeout_is_default = _parameter_is_default("timeout_sec")
     max_stall_is_default = _parameter_is_default("max_stall_sec")
     effort_value = _parse_effort(effort)
@@ -5495,6 +5510,207 @@ def ask(
         decision=decision,
         semantic_plan=plan,
         auth_prompts=_collect_session_auth_prompts(session_log),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# simplified job verbs
+# --------------------------------------------------------------------------- #
+
+
+@main.command(name="code")
+@click.option("--cwd", default=None, help="Repository working directory.")
+@click.option("--task", default=None, help="The coding task. Alias: --brief.")
+@click.option("--task-file", default=None, help="Read the coding task from a UTF-8 file.")
+@click.option("--brief", default=None, help="Delegation brief / prompt.")
+@click.option(
+    "--brief-file",
+    default=None,
+    help="Read the delegation brief from a UTF-8 file. Use '-' to read stdin.",
+)
+@click.option(
+    "--issue",
+    default=None,
+    help="Use a GitHub issue as the seed brief. Accepts N or owner/repo#N.",
+)
+@click.option(
+    "--issue-comment-limit",
+    default=10,
+    type=click.IntRange(min=0),
+    show_default=True,
+    help="Number of recent GitHub issue comments to include with --issue.",
+)
+@click.option(
+    "--attach",
+    "attach",
+    multiple=True,
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+    help="Attach a file to the brief. Repeat for multiple.",
+)
+@click.option("--log-file", default=None, help="Write structured NDJSON exec events.")
+@click.option("--json", "as_json", is_flag=True, default=False)
+@click.option("--silent-route", is_flag=True, default=False)
+@click.option(
+    "--preflight/--no-preflight",
+    "preflight",
+    default=True,
+    help="Run a provider health probe before forwarding tool-using code work.",
+)
+@click.option(
+    "--allow-short-brief",
+    is_flag=True,
+    default=False,
+    help="Suppress the short-brief warning for code delegation.",
+)
+@click.argument("prompt_words", nargs=-1)
+@click.pass_context
+def code_cmd(
+    ctx: click.Context,
+    cwd: str | None,
+    task: str | None,
+    task_file: str | None,
+    brief: str | None,
+    brief_file: str | None,
+    issue: str | None,
+    issue_comment_limit: int,
+    attach: tuple[str, ...],
+    log_file: str | None,
+    as_json: bool,
+    silent_route: bool,
+    preflight: bool,
+    allow_short_brief: bool,
+    prompt_words: tuple[str, ...],
+) -> None:
+    """Run code work through Conductor's default coding cascade."""
+    ctx.invoke(
+        ask,
+        kind="code",
+        effort="high",
+        cwd=cwd,
+        task=task,
+        task_file=task_file,
+        brief=brief,
+        brief_file=brief_file,
+        issue=issue,
+        issue_comment_limit=issue_comment_limit,
+        attach=attach,
+        log_file=log_file,
+        as_json=as_json,
+        silent_route=silent_route,
+        preflight=preflight,
+        allow_short_brief=allow_short_brief,
+        prompt_words=prompt_words,
+    )
+
+
+@main.command(name="research")
+@click.option("--cwd", default=None, help="Repository working directory for issue context.")
+@click.option("--task", default=None, help="The research task. Alias: --brief.")
+@click.option("--task-file", default=None, help="Read the research task from a UTF-8 file.")
+@click.option("--brief", default=None, help="Delegation brief / prompt.")
+@click.option(
+    "--brief-file",
+    default=None,
+    help="Read the delegation brief from a UTF-8 file. Use '-' to read stdin.",
+)
+@click.option(
+    "--issue",
+    default=None,
+    help="Use a GitHub issue as the seed brief. Accepts N or owner/repo#N.",
+)
+@click.option(
+    "--issue-comment-limit",
+    default=10,
+    type=click.IntRange(min=0),
+    show_default=True,
+    help="Number of recent GitHub issue comments to include with --issue.",
+)
+@click.option("--json", "as_json", is_flag=True, default=False)
+@click.option("--silent-route", is_flag=True, default=False)
+@click.argument("prompt_words", nargs=-1)
+@click.pass_context
+def research_cmd(
+    ctx: click.Context,
+    cwd: str | None,
+    task: str | None,
+    task_file: str | None,
+    brief: str | None,
+    brief_file: str | None,
+    issue: str | None,
+    issue_comment_limit: int,
+    as_json: bool,
+    silent_route: bool,
+    prompt_words: tuple[str, ...],
+) -> None:
+    """Run research through Conductor's default research cascade."""
+    ctx.invoke(
+        ask,
+        kind="research",
+        effort="medium",
+        cwd=cwd,
+        task=task,
+        task_file=task_file,
+        brief=brief,
+        brief_file=brief_file,
+        issue=issue,
+        issue_comment_limit=issue_comment_limit,
+        as_json=as_json,
+        silent_route=silent_route,
+        prompt_words=prompt_words,
+    )
+
+
+@main.command(name="council")
+@click.option("--task", default=None, help="The council task. Alias: --brief.")
+@click.option("--task-file", default=None, help="Read the council task from a UTF-8 file.")
+@click.option("--brief", default=None, help="Delegation brief / prompt.")
+@click.option(
+    "--brief-file",
+    default=None,
+    help="Read the delegation brief from a UTF-8 file. Use '-' to read stdin.",
+)
+@click.option(
+    "--issue",
+    default=None,
+    help="Use a GitHub issue as the seed brief. Accepts N or owner/repo#N.",
+)
+@click.option(
+    "--issue-comment-limit",
+    default=10,
+    type=click.IntRange(min=0),
+    show_default=True,
+    help="Number of recent GitHub issue comments to include with --issue.",
+)
+@click.option("--json", "as_json", is_flag=True, default=False)
+@click.option("--silent-route", is_flag=True, default=False)
+@click.argument("prompt_words", nargs=-1)
+@click.pass_context
+def council_cmd(
+    ctx: click.Context,
+    task: str | None,
+    task_file: str | None,
+    brief: str | None,
+    brief_file: str | None,
+    issue: str | None,
+    issue_comment_limit: int,
+    as_json: bool,
+    silent_route: bool,
+    prompt_words: tuple[str, ...],
+) -> None:
+    """Run a multi-model council and synthesize the result."""
+    ctx.invoke(
+        ask,
+        kind="council",
+        effort="medium",
+        task=task,
+        task_file=task_file,
+        brief=brief,
+        brief_file=brief_file,
+        issue=issue,
+        issue_comment_limit=issue_comment_limit,
+        as_json=as_json,
+        silent_route=silent_route,
+        prompt_words=prompt_words,
     )
 
 

--- a/src/conductor/semantic.py
+++ b/src/conductor/semantic.py
@@ -1,4 +1,4 @@
-"""Deterministic semantic routing policies for ``conductor ask``.
+"""Deterministic semantic routing policies for Conductor job verbs.
 
 The classic ``call`` / ``exec`` / ``review`` commands expose provider-level
 knobs. This module owns the higher-level ``kind × effort`` matrix so callers

--- a/tests/test_cli_delegation_ledger.py
+++ b/tests/test_cli_delegation_ledger.py
@@ -183,10 +183,13 @@ def test_research_command_records_research_ledger_event(monkeypatch):
     events = []
     monkeypatch.setenv("CONDUCTOR_INTERNAL_TELEMETRY", "0")
     monkeypatch.setattr("conductor.cli.record_delegation", events.append)
-    monkeypatch.setattr("conductor.cli.pick", lambda *args, **kwargs: ("fake", _decision("fake")))
+    monkeypatch.setattr(
+        "conductor.cli.pick",
+        lambda *args, **kwargs: ("openrouter", _decision("openrouter")),
+    )
     monkeypatch.setattr(
         "conductor.cli._invoke_with_fallback",
-        lambda *args, **kwargs: (_response(provider="fake", model="fake-model"), []),
+        lambda *args, **kwargs: (_response(provider="openrouter", model="fake-model"), []),
     )
 
     result = CliRunner().invoke(
@@ -197,7 +200,7 @@ def test_research_command_records_research_ledger_event(monkeypatch):
     assert result.exit_code == 0, result.output
     assert len(events) == 1
     assert events[0].command == "research"
-    assert events[0].provider == "fake"
+    assert events[0].provider == "openrouter"
     assert events[0].status == "ok"
 
 

--- a/tests/test_cli_delegation_ledger.py
+++ b/tests/test_cli_delegation_ledger.py
@@ -149,6 +149,58 @@ def test_ask_records_ledger_event(monkeypatch):
     assert events[0].route is None
 
 
+def test_code_command_records_code_ledger_event(monkeypatch):
+    events = []
+    monkeypatch.setenv("CONDUCTOR_INTERNAL_TELEMETRY", "0")
+    monkeypatch.setattr("conductor.cli.record_delegation", events.append)
+    monkeypatch.setattr("conductor.cli.pick", lambda *args, **kwargs: ("codex", _decision()))
+    monkeypatch.setattr(
+        "conductor.cli._invoke_with_fallback",
+        lambda *args, **kwargs: (_response(provider="codex", model="gpt-test"), []),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "code",
+            "--allow-short-brief",
+            "--no-preflight",
+            "this",
+            "is",
+            "semantic",
+            "code",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(events) == 1
+    assert events[0].command == "code"
+    assert events[0].provider == "codex"
+    assert events[0].status == "ok"
+
+
+def test_research_command_records_research_ledger_event(monkeypatch):
+    events = []
+    monkeypatch.setenv("CONDUCTOR_INTERNAL_TELEMETRY", "0")
+    monkeypatch.setattr("conductor.cli.record_delegation", events.append)
+    monkeypatch.setattr("conductor.cli.pick", lambda *args, **kwargs: ("fake", _decision("fake")))
+    monkeypatch.setattr(
+        "conductor.cli._invoke_with_fallback",
+        lambda *args, **kwargs: (_response(provider="fake", model="fake-model"), []),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["research", "summarize", "this", "topic"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(events) == 1
+    assert events[0].command == "research"
+    assert events[0].provider == "fake"
+    assert events[0].status == "ok"
+
+
 def test_internal_telemetry_records_route_metadata(monkeypatch):
     events = []
     monkeypatch.setenv("CONDUCTOR_INTERNAL_TELEMETRY", "1")

--- a/tests/test_cli_delegation_ledger.py
+++ b/tests/test_cli_delegation_ledger.py
@@ -199,3 +199,24 @@ def test_council_records_parent_and_member_events(monkeypatch):
     assert parent_events[0].command == "council"
     assert parent_events[0].provider == "openrouter"
     assert child_events
+
+
+def test_council_command_uses_council_semantic_route(monkeypatch):
+    events = []
+    fake_council = FakeCouncilProvider()
+    monkeypatch.setattr("conductor.cli.record_delegation", events.append)
+    monkeypatch.setattr(
+        "conductor.cli._openrouter_council_provider",
+        lambda **kwargs: fake_council,
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["council", "--json", "Compare", "these", "options"],
+    )
+
+    assert result.exit_code == 0, result.output
+    parent_events = [event for event in events if event.council_role == "parent"]
+    assert len(parent_events) == 1
+    assert parent_events[0].command == "council"
+    assert parent_events[0].semantic["kind"] == "council"

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -552,6 +552,33 @@ def test_code_command_uses_default_tool_using_code_cascade(mocker):
     assert exec_mock.call_args.kwargs["sandbox"] == "none"
 
 
+def test_code_command_preserves_default_stall_scaling(mocker):
+    _stub_all_configured(mocker, {"codex"})
+    mocker.patch(
+        "conductor.cli.get_network_profile",
+        return_value=NetworkProfile(310, "https://api.openai.com", 1_000),
+    )
+    exec_mock = mocker.patch.object(CodexProvider, "exec", return_value=_fake_response("codex"))
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "code",
+            "--allow-short-brief",
+            "--no-preflight",
+            "Implement",
+            "the",
+            "scoped",
+            "coding",
+            "change.",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert exec_mock.call_args.kwargs["timeout_sec"] is None
+    assert exec_mock.call_args.kwargs["max_stall_sec"] == 1080
+
+
 def test_ask_research_low_lets_openrouter_auto_select(mocker):
     _stub_all_configured(mocker, {"openrouter"})
     call_mock = mocker.patch.object(

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -480,6 +480,78 @@ def test_call_auto_can_route_to_openrouter_without_catalog_restrictions(mocker, 
 # ---------------------------------------------------------------------------
 
 
+def test_bare_ask_defaults_to_cheap_research(mocker):
+    _stub_all_configured(mocker, {"openrouter"})
+    call_mock = mocker.patch.object(
+        OpenRouterProvider,
+        "call",
+        return_value=_fake_response("openrouter", "openrouter/auto"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["ask", "--json", "Summarize", "this", "paper."],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert call_mock.called
+    assert set(call_mock.call_args.kwargs["task_tags"]) == {
+        "research",
+        "long-context",
+        "cheap",
+    }
+    payload = json.loads(result.stdout)
+    assert payload["semantic"]["kind"] == "research"
+    assert payload["semantic"]["effort_bucket"] == "minimal"
+    assert payload["semantic"]["mode"] == "call"
+
+
+def test_research_command_uses_research_semantic_route(mocker):
+    _stub_all_configured(mocker, {"openrouter"})
+    call_mock = mocker.patch.object(
+        OpenRouterProvider,
+        "call",
+        return_value=_fake_response("openrouter", "openrouter/auto"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["research", "--json", "Find", "the", "background."],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert call_mock.called
+    payload = json.loads(result.stdout)
+    assert payload["semantic"]["kind"] == "research"
+    assert payload["semantic"]["effort_bucket"] == "medium"
+    assert payload["semantic"]["mode"] == "call"
+
+
+def test_code_command_uses_default_tool_using_code_cascade(mocker):
+    _stub_all_configured(mocker, {"codex"})
+    exec_mock = mocker.patch.object(CodexProvider, "exec", return_value=_fake_response("codex"))
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "code",
+            "--allow-short-brief",
+            "Implement",
+            "the",
+            "scoped",
+            "coding",
+            "change.",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert exec_mock.called
+    assert exec_mock.call_args.kwargs["tools"] == frozenset(
+        {"Read", "Grep", "Glob", "Edit", "Write", "Bash"}
+    )
+    assert exec_mock.call_args.kwargs["sandbox"] == "none"
+
+
 def test_ask_research_low_lets_openrouter_auto_select(mocker):
     _stub_all_configured(mocker, {"openrouter"})
     call_mock = mocker.patch.object(


### PR DESCRIPTION
Add bare ask plus top-level code, research, and council commands that reuse the existing semantic routing matrix while keeping legacy ask --kind compatibility.

Refs #501

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
