### PR TITLE
fix: harden gemini call defaults

### DIFF
--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -210,6 +210,7 @@ PROFILE_PRECEDENCE_TEXT = (
     "Resolution order: profile defaults < CONDUCTOR_* env vars < explicit CLI flags."
 )
 DEFAULT_EXEC_MAX_STALL_SEC = 360
+GEMINI_CALL_DEFAULT_TIMEOUT_SEC = 540
 MIN_EXEC_BRIEF_CHARS = 300
 DEFAULT_EXEC_MAX_ITERATIONS = 10
 EXEC_MAX_ITERATION_MULTIPLIERS = {
@@ -466,6 +467,19 @@ def _scale_dispatch_defaults(
         resolved_max_stall = None if scaled_stall is None else math.ceil(scaled_stall)
 
     return resolved_timeout, resolved_max_stall
+
+
+def _materialize_call_timeout_default(
+    *,
+    provider_id: str | None,
+    timeout_sec: int | None,
+    timeout_is_default: bool,
+) -> int | None:
+    if not timeout_is_default:
+        return timeout_sec
+    if provider_id == "gemini":
+        return GEMINI_CALL_DEFAULT_TIMEOUT_SEC
+    return timeout_sec
 
 
 def _cap_default_auto_fallback_stall(
@@ -860,6 +874,45 @@ def _warn_if_text_only_research_grounding_requested(plan: SemanticPlan, body: st
         "path:line citations or grounded code references. Use "
         "`conductor ask --kind code --effort high` or `conductor exec` when the "
         "answer must inspect files.",
+        err=True,
+    )
+
+
+_GEMINI_WEB_SOURCE_CITATION_PATTERNS = (
+    re.compile(
+        r"(?is)\b(?:cite|cites|citation|citations|references?)\b"
+        r".{0,80}\b(?:sources?|urls?|links?)\b"
+    ),
+    re.compile(
+        r"(?is)\b(?:sources?|urls?|links?)\b"
+        r".{0,80}\b(?:cite|cites|citation|citations|references?|verified|grounded|fact[- ]?check)\b"
+    ),
+    re.compile(
+        r"(?is)\b(?:verified|grounded|fact[- ]?check|live)\b"
+        r".{0,80}\b(?:sources?|urls?|links?|citations?)\b"
+    ),
+)
+
+
+def _brief_requests_web_source_citations(body: str) -> bool:
+    return any(
+        pattern.search(body) for pattern in _GEMINI_WEB_SOURCE_CITATION_PATTERNS
+    )
+
+
+def _warn_if_gemini_source_citations_requested(
+    *,
+    provider_id: str | None,
+    body: str,
+) -> None:
+    if provider_id != "gemini":
+        return
+    if not _brief_requests_web_source_citations(body):
+        return
+    click.echo(
+        "[conductor] warning: Gemini web-search source URLs are "
+        "provider-generated and not verified by Conductor. Check cited links "
+        "before relying on factual claims.",
         err=True,
     )
 
@@ -5139,9 +5192,11 @@ def main(ctx: click.Context) -> None:
     type=int,
     hidden=True,
     help=(
-        "Wall-clock timeout in seconds for review/exec provider calls. "
-        "Unbounded by default. Review-tagged auto routes derive their own "
-        "provider budget. Council uses --council-timeout for its total cap."
+        "Wall-clock timeout in seconds for provider calls. "
+        "Unbounded by default except Gemini CLI call mode, which defaults "
+        "to 540s and scales on slow networks. Review-tagged auto routes "
+        "derive their own provider budget. Council uses --council-timeout "
+        "for its total cap."
     ),
 )
 @click.option(
@@ -5552,6 +5607,12 @@ def ask(
         click.echo(f"conductor: {e}", err=True)
         sys.exit(2)
 
+    if plan.mode == "call":
+        timeout_sec = _materialize_call_timeout_default(
+            provider_id=decision.provider,
+            timeout_sec=timeout_sec,
+            timeout_is_default=timeout_is_default,
+        )
     timeout_sec, max_stall_sec = _scale_dispatch_defaults(
         provider_id=decision.provider,
         timeout_sec=timeout_sec,
@@ -5572,6 +5633,10 @@ def ask(
         session_log = _start_exec_session_log(log_file=log_file, resume_session_id=None)
         _emit_session_route_decision(session_log, decision)
     _warn_if_text_only_research_grounding_requested(plan, body)
+    _warn_if_gemini_source_citations_requested(
+        provider_id=decision.provider,
+        body=body,
+    )
     print_caller_banner(decision.provider, silent=silent_route or as_json)
     _emit_route_log(decision, verbose=verbose_route, silent=silent_route or as_json)
     token_warning = _semantic_tool_context_warning(
@@ -6051,8 +6116,9 @@ def council_cmd(
     default=None,
     type=int,
     help=(
-        "Wall-clock timeout in seconds. Unbounded by default. Review-tagged "
-        "auto routes derive their own provider budget."
+        "Wall-clock timeout in seconds. Unbounded by default except Gemini "
+        "CLI call mode, which defaults to 540s and scales on slow networks. "
+        "Review-tagged auto routes derive their own provider budget."
     ),
 )
 @click.option(
@@ -6261,6 +6327,11 @@ def call(
             click.echo(exclusion_message, err=True)
         print_caller_banner(decision.provider, silent=silent_route or as_json)
         _emit_route_log(decision, verbose=verbose_route, silent=silent_route or as_json)
+        timeout_sec = _materialize_call_timeout_default(
+            provider_id=decision.provider,
+            timeout_sec=timeout_sec,
+            timeout_is_default=timeout_is_default,
+        )
         timeout_sec, max_stall_sec = _scale_dispatch_defaults(
             provider_id=decision.provider,
             timeout_sec=timeout_sec,
@@ -6288,6 +6359,10 @@ def call(
                 candidate_count=len(decision.ranked),
             )
         max_stall_sec = _normalize_max_stall_sec(max_stall_sec)
+        _warn_if_gemini_source_citations_requested(
+            provider_id=decision.provider,
+            body=body,
+        )
 
         try:
             response, fallbacks = _invoke_with_fallback(
@@ -6349,6 +6424,11 @@ def call(
             click.echo(f"conductor: {e}", err=True)
             sys.exit(2)
         print_caller_banner(provider_id, silent=silent_route or as_json)
+        timeout_sec = _materialize_call_timeout_default(
+            provider_id=provider_id,
+            timeout_sec=timeout_sec,
+            timeout_is_default=timeout_is_default,
+        )
         timeout_sec, max_stall_sec = _scale_dispatch_defaults(
             provider_id=provider_id,
             timeout_sec=timeout_sec,
@@ -6357,6 +6437,10 @@ def call(
             max_stall_is_default=max_stall_is_default,
         )
         max_stall_sec = _normalize_max_stall_sec(max_stall_sec)
+        _warn_if_gemini_source_citations_requested(
+            provider_id=provider_id,
+            body=body,
+        )
         try:
             if isinstance(provider, OpenRouterProvider):
                 response = provider.call(

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -26,6 +26,7 @@ from click.testing import CliRunner
 
 from conductor import offline_mode
 from conductor.cli import (
+    GEMINI_CALL_DEFAULT_TIMEOUT_SEC,
     _estimate_review_input_tokens,
     _estimate_text_tokens,
     _resolve_exec_max_iterations,
@@ -304,6 +305,105 @@ def test_call_auto_effort_max_flows_to_provider(mocker):
     assert "effort=max" in result.stderr
 
 
+def test_call_with_gemini_default_timeout_is_scaled(mocker):
+    _stub_all_configured(mocker, {"gemini"})
+    mocker.patch(
+        "conductor.cli.get_network_profile",
+        return_value=NetworkProfile(
+            105,
+            "https://generativelanguage.googleapis.com",
+            1_000,
+        ),
+    )
+    call_mock = mocker.patch.object(
+        GeminiProvider,
+        "call",
+        return_value=_fake_response("gemini", "gemini-2.5-pro"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "call",
+            "--with",
+            "gemini",
+            "--task",
+            "Find recent background and summarize it inline.",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert call_mock.call_args.kwargs["timeout_sec"] == (
+        GEMINI_CALL_DEFAULT_TIMEOUT_SEC * 2
+    )
+    assert "timeouts scaled 2" in result.stderr
+
+
+def test_call_with_gemini_explicit_timeout_is_not_scaled(mocker):
+    _stub_all_configured(mocker, {"gemini"})
+    mocker.patch(
+        "conductor.cli.get_network_profile",
+        return_value=NetworkProfile(
+            105,
+            "https://generativelanguage.googleapis.com",
+            1_000,
+        ),
+    )
+    call_mock = mocker.patch.object(
+        GeminiProvider,
+        "call",
+        return_value=_fake_response("gemini", "gemini-2.5-pro"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "call",
+            "--with",
+            "gemini",
+            "--timeout",
+            "600",
+            "--task",
+            "Find recent background and summarize it inline.",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert call_mock.call_args.kwargs["timeout_sec"] == 600
+
+
+def test_call_with_gemini_warns_on_source_citation_brief(mocker):
+    _stub_all_configured(mocker, {"gemini"})
+    mocker.patch(
+        "conductor.cli.get_network_profile",
+        return_value=NetworkProfile(
+            None,
+            "https://generativelanguage.googleapis.com",
+            1_000,
+        ),
+    )
+    mocker.patch.object(
+        GeminiProvider,
+        "call",
+        return_value=_fake_response("gemini", "gemini-2.5-pro"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "call",
+            "--with",
+            "gemini",
+            "--task",
+            "Fact-check this claim and cite source URLs for each verdict.",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Gemini web-search source URLs" in result.stderr
+    assert "not verified by Conductor" in result.stderr
+
+
 def test_call_auto_exclude_skips_named_provider(mocker):
     _stub_all_configured(mocker, {"claude", "codex"})
     codex_call = mocker.patch.object(CodexProvider, "call", return_value=_fake_response("codex"))
@@ -562,6 +662,41 @@ def test_text_review_command_uses_text_only_flat_rate_route(mocker):
         {"provider": "gemini", "models": []},
         {"provider": "openrouter", "models": []},
     ]
+
+
+def test_ask_text_review_gemini_default_timeout_is_scaled(mocker):
+    _stub_all_configured(mocker, {"gemini"})
+    mocker.patch(
+        "conductor.cli.get_network_profile",
+        return_value=NetworkProfile(
+            105,
+            "https://generativelanguage.googleapis.com",
+            1_000,
+        ),
+    )
+    call_mock = mocker.patch.object(
+        GeminiProvider,
+        "call",
+        return_value=_fake_response("gemini", "gemini-2.5-pro"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "ask",
+            "--kind",
+            "text-review",
+            "--brief",
+            "Review these project instructions for clarity.",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert call_mock.call_args.kwargs["timeout_sec"] == (
+        GEMINI_CALL_DEFAULT_TIMEOUT_SEC * 2
+    )
+    assert "timeouts scaled 2" in result.stderr
 
 
 def test_ask_text_review_rejects_code_review_targets(mocker):


### PR DESCRIPTION
## Linked Issues

Closes #519

Closes #519

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
