### PR TITLE
fix: warn on legacy routing controls

### DIFF
--- a/docs/consumers.md
+++ b/docs/consumers.md
@@ -18,14 +18,16 @@ Regression tests cover the high-risk pieces of this surface, including JSON auto
 ## Invocation forms
 
 ```bash
-# Auto-routed by tag preference
-conductor call --auto --tags <tag1,tag2> [options]
-
 # Semantic intent routing
 conductor ask --kind <research|code|review|text-review|council> --effort <level> [options]
+conductor code --brief-file task.md
+conductor research "summarize this paper"
 
 # Explicit provider
 conductor call --with <provider> [options]
+
+# Legacy compatibility auto-routing (deprecated during v0.11; removed in v0.12)
+conductor call --auto --tags <tag1,tag2> [options]
 
 # Force the local provider
 conductor call --offline [options]
@@ -41,7 +43,7 @@ conductor exec --with <provider> --permission-profile <read-only|patch|full> [op
 
 Use `conductor ask` when the caller knows the semantic kind but does not want to reason about providers. It applies Conductor's deterministic `kind × effort` matrix, then delegates to `call`, `exec`, `review`, or council fan-out internally. Provider/model/tag/tool overrides intentionally stay on the lower-level `call`, `exec`, and `review` commands. Do not combine `ask` with `--with` or `--model`; when the user explicitly requests a provider or model, use the lower-level command for that job, for example `conductor call --with openrouter --brief-file /tmp/brief.md`.
 
-Usually, exactly one of `--auto` or `--with` is required for `call` and `exec`. `review` is auto-routed by default when `--with` is absent; `--auto` remains accepted for compatibility. `--auto` runs the router using `--tags`, `--prefer`, and `--exclude` to pick a configured provider; `--with` bypasses the router for direct provider use. `--offline` is the exception for `call` and `exec`: it may be used without `--auto` or `--with`, sets the sticky offline flag, and rewrites the call to `--with ollama`. Passing `--offline --with <non-ollama>` is an error. `--no-offline` clears the sticky flag, then normal `--auto` / `--with` rules apply.
+Usually, exactly one of `--auto` or `--with` is required for `call` and `exec`. `review` is auto-routed by default when `--with` is absent; `--auto` remains accepted for compatibility. `--auto` runs the router using `--tags`, `--prefer`, and `--exclude` to pick a configured provider; `--with` bypasses the router for direct provider use. The legacy auto-routing controls on `call`, `review`, and `exec` (`--auto`, `--tags`, `--prefer`, `--exclude`, auto-route `--effort`, and the matching `CONDUCTOR_TAGS`, `CONDUCTOR_PREFER`, `CONDUCTOR_EFFORT`, and `CONDUCTOR_EXCLUDE` environment variables) are deprecated during the v0.11 compatibility window and emit stderr warnings outside `--json` / `--silent-route`. Use the job verbs (`ask`, `code`, `research`, `review`, `text-review`, `council`) for default routing; keep `--with <provider>` only as the lower-level explicit provider-pin escape hatch. `--offline` is the exception for `call` and `exec`: it may be used without `--auto` or `--with`, sets the sticky offline flag, and rewrites the call to `--with ollama`. Passing `--offline --with <non-ollama>` is an error. `--no-offline` clears the sticky flag, then normal `--auto` / `--with` rules apply.
 
 Use `conductor review` for code review. Its auto route uses the same semantic review cascade as `conductor ask --kind review --effort medium`: Codex `codex review`, Claude Code `/review`, then an OpenRouter hosted review prompt. Use `conductor ask --kind text-review --effort medium` or `conductor text-review` for prose, docs, prompt, or instruction review with no diff tooling. Use `conductor exec` for engineering or auto-fix tasks that may edit files.
 
@@ -120,13 +122,13 @@ The canonical reference is `conductor call --help`. The contract-level commitmen
 | Flag | Type | Stability | Notes |
 |---|---|---|---|
 | `--with <provider>` | string | stable | One of: kimi, claude, codex, deepseek-chat, deepseek-reasoner, gemini, ollama, openrouter |
-| `--auto` | bool | stable | Mutually exclusive with `--with` |
-| `--tags <csv>` | string | stable | For `--auto` routing |
-| `--prefer <mode>` | string | stable | One of: best, cheapest, fastest, balanced. Default: balanced |
-| `--effort <level>` | string \| int | stable | One of: minimal, low, medium, high, max. Or integer token budget. Default: medium |
+| `--auto` | bool | deprecated v0.11 | Compatibility auto-router entrypoint; use semantic job verbs for default routing |
+| `--tags <csv>` | string | deprecated v0.11 for auto-route | Compatibility auto-router tags |
+| `--prefer <mode>` | string | deprecated v0.11 for auto-route | One of: best, cheapest, fastest, balanced. Use job verbs instead of tuning the route |
+| `--effort <level>` | string \| int | stable; deprecated v0.11 for auto-route | One of: minimal, low, medium, high, max. Or integer token budget. Default: medium |
 | `--timeout <sec>` | int | stable | Wall-clock timeout. Unbounded by default. When set explicitly, value is honored as-is (no scaling) |
 | `--max-stall-seconds <sec>` | int | stable | Streaming CLI stall watchdog. Default: 360, scaled up on slow networks unless explicitly set. `0` disables |
-| `--exclude <csv>` | string | stable | Providers to skip in `--auto` |
+| `--exclude <csv>` | string | deprecated v0.11 for auto-route | Providers to skip in compatibility auto-routing |
 | `--brief <text>` | string | stable | Inline delegation brief / prompt |
 | `--brief-file <path>` | string | stable | File path, `-` for stdin |
 | `--issue <N\|owner/repo#N>` | string | stable | GitHub issue seed brief via `gh` |

--- a/src/conductor/cli.py
+++ b/src/conductor/cli.py
@@ -966,6 +966,102 @@ def _resolve_layered_value(
     return profile_value
 
 
+def _parameter_is_commandline(name: str) -> bool:
+    ctx = click.get_current_context(silent=True)
+    if ctx is None:
+        return False
+    return ctx.get_parameter_source(name) == ParameterSource.COMMANDLINE
+
+
+def _legacy_layered_control_source(
+    *,
+    param_name: str,
+    flag: str,
+    cli_value: object,
+    env_key: str,
+    profile_value: str | None = None,
+) -> str | None:
+    if cli_value is not None and _parameter_is_commandline(param_name):
+        return flag
+    if os.environ.get(env_key) is not None:
+        return env_key
+    if profile_value is not None:
+        return f"profile.{param_name}"
+    return None
+
+
+def _emit_legacy_auto_routing_warning(
+    *,
+    command: str,
+    auto: bool,
+    tags: str | None,
+    prefer: str | None,
+    effort: str | None,
+    exclude: str | None,
+    profile_spec: ProfileSpec | None,
+    warn_effort: bool,
+    silent: bool,
+) -> None:
+    if silent:
+        return
+
+    controls: list[str] = []
+    if auto and _parameter_is_commandline("auto"):
+        controls.append("--auto")
+
+    layered_controls = (
+        ("tags", "--tags", tags, "CONDUCTOR_TAGS", profile_spec.tags if profile_spec else None),
+        (
+            "prefer",
+            "--prefer",
+            prefer,
+            "CONDUCTOR_PREFER",
+            profile_spec.prefer if profile_spec else None,
+        ),
+        (
+            "exclude",
+            "--exclude",
+            exclude,
+            "CONDUCTOR_EXCLUDE",
+            None,
+        ),
+    )
+    for param_name, flag, value, env_key, profile_value in layered_controls:
+        source = _legacy_layered_control_source(
+            param_name=param_name,
+            flag=flag,
+            cli_value=value,
+            env_key=env_key,
+            profile_value=profile_value,
+        )
+        if source is not None:
+            controls.append(source)
+
+    if warn_effort:
+        source = _legacy_layered_control_source(
+            param_name="effort",
+            flag="--effort",
+            cli_value=effort,
+            env_key="CONDUCTOR_EFFORT",
+            profile_value=profile_spec.effort if profile_spec else None,
+        )
+        if source is not None:
+            controls.append(source)
+
+    if not controls:
+        return
+
+    unique_controls = ", ".join(dict.fromkeys(controls))
+    click.echo(
+        f"[conductor] deprecation: legacy auto-routing controls on `conductor {command}` "
+        f"are deprecated for the v0.11 compatibility window and will be removed in v0.12 "
+        f"({unique_controls}). Use job verbs like `conductor ask`, `conductor code`, "
+        "`conductor research`, and `conductor review` for default routing; keep "
+        "`--with <provider>` only for explicit lower-level provider pins.",
+        err=True,
+    )
+
+
 def _load_named_profile(name: str | None) -> ProfileSpec | None:
     if name is None:
         return None
@@ -6292,6 +6388,18 @@ def call(
         )
     if provider_id and not auto:
         _enforce_local_provider_opt_in(provider_id, offline_requested=offline is True)
+    if auto:
+        _emit_legacy_auto_routing_warning(
+            command="call",
+            auto=auto,
+            tags=tags,
+            prefer=prefer,
+            effort=effort,
+            exclude=exclude,
+            profile_spec=profile_spec,
+            warn_effort=True,
+            silent=silent_route or as_json,
+        )
 
     brief_input = _read_task(
         task,
@@ -6741,6 +6849,18 @@ def review(
     review_target_count = sum(1 for value in (base, commit, uncommitted) if value)
     if review_target_count > 1:
         raise click.UsageError("use only one of --base, --commit, or --uncommitted.")
+    if auto_route:
+        _emit_legacy_auto_routing_warning(
+            command="review",
+            auto=auto,
+            tags=tags,
+            prefer=prefer,
+            effort=effort,
+            exclude=exclude,
+            profile_spec=profile_spec,
+            warn_effort=True,
+            silent=silent_route or as_json,
+        )
 
     brief_input = _read_task(
         task,
@@ -11473,6 +11593,18 @@ def exec_cmd(
         )
     if provider_id and not auto:
         _enforce_local_provider_opt_in(provider_id, offline_requested=offline is True)
+    if auto:
+        _emit_legacy_auto_routing_warning(
+            command="exec",
+            auto=auto,
+            tags=tags,
+            prefer=prefer,
+            effort=effort,
+            exclude=exclude,
+            profile_spec=profile_spec,
+            warn_effort=True,
+            silent=silent_route or as_json,
+        )
 
     brief_files = tuple(brief_file)
     if auto_phase and len(brief_files) > 1:

--- a/tests/test_cli_v02.py
+++ b/tests/test_cli_v02.py
@@ -306,6 +306,72 @@ def test_call_auto_effort_max_flows_to_provider(mocker):
     assert "effort=max" in result.stderr
 
 
+def test_call_auto_legacy_routing_controls_warn(mocker):
+    _stub_all_configured(mocker, {"claude"})
+    mocker.patch.object(ClaudeProvider, "call", return_value=_fake_response("claude"))
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "call",
+            "--auto",
+            "--prefer",
+            "best",
+            "--effort",
+            "high",
+            "--tags",
+            "cheap",
+            "--exclude",
+            "ollama",
+            "--task",
+            "hi",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "legacy auto-routing controls" in result.stderr
+    for token in ("--auto", "--prefer", "--effort", "--tags", "--exclude"):
+        assert token in result.stderr
+    assert "conductor ask" in result.stderr
+    assert "conductor code" in result.stderr
+
+
+def test_call_auto_env_legacy_routing_controls_warn(mocker, monkeypatch):
+    _stub_all_configured(mocker, {"claude"})
+    monkeypatch.setenv("CONDUCTOR_PREFER", "best")
+    mocker.patch.object(ClaudeProvider, "call", return_value=_fake_response("claude"))
+
+    result = CliRunner().invoke(main, ["call", "--auto", "--task", "hi"])
+
+    assert result.exit_code == 0, result.output
+    assert "legacy auto-routing controls" in result.stderr
+    assert "CONDUCTOR_PREFER" in result.stderr
+
+
+def test_call_auto_legacy_warning_suppressed_for_json(mocker):
+    _stub_all_configured(mocker, {"claude"})
+    mocker.patch.object(ClaudeProvider, "call", return_value=_fake_response("claude"))
+
+    result = CliRunner().invoke(
+        main,
+        ["call", "--auto", "--prefer", "best", "--task", "hi", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    json.loads(result.stdout)
+    assert "legacy auto-routing controls" not in result.stderr
+
+
+def test_call_with_provider_pin_does_not_warn_legacy_routing(mocker):
+    _stub_all_configured(mocker, {"claude"})
+    mocker.patch.object(ClaudeProvider, "call", return_value=_fake_response("claude"))
+
+    result = CliRunner().invoke(main, ["call", "--with", "claude", "--task", "hi"])
+
+    assert result.exit_code == 0, result.output
+    assert "legacy auto-routing controls" not in result.stderr
+
+
 def test_call_with_gemini_default_timeout_is_scaled(mocker):
     _stub_all_configured(mocker, {"gemini"})
     mocker.patch(
@@ -1997,6 +2063,41 @@ def test_review_auto_honors_router_defaults_within_semantic_stack(
     assert "→ claude" in result.stderr
 
 
+def test_review_legacy_routing_controls_warn(mocker):
+    _stub_all_configured(mocker, {"codex"})
+    mocker.patch.object(CodexProvider, "review_configured", return_value=(True, None))
+    mocker.patch.object(
+        CodexProvider,
+        "review",
+        return_value=_fake_response("codex", "codex-review"),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "review",
+            "--auto",
+            "--prefer",
+            "best",
+            "--effort",
+            "high",
+            "--tags",
+            "cheap",
+            "--exclude",
+            "openrouter",
+            "--base",
+            "origin/main",
+            "--brief",
+            "Review this merge.",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "legacy auto-routing controls" in result.stderr
+    for token in ("--auto", "--prefer", "--effort", "--tags", "--exclude"):
+        assert token in result.stderr
+
+
 def test_review_without_auto_or_with_uses_semantic_review_route(mocker, tmp_path):
     brief = tmp_path / "review.md"
     brief.write_text("Review this merge using the project reviewer guide.", encoding="utf-8")
@@ -2948,6 +3049,38 @@ def test_exec_auto_routes_to_tool_capable_provider(mocker):
     assert exec_mock.called
     # kimi would be skipped by the tools filter (supported_tools=frozenset()).
     assert "→ claude" in result.stderr
+
+
+def test_exec_auto_legacy_routing_controls_warn(mocker):
+    _stub_all_configured(mocker, {"claude", "codex"})
+    exec_mock = mocker.patch.object(ClaudeProvider, "exec", return_value=_fake_response("claude"))
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "exec",
+            "--auto",
+            "--prefer",
+            "best",
+            "--effort",
+            "high",
+            "--tags",
+            "coding",
+            "--exclude",
+            "codex",
+            "--tools",
+            "Read",
+            "--no-preflight",
+            "--task",
+            "do it",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert exec_mock.called
+    assert "legacy auto-routing controls" in result.stderr
+    for token in ("--auto", "--prefer", "--effort", "--tags", "--exclude"):
+        assert token in result.stderr
 
 
 def test_exec_unknown_tool_errors_with_hint():


### PR DESCRIPTION
## Linked Issues

Closes #501

Closes #501

---

## Summary

<!-- What does this PR do and why? 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed. -->

## Testing

<!-- How was this tested? Include commands run, manual checks, or "see new tests." -->

- [ ] Tests pass locally
- [ ] No new silent failures (no `except: pass`, no swallowed errors)
- [ ] No new code paths that diverge between environments

## Risk

<!-- What could go wrong? What's the blast radius? -->

- [ ] Low risk — isolated change, no shared state affected
- [ ] Medium risk — touches shared infrastructure or data paths
- [ ] High risk — touches critical paths (see AGENTS.md for high-scrutiny list)

## Rollback

<!-- How would you revert this if it breaks? Is it a clean revert or does it need data migration? -->
