### PR TITLE
fix: include version in route diagnostics

### DIFF
--- a/.cursor/rules/conductor-delegation.mdc
+++ b/.cursor/rules/conductor-delegation.mdc
@@ -2,7 +2,7 @@
 description: Use when delegating or routing tasks to a different LLM via the conductor CLI — e.g., cheap second opinions, long-context reads, web search, or offline runs.
 globs: ""
 alwaysApply: false
-managed-by: conductor v0.10.35
+managed-by: conductor v0.10.37
 ---
 
 # Conductor delegation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,7 @@ If there are zero blocking issues, the review is just: "LGTM."
 
 @.cortex/protocol.md
 
-<!-- conductor:begin v0.10.35 -->
+<!-- conductor:begin v0.10.37 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
 
-<!-- conductor:begin v0.10.35 -->
+<!-- conductor:begin v0.10.37 -->
 ## Conductor delegation
 
 This project has [conductor](https://github.com/autumngarage/conductor)

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -4666,11 +4666,12 @@ def _format_route_log_line(decision: RouteDecision) -> str:
     """Single-line route summary for stderr observability."""
     tags_matched = ",".join(decision.matched_tags) or "none"
     effort_str = decision.effort if isinstance(decision.effort, str) else f"{decision.effort}tok"
+    conductor_version = __version__.split("+", 1)[0]
     return (
         f"[conductor] {decision.prefer} (effort={effort_str}) → {decision.provider} "
         f"(tier: {decision.tier} · matched: {tags_matched} · "
         f"est: {decision.estimated_input_tokens:,} in/"
-        f"{decision.estimated_output_tokens:,} out)"
+        f"{decision.estimated_output_tokens:,} out · conductor={conductor_version})"
     )
 
 
@@ -4826,6 +4827,7 @@ def _emit_session_route_decision(
             "estimated_input_tokens": decision.estimated_input_tokens,
             "estimated_output_tokens": decision.estimated_output_tokens,
             "estimated_thinking_tokens": decision.estimated_thinking_tokens,
+            "conductor_version": __version__,
             "tag_default_applied": decision.tag_default_applied,
             "tag_default_considered": [
                 {"tag": tag, "provider": provider, "status": status}

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -4696,7 +4696,12 @@ def _format_usage_line(response: CallResponse) -> str:
 
 def _format_route_ranking(decision: RouteDecision) -> list[str]:
     """Verbose ranking table for --verbose-route."""
-    lines = [f"[conductor] route decision (prefer={decision.prefer}, effort={decision.effort}):"]
+    conductor_version = __version__.split("+", 1)[0]
+    lines = [
+        "[conductor] route decision "
+        f"(prefer={decision.prefer}, effort={decision.effort}, "
+        f"conductor={conductor_version}):"
+    ]
     if decision.tag_default_considered:
         for tag, provider, status in decision.tag_default_considered:
             picked_note = ""

--- a/tests/test_cli_log_file.py
+++ b/tests/test_cli_log_file.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from click.testing import CliRunner
 
+from conductor import __version__
 from conductor.cli import main
 from conductor.providers import (
     CallResponse,
@@ -200,6 +201,7 @@ def test_exec_log_file_writes_structured_ndjson_for_auto_route(
     assert "usage" in kinds
     route_event = next(event for event in events if event["event"] == "route_decision")
     assert route_event["data"]["provider"] == "claude"
+    assert route_event["data"]["conductor_version"] == __version__
     usage_event = next(event for event in events if event["event"] == "usage")
     assert usage_event["data"]["usage"]["output_tokens"] == 4
 

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -24,7 +24,7 @@ import pytest
 import respx
 from click.testing import CliRunner
 
-from conductor import offline_mode
+from conductor import __version__, offline_mode
 from conductor.cli import (
     GEMINI_CALL_DEFAULT_TIMEOUT_SEC,
     _estimate_review_input_tokens,
@@ -269,6 +269,7 @@ def test_call_auto_prefer_best_routes_to_frontier(mocker):
     assert "[conductor] best" in result.stderr
     assert "→ claude" in result.stderr
     assert "tier: frontier" in result.stderr
+    assert f"conductor={__version__.split('+', 1)[0]}" in result.stderr
 
 
 def test_call_auto_route_json_includes_prompt_size_estimate(mocker):

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -509,8 +509,9 @@ def test_call_verbose_route_prints_full_ranking(mocker):
     )
 
     assert result.exit_code == 0
-    # Verbose mode emits the ranking table.
+    # Verbose mode emits the ranking table with the conductor version marker.
     assert "route decision" in result.stderr
+    assert f"conductor={__version__.split('+', 1)[0]}" in result.stderr
     assert "1. claude" in result.stderr
     assert "codex" in result.stderr
     assert "ollama" in result.stderr


### PR DESCRIPTION
Route decision stderr and structured session logs now carry the Conductor version, making stale-runtime failures distinguishable from fresh provider regressions in transcript tails.

Refs #561

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
