### PR TITLE
fix: clarify provider pinning escape hatch

### DIFF
--- a/.cursor/rules/conductor-delegation.mdc
+++ b/.cursor/rules/conductor-delegation.mdc
@@ -35,6 +35,10 @@ context, scope, constraints, expected output, and validation.
 Default to `conductor ask`; use provider-specific `call` / `exec` only
 when the user explicitly asks for a provider or the semantic API does not
 fit.
+Do not attach `--with` or `--model` to `conductor ask`; provider/model
+overrides belong to lower-level commands, for example:
+
+    conductor call --with openrouter --brief-file /tmp/brief.md
 
 For longer running tool-using sessions:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,10 @@ output, and validation; use `--brief-file` for nontrivial `exec` tasks.
 Default to `conductor ask`; use provider-specific `call` / `exec` only
 when the user explicitly asks for a provider or the semantic API does not
 fit.
+Do not attach `--with` or `--model` to `conductor ask`; provider/model
+overrides belong to lower-level commands, for example:
+
+    conductor call --with openrouter --brief-file /tmp/brief.md
 
 Default routing is flat-rate-first when the job contract allows it, then
 OpenRouter as metered overflow. `review` means code diff/PR review;

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -31,6 +31,10 @@ output, and validation; use `--brief-file` for nontrivial `exec` tasks.
 Default to `conductor ask`; use provider-specific `call` / `exec` only
 when the user explicitly asks for a provider or the semantic API does not
 fit.
+Do not attach `--with` or `--model` to `conductor ask`; provider/model
+overrides belong to lower-level commands, for example:
+
+    conductor call --with openrouter --brief-file /tmp/brief.md
 
 Default routing is flat-rate-first when the job contract allows it, then
 OpenRouter as metered overflow. `review` means code diff/PR review;

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ expected output, and validation. Conductor only sees the brief you pass
 plus any files the delegated provider can inspect; it does not inherit
 the caller's conversation context. Existing `--task` / `--task-file`
 flags remain supported as compatibility aliases.
+Do not combine `conductor ask` with provider/model flags such as `--with`
+or `--model`; when a provider or model is explicitly requested, use the
+lower-level `conductor call --with ...` escape hatch instead.
 Headless orchestrators can run repo-changing work with
 `conductor exec --brief-file /tmp/brief.md`.
 

--- a/docs/consumers.md
+++ b/docs/consumers.md
@@ -39,7 +39,7 @@ conductor exec --auto --permission-profile <read-only|patch|full> [options]
 conductor exec --with <provider> --permission-profile <read-only|patch|full> [options]
 ```
 
-Use `conductor ask` when the caller knows the semantic kind but does not want to reason about providers. It applies Conductor's deterministic `kind × effort` matrix, then delegates to `call`, `exec`, `review`, or council fan-out internally. Provider/model/tag/tool overrides intentionally stay on the lower-level `call`, `exec`, and `review` commands.
+Use `conductor ask` when the caller knows the semantic kind but does not want to reason about providers. It applies Conductor's deterministic `kind × effort` matrix, then delegates to `call`, `exec`, `review`, or council fan-out internally. Provider/model/tag/tool overrides intentionally stay on the lower-level `call`, `exec`, and `review` commands. Do not combine `ask` with `--with` or `--model`; when the user explicitly requests a provider or model, use the lower-level command for that job, for example `conductor call --with openrouter --brief-file /tmp/brief.md`.
 
 Usually, exactly one of `--auto` or `--with` is required for `call` and `exec`. `review` is auto-routed by default when `--with` is absent; `--auto` remains accepted for compatibility. `--auto` runs the router using `--tags`, `--prefer`, and `--exclude` to pick a configured provider; `--with` bypasses the router for direct provider use. `--offline` is the exception for `call` and `exec`: it may be used without `--auto` or `--with`, sets the sticky offline flag, and rewrites the call to `--with ollama`. Passing `--offline --with <non-ollama>` is an error. `--no-offline` clears the sticky flag, then normal `--auto` / `--with` rules apply.
 
@@ -141,7 +141,7 @@ The canonical reference is `conductor call --help`. The contract-level commitmen
 | `--offline` / `--no-offline` | bool | stable | Force/clear local-only routing |
 | `--profile <name>` | string | stable | Apply named profile defaults |
 
-`conductor ask --help` is the canonical reference for the semantic API. Its stable default-path flags are: --kind, --effort, --cwd, --base, --commit, --uncommitted, --title, --brief, --brief-file, --issue, --issue-comment-limit, --task, --task-file, --log-file, --json, --verbose-route, --silent-route, --offline, --no-offline, --preflight, --no-preflight, and --allow-short-brief. It intentionally does not expose router knobs such as `--tags` or `--prefer`; those belong to `call`, `exec`, `review`, and `route`.
+`conductor ask --help` is the canonical reference for the semantic API. Its stable default-path flags are: --kind, --effort, --cwd, --base, --commit, --uncommitted, --title, --brief, --brief-file, --issue, --issue-comment-limit, --task, --task-file, --log-file, --json, --verbose-route, --silent-route, --offline, --no-offline, --preflight, --no-preflight, and --allow-short-brief. It intentionally does not expose router knobs such as `--tags` or `--prefer`, or provider/model override knobs such as `--with` or `--model`; those belong to `call`, `exec`, `review`, and `route`.
 
 ## Output (`--json`)
 

--- a/src/conductor/_agent_templates.py
+++ b/src/conductor/_agent_templates.py
@@ -49,6 +49,10 @@ and not squeezed through shell quoting.
 Default to semantic routing. Choose only `kind` and `effort`; let
 Conductor choose providers and models unless the user explicitly asks for
 a specific provider.
+Never combine `conductor ask` with provider/model flags such as `--with`
+or `--model`. If the user explicitly names a provider or model, use the
+lower-level command for that job, for example
+`conductor call --with openrouter --brief-file /tmp/brief.md`.
 
 Use this decision ladder; pick the first line that fits:
 
@@ -82,7 +86,8 @@ Use `council` when the user wants multiple perspectives. Council always
 routes through OpenRouter and asks multiple models independently before a
 synthesis pass. Do not route council to Codex, Claude, Gemini CLI, or Ollama.
 
-Manual provider calls are the escape hatch, not the default:
+Manual provider calls are the explicit provider/model escape hatch, not
+the default:
 
     conductor call --with <provider> --brief "..."
 
@@ -542,6 +547,10 @@ output, and validation; use `--brief-file` for nontrivial `exec` tasks.
 Default to `conductor ask`; use provider-specific `call` / `exec` only
 when the user explicitly asks for a provider or the semantic API does not
 fit.
+Do not attach `--with` or `--model` to `conductor ask`; provider/model
+overrides belong to lower-level commands, for example:
+
+    conductor call --with openrouter --brief-file /tmp/brief.md
 
 Default routing is flat-rate-first when the job contract allows it, then
 OpenRouter as metered overflow. `review` means code diff/PR review;
@@ -594,6 +603,10 @@ context, scope, constraints, expected output, and validation.
 Default to `conductor ask`; use provider-specific `call` / `exec` only
 when the user explicitly asks for a provider or the semantic API does not
 fit.
+Do not attach `--with` or `--model` to `conductor ask`; provider/model
+overrides belong to lower-level commands, for example:
+
+    conductor call --with openrouter --brief-file /tmp/brief.md
 
 For longer running tool-using sessions:
 
@@ -631,6 +644,11 @@ When invoked:
 
        conductor ask --kind <kind> --effort <minimal|low|medium|high|max> \\
            --brief-file /tmp/conductor-brief.md --json
+
+   `conductor ask` is only the semantic kind+effort surface. Do not add
+   `--with`, `--model`, `--tags`, or `--prefer` to it. If the user
+   explicitly names a provider or model, use a lower-level command such as
+   `conductor call --with openrouter --brief-file /tmp/conductor-brief.md --json`.
 
    Use `review` only for code diffs, PRs, merges, and commits. Use
    `text-review` for text-only critique. `text-review` runs in call mode,

--- a/tests/test_agent_template_drift.py
+++ b/tests/test_agent_template_drift.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from conductor import _agent_templates as templates
@@ -177,3 +178,31 @@ def test_generated_semantic_ask_examples_include_effort():
                 missing_effort.append(f"{surface}:{lineno}: {line.strip()}")
 
     assert not missing_effort
+
+
+def test_generated_semantic_ask_examples_do_not_pin_providers():
+    """Provider/model pinning must stay on lower-level commands, not ask."""
+    surfaces = {
+        "delegation-guidance": templates.DELEGATION_GUIDANCE,
+        "agents-md-block": templates.AGENTS_MD_BLOCK,
+        "cursor-rule": templates.CURSOR_RULE_BODY,
+        "conductor-auto": templates.SUBAGENT_CONDUCTOR_AUTO,
+        "checked-in-agents-md": Path("AGENTS.md").read_text(encoding="utf-8"),
+        "checked-in-gemini-md": Path("GEMINI.md").read_text(encoding="utf-8"),
+        "checked-in-cursor-rule": Path(".cursor/rules/conductor-delegation.mdc").read_text(
+            encoding="utf-8"
+        ),
+    }
+    invalid_command = re.compile(r"conductor ask\b[^\n`]*(?:--with|--model)\b")
+
+    invalid_examples = []
+    missing_escape_hatch = []
+    for surface, text in surfaces.items():
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if invalid_command.search(line):
+                invalid_examples.append(f"{surface}:{lineno}: {line.strip()}")
+        if "conductor call --with openrouter" not in text:
+            missing_escape_hatch.append(surface)
+
+    assert not invalid_examples
+    assert not missing_escape_hatch

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -1240,6 +1240,44 @@ def test_ask_rejects_router_tags():
     assert "--task" in result.output
 
 
+def test_ask_rejects_provider_override_flags():
+    result = CliRunner().invoke(
+        main,
+        [
+            "ask",
+            "--kind",
+            "research",
+            "--effort",
+            "medium",
+            "--with",
+            "openrouter",
+            "--brief",
+            "Use OpenRouter.",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "No such option: --with" in result.output
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "ask",
+            "--kind",
+            "research",
+            "--effort",
+            "medium",
+            "--model",
+            "openrouter/auto",
+            "--brief",
+            "Use this model.",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "No such option: --model" in result.output
+
+
 def test_ask_help_exposes_only_kind_and_effort_as_semantic_knobs():
     result = CliRunner().invoke(main, ["ask", "--help"])
 
@@ -1248,6 +1286,8 @@ def test_ask_help_exposes_only_kind_and_effort_as_semantic_knobs():
     assert "--effort" in result.output
     assert "--tags" not in result.output
     assert "--prefer" not in result.output
+    assert "--with" not in result.output
+    assert "--model" not in result.output
 
 
 def test_call_with_ollama_online_requires_local_opt_in(mocker):


### PR DESCRIPTION
## Linked Issues

Closes #545

Closes #545

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
