### PR TITLE
fix: preserve exec boundary dirty paths

### DIFF
--- a/src/conductor/exec_boundary.py
+++ b/src/conductor/exec_boundary.py
@@ -76,8 +76,10 @@ def enforce_exec_boundary(
     if not dirty:
         return ExecBoundaryResult("clean", scoped_paths=tuple(sorted(scoped)))
 
-    in_scope = tuple(sorted(path for path in dirty if _matches_scope(path, scoped)))
-    out_of_scope = tuple(sorted(path for path in dirty if path not in in_scope))
+    in_scope_paths = {path for path in dirty if _matches_scope(path, scoped)}
+    out_of_scope_paths = dirty - in_scope_paths
+    in_scope = tuple(sorted(in_scope_paths))
+    out_of_scope = tuple(sorted(out_of_scope_paths))
     warnings: list[str] = []
     if out_of_scope:
         warnings.append(
@@ -167,14 +169,24 @@ def _dirty_paths(worktree: Path) -> list[str]:
         idx += 1
         if not entry:
             continue
-        status = entry[:2]
-        path = entry[3:] if len(entry) > 3 else ""
-        if (status.startswith("R") or status.startswith("C")) and idx < len(entries):
+        status, path = _status_entry_path(entry)
+        if status.strip().startswith(("R", "C")) and idx < len(entries):
             path = entries[idx]
             idx += 1
         if path:
             paths.append(path)
     return sorted(dict.fromkeys(paths))
+
+
+def _status_entry_path(entry: str) -> tuple[str, str]:
+    if len(entry) >= 3 and entry[2] == " ":
+        return entry[:2], entry[3:]
+    status, separator, path = entry.partition(" ")
+    if separator:
+        return status, path
+    if len(entry) > 2:
+        return entry[:2], entry[2:]
+    return entry, ""
 
 
 def _git_stdout(worktree: Path, args: list[str]) -> str | None:

--- a/tests/test_root_cause_redesign.py
+++ b/tests/test_root_cause_redesign.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
+from conductor import exec_boundary as exec_boundary_module
 from conductor.cli import (
     _apply_exec_commit_boundary,
     _invoke_with_fallback,
@@ -16,7 +17,11 @@ from conductor.cli import (
     _response_with_council_health,
     main,
 )
-from conductor.exec_boundary import capture_exec_boundary_snapshot, enforce_exec_boundary
+from conductor.exec_boundary import (
+    ExecBoundarySnapshot,
+    capture_exec_boundary_snapshot,
+    enforce_exec_boundary,
+)
 from conductor.provider_capabilities import capabilities_for
 from conductor.providers import (
     CallResponse,
@@ -186,6 +191,46 @@ def test_exec_boundary_commits_only_in_scope_dirty_paths(tmp_path: Path) -> None
         "src/app.py"
     ]
     assert "?? AGENTS.md" in _git(repo, "status", "--short")
+
+
+def test_exec_boundary_preserves_single_column_dirty_status_paths(mocker) -> None:
+    repo = Path("/repo")
+
+    def fake_git_stdout(_worktree: Path, args: list[str]) -> str | None:
+        if args == ["status", "--porcelain", "-z", "--untracked-files=all"]:
+            return (
+                "M src/cortex/hosted/ask_ledger.py\0"
+                "M tests/test_hosted_ask_ledger.py\0"
+            )
+        if args == ["rev-parse", "--short", "HEAD"]:
+            return "abc123"
+        return None
+
+    git_run = mocker.patch.object(exec_boundary_module, "_git_run", return_value=None)
+    mocker.patch.object(exec_boundary_module, "_git_stdout", side_effect=fake_git_stdout)
+
+    result = enforce_exec_boundary(
+        ExecBoundarySnapshot(worktree=repo, head="before"),
+        brief=(
+            "Fix `src/cortex/hosted/ask_ledger.py` and "
+            "`tests/test_hosted_ask_ledger.py`."
+        ),
+        agent_write_set=set(),
+    )
+
+    assert result.status == "committed"
+    assert result.committed_paths == (
+        "src/cortex/hosted/ask_ledger.py",
+        "tests/test_hosted_ask_ledger.py",
+    )
+    assert result.out_of_scope_paths == ()
+    assert result.warnings == ()
+    assert git_run.call_args_list[0].args[1] == [
+        "add",
+        "--",
+        "src/cortex/hosted/ask_ledger.py",
+        "tests/test_hosted_ask_ledger.py",
+    ]
 
 
 def test_exec_boundary_preserves_hidden_directory_scope(tmp_path: Path) -> None:


### PR DESCRIPTION
## Linked Issues

Closes #547

Closes-issue: #547

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
