### PR TITLE
fix: isolate merge review worktrees

### DIFF
--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -1951,6 +1951,35 @@ conductor_inner_timeout() {
   printf '%s\n' "$((wrapper_timeout - grace))"
 }
 
+conductor_review_should_isolate_worktree() {
+  local phase="${1:-review}"
+  local subcommand="${2:-review}"
+
+  [ "$phase" = "review" ] || return 1
+  [ "$subcommand" = "review" ] || return 1
+  [ -n "${CODEX_REVIEW_PR_NUMBER:-}" ] || return 1
+  ! is_truthy "${TOUCHSTONE_REVIEW_DISABLE_ISOLATED_WORKTREE:-false}"
+}
+
+conductor_create_isolated_review_worktree() {
+  local path
+
+  path="$(mktemp -d "${TMPDIR:-/tmp}/touchstone-review-worktree.XXXXXX")" || return 1
+  if ! git worktree add --detach -q "$path" HEAD >/dev/null 2>&1; then
+    rm -rf "$path"
+    return 1
+  fi
+  printf '%s' "$path"
+}
+
+conductor_remove_isolated_review_worktree() {
+  local path="${1:-}"
+
+  [ -n "$path" ] || return 0
+  git worktree remove --force "$path" >/dev/null 2>&1 || rm -rf "$path"
+  git worktree prune >/dev/null 2>&1 || true
+}
+
 reviewer_conductor_exec() {
   local prompt="$1"
   local phase="${REVIEW_PHASE:-review}"
@@ -1959,6 +1988,7 @@ reviewer_conductor_exec() {
   local tools
   local effective_with
   local conductor_timeout
+  local review_cwd=""
 
   # REVIEW_MODE + REVIEW_PHASE → Conductor job shape. The default phase uses
   # Conductor's semantic review command and lets Conductor own routing policy.
@@ -1985,6 +2015,21 @@ reviewer_conductor_exec() {
     fi
     if [ -n "${REVIEW_MAX_STALL_SEC:-}" ]; then
       args+=(--max-stall-seconds "$REVIEW_MAX_STALL_SEC")
+    fi
+    if conductor_review_should_isolate_worktree "$phase" "$subcommand"; then
+      if ! review_cwd="$(conductor_create_isolated_review_worktree)"; then
+        echo "[conductor] review isolation failed: could not create temporary worktree" >&2
+        return 1
+      fi
+      echo "[conductor] review isolation: using temporary worktree $review_cwd" >&2
+      args+=(--cwd "$review_cwd")
+      (
+        trap 'rc=$?; conductor_remove_isolated_review_worktree "$review_cwd"; exit $rc' EXIT
+        trap 'exit 143' TERM INT
+        printf '%s' "$prompt" \
+          | CODEX_REVIEW_IN_PROGRESS=1 conductor review "${args[@]}"
+      )
+      return $?
     fi
     printf '%s' "$prompt" \
       | CODEX_REVIEW_IN_PROGRESS=1 conductor review "${args[@]}"

--- a/tests/test_review_cascade.py
+++ b/tests/test_review_cascade.py
@@ -984,6 +984,53 @@ esac
 exit 1
 '''
 
+FAKE_CONDUCTOR_REVIEW_MUTATES_CWD = '''
+#!/usr/bin/env bash
+case "$1" in
+  --version)
+    echo "conductor 0.10.99"
+    exit 0
+    ;;
+  doctor)
+    if [ "$2" = "--json" ]; then
+      echo '{"configured": true}'
+      exit 0
+    fi
+    ;;
+  route)
+    for arg in "$@"; do
+      if [ "$arg" = "--help" ]; then
+        exit 0
+      fi
+    done
+    echo '{"selected_provider":"codex","provider":"codex"}'
+    exit 0
+    ;;
+  review)
+    cwd="$PWD"
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --cwd)
+          cwd="$2"
+          shift 2
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+    git -C "$cwd" checkout -q --detach HEAD~1
+    echo "reviewer mutation" >> "$cwd/README"
+    git -C "$cwd" -c user.name=t -c user.email=t@t add README
+    git -C "$cwd" -c user.name=t -c user.email=t@t commit -q -m "unauthorized review commit"
+    echo "Looks fine."
+    echo "CODEX_REVIEW_CLEAN"
+    exit 0
+    ;;
+esac
+exit 1
+'''
+
 # Codex writes a file (simulating a partial edit) then exits non-zero
 # without ever emitting CODEX_REVIEW_FIXED. In fix mode the cascade must
 # discard this partial edit before falling through, otherwise claude would
@@ -1189,6 +1236,65 @@ def test_cascade_exhausted_blocks_when_fail_closed(tmp_path: Path) -> None:
     assert result.returncode == 1, f"stdout={result.stdout}\nstderr={result.stderr}"
     assert "All reviewers in the cascade failed" in result.stdout
     assert "blocking push" in result.stderr or "blocking push" in result.stdout
+
+
+def test_merge_gate_conductor_review_uses_isolated_worktree(tmp_path: Path) -> None:
+    """A merge-gate read-only Conductor review may use stateful native providers.
+
+    Provider-side branch switches or commits must land in a disposable worktree,
+    not in the source PR checkout that the merge gate will later merge or fix.
+    """
+    repo = _make_repo(tmp_path)
+    _write_config(repo, ["conductor"], on_error="fail-closed", mode="fix")
+    head_before = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    fakes = tmp_path / "fakes"
+    fakes.mkdir()
+    _write_executable(fakes / "conductor", FAKE_CONDUCTOR_REVIEW_MUTATES_CWD)
+
+    result = _run_script(
+        repo,
+        fakes,
+        extra_env={"CODEX_REVIEW_MODE": "fix", "CODEX_REVIEW_PR_NUMBER": "357"},
+    )
+
+    assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+    assert "review isolation: using temporary worktree" in result.stdout
+    assert subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip() == head_before
+    assert subprocess.run(
+        ["git", "branch", "--show-current"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip() == "main"
+    assert subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout == ""
+    assert "touchstone-review-worktree" not in subprocess.run(
+        ["git", "worktree", "list", "--porcelain"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert "reviewer mutation" not in (repo / "README").read_text(encoding="utf-8")
 
 
 def test_fix_mode_discards_partial_edits_before_fallthrough(tmp_path: Path) -> None:


### PR DESCRIPTION
## Linked Issues

Closes #533

Closes-issue: #533

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
